### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+services:
+  - docker
+
+script:
+  - docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/madoko-debian:sid-with-fonts make html
+
+after_success:
+  - ls docs/v1/build
+
+deploy:
+  - provider: s3
+    access_key_id: AKIAIT3MAUFCQEY7KAFQ
+    secret_access_key:
+      secure: O1tX0ymUh2sX3t+N0IYKbFasvAVsOxJZ3OyIi5M/6m5IHsDJUS3ldtHGVCAMD+dJEiSbcaxYdXfnxNlO8IFCH60eF4Q4STKmKn7jqjSRpAwf/97HPfI1M97RhMBFbqD0LM8nLQtAhQT5VVQQNcOl49LHZqMEDVtfA6Ta4noLXh32aawEq5DS+jI4iXBhk6CNfTTSs8GeSJmXIxJcoOmMkH6ibg3ZJ1mOV0F66IVqLyVoGhCgS4uwY9v7YmWJ4LRQDM3fycx08awlosFrzwOKrZp2fgTIzXAFd2ndL2OXzhCj+2p5Lp/LM6gIG/QQVHPnOPDs8ZxsKYOrycsPlJHs+3j+Wjy6a0RutZuLUXC2uHxuK/ZFQ+gJ1ExePzFRS83IESgG4swd9fGa9vBeWaP/RbS3KCc2LWLBsQf7MMIN+8tWLqul9k3yuUwaANOnE3Lt6bw6nKW5sef4ULqHkMO4ZH/S6a+TLeoKqDh59d4KpS/K2YPXediEBWk2Jk5bI5JHZDDFbde0Kls3cXOj3b6DTfMUQ4zcgDqVpyNKfOU764FnOGThVt9+zU6vIXRr6Y9olumgC24sz8IeEVEJv5234sdNd4E11B8tQE9JjoQDzmLgJ+xHNan0b1RgW/watYW2JFixwgYu2RLvHGMNySj9kw5t8Mj2Olj0FtsOq9MRHNE=
+    bucket: p4runtime
+    local-dir: docs/v1/build
+    upload-dir: travis/$TRAVIS_BRANCH
+    acl: public_read
+    region: us-west-2
+    on:
+      repo: p4lang/p4runtime
+      all_branches: true
+  - provider: s3
+    access_key_id: AKIAIT3MAUFCQEY7KAFQ
+    secret_access_key:
+      secure: O1tX0ymUh2sX3t+N0IYKbFasvAVsOxJZ3OyIi5M/6m5IHsDJUS3ldtHGVCAMD+dJEiSbcaxYdXfnxNlO8IFCH60eF4Q4STKmKn7jqjSRpAwf/97HPfI1M97RhMBFbqD0LM8nLQtAhQT5VVQQNcOl49LHZqMEDVtfA6Ta4noLXh32aawEq5DS+jI4iXBhk6CNfTTSs8GeSJmXIxJcoOmMkH6ibg3ZJ1mOV0F66IVqLyVoGhCgS4uwY9v7YmWJ4LRQDM3fycx08awlosFrzwOKrZp2fgTIzXAFd2ndL2OXzhCj+2p5Lp/LM6gIG/QQVHPnOPDs8ZxsKYOrycsPlJHs+3j+Wjy6a0RutZuLUXC2uHxuK/ZFQ+gJ1ExePzFRS83IESgG4swd9fGa9vBeWaP/RbS3KCc2LWLBsQf7MMIN+8tWLqul9k3yuUwaANOnE3Lt6bw6nKW5sef4ULqHkMO4ZH/S6a+TLeoKqDh59d4KpS/K2YPXediEBWk2Jk5bI5JHZDDFbde0Kls3cXOj3b6DTfMUQ4zcgDqVpyNKfOU764FnOGThVt9+zU6vIXRr6Y9olumgC24sz8IeEVEJv5234sdNd4E11B8tQE9JjoQDzmLgJ+xHNan0b1RgW/watYW2JFixwgYu2RLvHGMNySj9kw5t8Mj2Olj0FtsOq9MRHNE=
+    bucket: p4runtime
+    local-dir: docs/v1/build
+    upload-dir: docs/master
+    acl: public_read
+    region: us-west-2
+    on:
+      repo: p4lang/p4runtime
+      branch: master
+  - provider: s3
+    access_key_id: AKIAIT3MAUFCQEY7KAFQ
+    secret_access_key:
+      secure: O1tX0ymUh2sX3t+N0IYKbFasvAVsOxJZ3OyIi5M/6m5IHsDJUS3ldtHGVCAMD+dJEiSbcaxYdXfnxNlO8IFCH60eF4Q4STKmKn7jqjSRpAwf/97HPfI1M97RhMBFbqD0LM8nLQtAhQT5VVQQNcOl49LHZqMEDVtfA6Ta4noLXh32aawEq5DS+jI4iXBhk6CNfTTSs8GeSJmXIxJcoOmMkH6ibg3ZJ1mOV0F66IVqLyVoGhCgS4uwY9v7YmWJ4LRQDM3fycx08awlosFrzwOKrZp2fgTIzXAFd2ndL2OXzhCj+2p5Lp/LM6gIG/QQVHPnOPDs8ZxsKYOrycsPlJHs+3j+Wjy6a0RutZuLUXC2uHxuK/ZFQ+gJ1ExePzFRS83IESgG4swd9fGa9vBeWaP/RbS3KCc2LWLBsQf7MMIN+8tWLqul9k3yuUwaANOnE3Lt6bw6nKW5sef4ULqHkMO4ZH/S6a+TLeoKqDh59d4KpS/K2YPXediEBWk2Jk5bI5JHZDDFbde0Kls3cXOj3b6DTfMUQ4zcgDqVpyNKfOU764FnOGThVt9+zU6vIXRr6Y9olumgC24sz8IeEVEJv5234sdNd4E11B8tQE9JjoQDzmLgJ+xHNan0b1RgW/watYW2JFixwgYu2RLvHGMNySj9kw5t8Mj2Olj0FtsOq9MRHNE=
+    bucket: p4runtime
+    local-dir: docs/v1/build
+    upload-dir: docs/$TRAVIS_TAG
+    acl: public_read
+    region: us-west-2
+    on:
+      repo: p4lang/p4runtime
+      tags: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,15 @@
 # P4Runtime specification documents
+
+## CI upload of build documents
+
+Travis takes care of uploading the built HTML version of the spec to AWS S3. The
+latest working draft (master branch) can be found
+[here](https://s3-us-west-2.amazonaws.com/p4runtime/docs/master/P4Runtime-Spec.html).
+
+Additionally, you can access the HTML version of the spec for any given branch
+of this repository by using the following URL:
+https://s3-us-west-2.amazonaws.com/p4runtime/travis/<your_branch_nam>/P4Runtime-Spec.html.
+
+Unfortunately, because of how Travis encrypts environment variables (which are
+required to upload documents to S3), this does not work for branches in forked
+repositories, even for opened pull requests.


### PR DESCRIPTION
Travis now takes care of building the HTML version of the spec and
uploading it to AWS S3. This works for every branch that is hosted on
the p4lang/p4runtime repo, but not for PRs opened from forks (for
security reasons).