### PR TITLE
Improve syntax highlighting for code blocks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,95 @@
 # P4Runtime specification documents
 
-## CI upload of build documents
+## Writing Madoko content
+
+Please refer to the [Madoko documentation](http://madoko.org/reference.html) and
+this FAQ.
+
+### FAQ
+
+#### How to write nested numbered lists in Madoko?
+
+It's easy but you cannot us x.y.z. to number the nested items otherwise it won't
+render properly. Instead use a single number for all items and make sure you
+indent each nested level with 4 spaces:
+```
+1. aaa1
+    1. aaa11
+        1. aaa111
+        2. aaa112
+    2. aaa12
+        1. aaa121
+...
+```
+
+#### What determines how code blocks are rendered?
+
+Quite a few thing actually.
+
+The `pre, code` metadata rule sets some defaults for all code blocks, such as
+font family and size. See
+[here](http://madoko.org/reference.html#sec-css-font-family).
+
+We also use some CSS rules in the metadata section to customize the behavior of
+the syntax highlighter. See
+[here](http://madoko.org/reference.html#sec-advanced--customizing-highlight-colors).
+For example:
+```
+.token.keyword    {
+    font-weight: bold;
+}
+```
+
+We use custom syntax highlighters for C++, P4, Protobuf and Protobuf text
+messages. For each of these we have a JSON file (e.g. `p4.json`). They are
+"imported" through the `Colorizer` metadata key:
+```
+Colorizer: p4
+Colorizer: proto
+Colorizer: prototext
+Colorizer: cpp
+```
+The name of the language can be specified when introducing a code block:
+````
+```<language>
+...code...
+```
+````
+See
+[here](http://madoko.org/reference.html#sec-advanced--custom-syntax-highlighting)
+for more information.
+
+Finally, to facilitate the definition of code blocks, we use [replacement
+rules](http://madoko.org/reference.html#sec-replace) for each language:
+```
+p4example {
+  replace: "~ Begin P4ExampleBlock&nl;\
+                 ````p4&nl;&source;&nl;````&nl;\
+                 ~ End P4ExampleBlock";
+  padding:6pt;
+  margin-top: 6pt;
+  margin-bottom: 6pt;
+  border: solid;
+  background-color: #ffffdd;
+  border-width: 0.5pt;
+}
+```
+This enables us to define additional properties which will be applied to every
+"p4" code block (e.g. background color). Defining a new P4 code block becomes
+very easy:
+```
+~ Begin P4Example
+header PacketOut_t {
+  bit<9> egress_port;
+  bit<8> queue_id;
+}
+~ End P4Example
+```
+It seems that when defining the replacement rule, the name of the rule and the
+name of the block tag have to match, but the case doesn't matter (`p4example`
+and `P4Example`).
+
+## CI upload of built documents
 
 Travis takes care of uploading the built HTML version of the spec to AWS S3. The
 latest working draft (master branch) can be found

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -21,7 +21,6 @@ title,titlenote,titlefooter,authors,h1,h2,h3,h4,h5 {
   font-weight: bold;
 }
 pre, code {
-  language: p4;
   font-family: monospace;
   font-size: 10pt;
 }
@@ -36,13 +35,16 @@ title,titlenote,titlefooter,authors {
   font-weight: bold;
 }
 pre, code {
-  language: p4;
   font-family: LuxiMono;
   font-size: 75%;
 }
 }
 
 Colorizer: p4
+Colorizer: proto
+Colorizer: prototext
+Colorizer: cpp
+
 .token.keyword    {
     font-weight: bold;
 }
@@ -50,7 +52,7 @@ Colorizer: p4
 @if html {
 p4example {
   replace: "~ Begin P4ExampleBlock&nl;\
-                 ````&nl;&source;&nl;````&nl;\
+                 ````p4&nl;&source;&nl;````&nl;\
                  ~ End P4ExampleBlock";
   padding:6pt;
   margin-top: 6pt;
@@ -64,7 +66,7 @@ p4example {
 @if tex {
 p4example {
   replace: "~ Begin P4ExampleBlock&nl;\
-                 ````&nl;&source;&nl;````&nl;\
+                 ````p4&nl;&source;&nl;````&nl;\
                  ~ End P4ExampleBlock";
   breakable: true;
   padding: 6pt;
@@ -106,9 +108,38 @@ pseudo {
 }
 
 @if html {
+cpp {
+  replace: "~ Begin CPPblock&nl;\
+                 ````cpp&nl;&source;&nl;````&nl;\
+                 ~ End CPPblock";
+  border: solid;
+  margin-top: 6pt;
+  margin-bottom: 6pt;
+  padding: 6pt;
+  background-color: #e9fce9;
+  border-width: 0.5pt;
+}
+}
+
+@if tex {
+cpp {
+  replace: "~ Begin CPPblock&nl;\
+                 ````cpp&nl;&source;&nl;````&nl;\
+                 ~ End CPPblock";
+  breakable: true;
+  margin-top: 6pt;
+  margin-bottom: 6pt;
+  padding: 6pt;
+  background-color: #e9fce9;
+  border: solid;
+  border-width: 0.5pt;
+}
+}
+
+@if html {
 proto {
   replace: "~ Begin Protoblock&nl;\
-                 ````&nl;&source;&nl;````&nl;\
+                 ````proto&nl;&source;&nl;````&nl;\
                  ~ End Protoblock";
   border: solid;
   margin-top: 6pt;
@@ -122,8 +153,37 @@ proto {
 @if tex {
 proto {
   replace: "~ Begin Protoblock&nl;\
-                 ````&nl;&source;&nl;````&nl;\
+                 ````proto&nl;&source;&nl;````&nl;\
                  ~ End Protoblock";
+  breakable: true;
+  margin-top: 6pt;
+  margin-bottom: 6pt;
+  padding: 6pt;
+  background-color: #e6ffff;
+  border: solid;
+  border-width: 0.5pt;
+}
+}
+
+@if html {
+prototext {
+  replace: "~ Begin Prototextblock&nl;\
+                 ````prototext&nl;&source;&nl;````&nl;\
+                 ~ End Prototextblock";
+  border: solid;
+  margin-top: 6pt;
+  margin-bottom: 6pt;
+  padding: 6pt;
+  background-color: #e6ffff;
+  border-width: 0.5pt;
+}
+}
+
+@if tex {
+prototext {
+  replace: "~ Begin Prototextblock&nl;\
+                 ````prototext&nl;&source;&nl;````&nl;\
+                 ~ End Prototextblock";
   breakable: true;
   margin-top: 6pt;
   margin-bottom: 6pt;
@@ -1138,7 +1198,8 @@ header PacketIn_t {
   bit<1> is_clone;     /* 1 if this is a clone of the
                           original packet */
 }
-...
+~ End P4Example
+~ Begin Prototext
 controller_packet_metadata {
   preamble {
     id: 2868916615
@@ -1174,7 +1235,7 @@ controller_packet_metadata {
     bitwidth: 1
   }
 }
-~End P4Example
+~End Prototext
 
 ### ValueSet
 
@@ -1421,7 +1482,7 @@ state parse_ipv4 {
        default: accept;
    }
 }
-...
+// ...
 header_union ip_t {
    ipv4_t ipv4;
    ipv6_t ipv6;
@@ -1512,7 +1573,7 @@ Register<ip_t, bit<32> >(128) register_ip;
 
 Here's the corresponding entry in the P4Info message:
 
-~ Begin Proto
+~ Begin Prototext
 registers {
   preamble {
     id: 369119267
@@ -1539,7 +1600,7 @@ type_info {
             bitwidth: 4
           }
         }
-      } …
+      } # ...
   headers {
     key: "ipv6_t"
     value {
@@ -1550,7 +1611,7 @@ type_info {
             bitwidth: 4
           }
         }
-      } …
+      } # ...
   header_unions {
     key: "ip_t"
     value {
@@ -1569,10 +1630,10 @@ type_info {
     }
   }
 }
-~ End Proto
+~ End Prototext
 Here's a p4.WriteRequest to set the value of register_ip[12]:
 
-~ Begin Proto
+~ Begin Prototext
 update {
   type: INSERT
   entity {
@@ -1587,14 +1648,14 @@ update {
           valid_header {
             is_valid: true
             bitstrings: "\x04"
-            bitstrings: …
+            bitstrings: # ...
           }
         }
       }
     }
   }
 }
-~ End Proto
+~ End Prototext
 
 ### enum and error
 
@@ -1846,7 +1907,7 @@ be used to select and filter results:
 For example, in order to read all entries from all tables from device 3, the
 client can use the following ReadRequest message.
 
-~ Begin Proto
+~ Begin Prototext
 device_id: 3
 entities {
   table_entry {
@@ -1855,12 +1916,12 @@ entities {
     controller_metadata: 0
   }
 }
-~ End Proto
+~ End Prototext
 
 In order to read all entries with priority 11 from a specific table (with id
 0x0212ab34) from device 3, the client can use the following ReadRequest message:
 
-~ Begin Proto
+~ Begin Prototext
 device_id: 3
 entities {
   table_entry {
@@ -1869,7 +1930,7 @@ entities {
     controller_metadata: 0
   }
 }
-~ End Proto
+~ End Prototext
 
 ### Direct resources
 
@@ -2413,7 +2474,7 @@ control arp_multicast(inout H hdr, inout M smeta) {
 At runtime, the client writes the following update in the target (shown in
 protobuf text format).
 
-~ Begin Proto
+~ Begin Prototext
 type: INSERT
 entity {
   packet_replication_engine_entry {
@@ -2426,7 +2487,7 @@ entity {
     }
   }
 }
-~ End Proto
+~ End Prototext
 
 As a result of the above P4Runtime programming, the target device will create
 four replicas of an ARP packet. These replicas will appear in the egress
@@ -2488,7 +2549,7 @@ control clone_low_ttl(inout H hdr, inout M smeta) {
 At runtime, the client writes the following update in the target (shown in
 protobuf text format).
 
-~ Begin Proto
+~ Begin Prototext
 type: INSERT
 entity {
   packet_replication_engine_entry {
@@ -2500,7 +2561,7 @@ entity {
     }
   }
 }
-~ End Proto
+~ End Prototext
 
 As a result of the above P4Runtime programming, the target device will create
 one replica of a low TTL packet from the ingress to the egress. Note that the
@@ -2724,7 +2785,7 @@ mastership change.
 Here is some pseudo-code implementing the handling of digest messages in the
 P4Runtime server:
 
-~ Begin Pseudo
+~ Begin CPP
 DigestStream stream;
 DigestCache cache;
 DigestBuffer buffers;
@@ -2754,7 +2815,7 @@ handle_stream_ack(DigestListAck ack) {
 }
 
 // loop to enforce timeouts
-while (TRUE) {
+while (true) {
   now = now();
   // check for buffers that need to be sent
   for ((digest_id, buffer) in buffers) {
@@ -2768,7 +2829,7 @@ while (TRUE) {
   }
   sleep(X);
 }
-~ End Pseudo
+~ End CPP
 
 ## ExternEntry
 
@@ -2800,11 +2861,11 @@ gRPC uses
 [grpc::Status](https://github.com/grpc/grpc/blob/master/include/grpc%2B%2B/impl/codegen/status.h)
 class to represent the status returned by an RPC. It has 3 attributes:
 
-~ Begin Proto
+~ Begin CPP
 StatusCode code_;
 grpc::string error_message_;
 grpc::string binary_error_details_;
-~ End Proto
+~ End CPP
 
 The `code_` represents a canonical error (see
 [Code](https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto)
@@ -2816,11 +2877,11 @@ developer-facing error message, which should be in English. The
 [google.rpc.Status](https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto)
 message, which has 3 fields:
 
-~ Begin Pseudo
+~ Begin Proto
 int32 code = 1;  // see code.proto
 string message = 2;
 repeated google.protobuf.Any details = 3;
-~ End Pseudo
+~ End Proto
 
 The code and message fields must be the same as `code_` and `error_message_`
 fields from `*grpc::Status*` above. The details field is a list that consists of
@@ -3019,33 +3080,32 @@ therefore always match the number of updates in the WriteRequest. If some of the
 updates were successful, the corresponding p4.Error should set the code to OK
 and omit other fields.
 
-~ Begin Proto
+~ Begin Prototext
 # Example of a grpc::Status returned for a Write RPC with a batch of 3 updates.
 # The first and third updates encountered an error, while the second update
 # succeeded.
-
-  code_ = 2  # UNKNOWN
-  error_message_ = "Write failure."
-  binary_error_details {
-    code: 2  # UNKNOWN
-    message: "Write failure."
-    details {
-      canonical_code: 8  # RESOURCE_EXHAUSTED
-      message: "Table is full."
-      space: "targetX-psa-vendorY"
-      code: 500  # ERR_TABLE_FULL
-    }
-    details {
-      canonical_code: 0  # OK
-    }
-    details {
-      canonical_code: 6  # ALREADY_EXISTS
-      message: "Entity already exists."
-      space: "targetX-psa-vendorY"
-      code: 600  # ERR_ENITTY_ALREADY_EXISTS
-    }
+code_ = 2  # UNKNOWN
+error_message_ = "Write failure."
+binary_error_details {
+  code: 2  # UNKNOWN
+  message: "Write failure."
+  details {
+    canonical_code: 8  # RESOURCE_EXHAUSTED
+    message: "Table is full."
+    space: "targetX-psa-vendorY"
+    code: 500  # ERR_TABLE_FULL
   }
-~ End Proto
+  details {
+    canonical_code: 0  # OK
+  }
+  details {
+    canonical_code: 6  # ALREADY_EXISTS
+    message: "Entity already exists."
+    space: "targetX-psa-vendorY"
+    code: 600  # ERR_ENTITY_ALREADY_EXISTS
+  }
+}
+~ End Prototext
 # Read RPC
 
 The *Read* RPC retrieves one or more P4 entities from the P4Runtime server. The
@@ -3114,26 +3174,25 @@ A P4Runtime server will process the batch as follows:
 
 1. Lock state (preventing new Writes) and validate each *request* in the batch
 
-    1.1 If it is a valid *request*, perform the read
+    1. If it is a valid *request*, perform the read
 
-        1.1.1 If the read was successful, return the entities read in
-        ReadResponse stream
-
-        1.1.2. If the read failed (exception/critical-error), prepare a p4.Error
+        1. If the read was successful, return the entities read in ReadResponse
+        stream
+        2. If the read failed (exception/critical-error), prepare a p4.Error
         with code set to INTERNAL
 
-    1.2. If the *request* is invalid (invalid-argument, not-supported, etc.),
+    2. If the *request* is invalid (invalid-argument, not-supported, etc.),
     prepare a p4.Error with relevant canonical code to capture the error
 
 2. Unlock the state (allowing new Writes)
 
 3. Close the ReadResponse stream and return a grpc::Status as follows:
 
-    3.1 If no errors were encountered, set code to OK and do not populate any
+    1. If no errors were encountered, set code to OK and do not populate any
     other field.
 
-    3.2. Otherwise, the overall code should be set to UNKNOWN. See section
-    [Error Reporting Messages](#heading=h.ct7nepyfmt5n) for information on error
+    2. Otherwise, the overall code should be set to UNKNOWN. See section [Error
+    Reporting Messages](#heading=h.ct7nepyfmt5n) for information on error
     reporting messages and guidelines. Assemble a list of p4.Error messages
     (from step 1 above) such that each element reflects the status of the
     request in the batch at the same location (1:1 correspondence). This list
@@ -3433,15 +3492,15 @@ server software, the channel or the client can handle.
 Here is a reasonable pseudo-code implementation for idle timeout for table
 entries:
 
-~ Begin Pseudo
+~ Begin CPP
 IdleTimeoutStream stream;
 
 scanning_interval = 10ms;
 
-while (TRUE) {
+while (true) {
   // iterate over all tables which support idle timeout
   for (table in tables) {
-    if (NOT table.idle_timeout_supported) continue;
+    if (!table.idle_timeout_supported) continue;
     // we coalesce all idle notifications for the same table in one
     // message
     IdleTimeoutNotification msg;
@@ -3459,7 +3518,7 @@ while (TRUE) {
   }
   sleep(scanning_interval);
 }
-~ End Pseudo
+~ End CPP
 
 # Portability considerations
 
@@ -3514,7 +3573,7 @@ its CPU and recirculate ports in the device specific port number space.
 P4Runtime reserves device-independent and controller-specific 32-bit constants
 for the CPU port and the recirculate port as follows:
 
-~ Begin Pseudo
+~ Begin Proto
 enum SdnPort {
   SDN_PORT_UNSPECIFIED = 0;
 
@@ -3529,7 +3588,7 @@ enum SdnPort {
   SDN_PORT_RECIRCULATE = 0xFFFFFFFA;
   SDN_PORT_CPU = 0xFFFFFFFD;
 }
-~ End Pseudo
+~ End Proto
 
 The sub-sections below detail the translation mechanics for different usage of
 PSA port types in P4 programs.

--- a/docs/v1/cpp.json
+++ b/docs/v1/cpp.json
@@ -1,45 +1,45 @@
 {
-    "displayName": "P4",
-    "name": "p4",
+    "displayName":    "C++",
+    "name":           "cpp",
+    "mimeTypes":      ["text/cpp","text/c"],
+    "fileExtensions": ["cpp","c++","h","c"],
 
     "lineComment":      "//",
     "blockCommentStart": "/*",
     "blockCommentEnd":   "*/",
 
-    "keywords": [ "action", "apply", "control", "default", "else",
-        "extern", "exit", "false", "if",
-        "package", "parser", "return", "select", "state", "switch",
-        "table", "transition", "true", "typedef", "verify"
+    "keywords": [
+        "alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand", "bitor", "bool", "break", "case",
+        "catch", "char", "char16_t", "char32_t", "class", "compl", "const", "constexpr", "const_cast",
+        "continue", "decltype", "default", "delete", "do", "double", "dynamic_cast", "else",
+        "enum", "explicit", "export", "extern", "false", "float", "for", "friend", "goto", "if", "inline",
+        "int", "long", "mutable", "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator",
+        "or", "or_eq", "private", "protected", "public", "register", "reinterpret_cast",
+        "return", "short", "signed", "sizeof", "static", "static_assert", "static_cast", "struct",
+        "switch", "template", "this", "thread_local", "throw", "true", "try", "typedef", "typeid",
+        "typename", "union", "unsigned", "using", "virtual", "void", "volatile", "wchar_t", "while",
+        "xor", "xor_eq"
     ],
-
-    "extraKeywords": [],
 
     "typeKeywords": [
-        "bool", "bit", "const", "enum", "entries", "error", "header", "header_union", "in", "inout", "int", "match_kind", "out", "tuple", "struct", "varbit", "void"
+        "bool", "double", "byte", "int", "short", "char", "void", "long", "float",
+        "char32_t", "unsigned", "wchar_t", "char16_t"
     ],
-
-    "extraTypeKeywords": [],
 
     "directives": [
-        "include","if","endif","ifdef","define","ifndef","undef","line"
-    ],
-
-    "annotations": [
-        "atomic", "defaultonly", "name", "priority", "tableonly", "hidden", "globalname"
+        "include","if","endif","ifdef","define","line","warning","error"
     ],
 
     "operators": [
         "=", ">", "<", "!", "~", "?", ":",
-        "==", "<=", ">=", "!=", "&&", "||", "++",
+        "==", "<=", ">=", "!=", "&&", "||", "++", "--",
         "+", "-", "*", "/", "&", "|", "^", "%", "<<",
-        ">>", "&&&", ".."
+        ">>", ">>>", "+=", "-=", "*=", "/=", "&=", "|=",
+        "^=", "%=", "<<=", ">>=", ">>>="
     ],
-
-    "extraOperators": [],
 
     "symbols":  "[=><!~?:&|+\\-*\\/\\^%]+",
     "escapes":  "\\\\(?:[abfnrtv\\\\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
-
 
     "tokenizer": {
         "root": [
@@ -47,20 +47,15 @@
             ["\\w+::(?=\\w)", "namespace" ],
             ["(namespace)(\\s*)((?:\\w+::)*\\w+)", ["keyword","white","namespace"] ],
 
-            ["[a-z_$][\\w]*",  { "cases": {
-                "@typeKeywords": "keyword.type",
-                "@extraTypeKeywords": "keyword.type.extra",
-                "@keywords": "keyword",
-                "@extraKeywords": "keyword.extra",
-                "@default": "identifier" } } ],
+            ["[a-z_$][\\w]*",  { "cases": { "@typeKeywords": "keyword.type",
+                                            "@keywords": "keyword",
+                                            "@default": "identifier" } } ],
+            ["(\\.|\\->)([A-Z][\\w]*)", ["keyword", "identifier"] ],
+            ["[A-Z][\\w]*(?!\\s*[\\w\\(])", "type.identifier" ],
+            ["[A-Z][A-Z0-9_]*(?![\\w\\(])", "type.identifier" ],
 
             ["^(\\s*#)(\\w+)(.*)", { "cases": {
                 "$2@directives": ["namespace","namespace","string"],
-                "@default": ["meta","meta","string"]
-            } } ],
-
-            ["^(\\s*@)(\\w+)(.*)", { "cases": {
-                "$2@annotations": ["namespace","namespace","string"],
                 "@default": ["meta","meta","string"]
             } } ],
 
@@ -68,10 +63,8 @@
 
             ["[{}()\\[\\]]", "@brackets"],
             ["[<>](?!@symbols)", "@brackets"],
-            ["@symbols", { "cases": {
-                "@operators": "operator",
-                "@extraOperators": "operator.extra",
-                "@default"  : "" } } ],
+            ["@symbols", { "cases": { "@operators": "operator",
+                                      "@default"  : "" } } ],
 
             ["\\d*\\.\\d+([eE][\\-+]?\\d+)?[fFdD]?", "number.float"],
             ["0[xX][0-9a-fA-F_]*[0-9a-fA-F][Ll]?", "number.hex"],
@@ -81,9 +74,8 @@
 
             ["[;,.]", "delimiter"],
 
-            ["[lL]\"([^\"\\\\]|\\\\.)*$", "string.invalid"],
+            ["[lL]\"([^\"\\\\]|\\\\.)*$", "string.invalid" ],
             ["\"",  "string", "@string" ],
-
 
             ["'[^\\\\']'", "string"],
             ["(')(@escapes)(')", ["string","string.escape","string"]],

--- a/docs/v1/proto.json
+++ b/docs/v1/proto.json
@@ -1,77 +1,50 @@
 {
-    "displayName": "P4",
-    "name": "p4",
+    "displayName": "Protobuf",
+    "name": "proto",
 
     "lineComment":      "//",
     "blockCommentStart": "/*",
     "blockCommentEnd":   "*/",
 
-    "keywords": [ "action", "apply", "control", "default", "else",
-        "extern", "exit", "false", "if",
-        "package", "parser", "return", "select", "state", "switch",
-        "table", "transition", "true", "typedef", "verify"
+    "keywords": [
+        "syntax", "import", "package", "service",
+        "rpc", "returns",
+        "message", "oneof", "repeated",
+        "reserved",
+        "="
     ],
 
-    "extraKeywords": [],
+    "extraKeywords": ["optimize_for", "cc_enable_arenas", "objc_class_prefix", "deprecated"],
 
     "typeKeywords": [
-        "bool", "bit", "const", "enum", "entries", "error", "header", "header_union", "in", "inout", "int", "match_kind", "out", "tuple", "struct", "varbit", "void"
+        "enum",
+        "double", "float",
+        "int32", "int64", "uint32", "uint64", "sint32", "sint64",
+        "fixed32", "fixed64", "sfixed32", "sfixed64",
+        "bool",
+        "string", "bytes"
     ],
 
-    "extraTypeKeywords": [],
-
-    "directives": [
-        "include","if","endif","ifdef","define","ifndef","undef","line"
-    ],
-
-    "annotations": [
-        "atomic", "defaultonly", "name", "priority", "tableonly", "hidden", "globalname"
-    ],
-
-    "operators": [
-        "=", ">", "<", "!", "~", "?", ":",
-        "==", "<=", ">=", "!=", "&&", "||", "++",
-        "+", "-", "*", "/", "&", "|", "^", "%", "<<",
-        ">>", "&&&", ".."
-    ],
-
-    "extraOperators": [],
+    "directives": [],
 
     "symbols":  "[=><!~?:&|+\\-*\\/\\^%]+",
     "escapes":  "\\\\(?:[abfnrtv\\\\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
 
-
     "tokenizer": {
         "root": [
             ["__\\w+", "identifier.predefined"],
-            ["\\w+::(?=\\w)", "namespace" ],
-            ["(namespace)(\\s*)((?:\\w+::)*\\w+)", ["keyword","white","namespace"] ],
 
             ["[a-z_$][\\w]*",  { "cases": {
                 "@typeKeywords": "keyword.type",
-                "@extraTypeKeywords": "keyword.type.extra",
                 "@keywords": "keyword",
                 "@extraKeywords": "keyword.extra",
                 "@default": "identifier" } } ],
 
-            ["^(\\s*#)(\\w+)(.*)", { "cases": {
-                "$2@directives": ["namespace","namespace","string"],
-                "@default": ["meta","meta","string"]
-            } } ],
-
-            ["^(\\s*@)(\\w+)(.*)", { "cases": {
-                "$2@annotations": ["namespace","namespace","string"],
-                "@default": ["meta","meta","string"]
-            } } ],
-
             { "include": "@whitespace" },
 
             ["[{}()\\[\\]]", "@brackets"],
-            ["[<>](?!@symbols)", "@brackets"],
-            ["@symbols", { "cases": {
-                "@operators": "operator",
-                "@extraOperators": "operator.extra",
-                "@default"  : "" } } ],
+            ["@symbols", { "cases": { "@keywords" : "keyword",
+                                      "@default"  : "" } } ],
 
             ["\\d*\\.\\d+([eE][\\-+]?\\d+)?[fFdD]?", "number.float"],
             ["0[xX][0-9a-fA-F_]*[0-9a-fA-F][Ll]?", "number.hex"],
@@ -81,9 +54,9 @@
 
             ["[;,.]", "delimiter"],
 
+
             ["[lL]\"([^\"\\\\]|\\\\.)*$", "string.invalid"],
             ["\"",  "string", "@string" ],
-
 
             ["'[^\\\\']'", "string"],
             ["(')(@escapes)(')", ["string","string.escape","string"]],

--- a/docs/v1/prototext.json
+++ b/docs/v1/prototext.json
@@ -1,0 +1,54 @@
+{
+    "displayName": "Protobuf text",
+    "name": "prototext",
+
+    "lineComment":      "#",
+
+    "keywords": [],
+
+    "typeKeywords": [],
+
+    "directives": [],
+
+    "symbols":  "[=><!~?:&|+\\-*\\/\\^%]+",
+    "escapes":  "\\\\(?:[abfnrtv\\\\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})",
+
+    "tokenizer": {
+        "root": [
+            ["__\\w+", "identifier.predefined"],
+
+            ["[a-z_$][\\w]*",  "identifier"],
+
+            { "include": "@whitespace" },
+
+            ["[{}()\\[\\]]", "@brackets"],
+            ["@symbols", { "cases": { "@keywords" : "keyword",
+                                      "@default"  : "" } } ],
+
+            ["\\d*\\.\\d+([eE][\\-+]?\\d+)?[fFdD]?", "number.float"],
+            ["0[xX][0-9a-fA-F_]*[0-9a-fA-F][Ll]?", "number.hex"],
+            ["0[0-7_]*[0-7][Ll]?", "number.octal"],
+            ["0[bB][0-1_]*[0-1][Ll]?", "number.binary"],
+            ["\\d+[lL]?", "number"],
+
+            ["[lL]\"([^\"\\\\]|\\\\.)*$", "string.invalid"],
+            ["\"",  "string", "@string" ],
+
+            ["'[^\\\\']'", "string"],
+            ["(')(@escapes)(')", ["string","string.escape","string"]],
+            ["'", "string.invalid"]
+        ],
+
+        "whitespace": [
+            ["[ \\t\\r\\n]+", "white"],
+            ["#.*$",    "comment"]
+        ],
+
+        "string": [
+            ["[^\\\\\"]+",  "string"],
+            ["@escapes", "string.escape"],
+            ["\\\\.",      "string.escape.invalid"],
+            ["\"",        "string", "@pop" ]
+        ]
+    }
+}


### PR DESCRIPTION
We do not use P4 as the default language for every code block. We now
have extra syntax files for .proto, .cpp and .pb.txt. The C++ syntax
highlighter was taken from the Madoko github. There is probably a lot of
room for improvement for the proto ones.

I added an FAQ to the docs' README to keep track of some Madoko
"specificities".