### PR TITLE
Validate Protobuf files as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 services:
   - docker
 
+install:
+  - docker build -t p4runtime-ci -f CI/Dockerfile .
+
+# We check that the P4Runtime Protobuf files are correct (by compiling them with
+# protoc), then we generate the HTML for the spec.
 script:
+  - docker run -t p4runtime-ci /p4runtime/CI/compile_protos.sh /tmp/
   - docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/madoko-debian:sid-with-fonts make html
 
 after_success:

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -1,0 +1,8 @@
+FROM p4lang/third-party:latest
+LABEL maintainer="P4 API Working Group <p4-dev@lists.p4.org>"
+LABEL description="Dockerfile used for CI testing of p4lang/p4runtime"
+
+COPY . /p4runtime/
+WORKDIR /p4runtime/
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common git

--- a/CI/compile_protos.sh
+++ b/CI/compile_protos.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# This script is meant for CI testing, to ensure that the P4Runtime Protobuf
+# files are correct and compile with the protoc compiler (CPP, gRPC and Python).
+
+if [ $# -ne 1 ]; then
+    echo "Usage: compile_protos.sh <BUILD_DIR>"
+    exit 1
+fi
+
+BUILD_DIR=$1
+PROTOC=$(which protoc)
+if [ $? -ne 0 ]; then
+    echo "Could not find protoc"
+    exit 2
+fi
+
+echo "Using $PROTOC"
+
+GRPC_CPP_PLUGIN=$(which grpc_cpp_plugin)
+if [ $? -ne 0 ]; then
+    echo "Could not find CPP protoc plugin"
+    exit 2
+fi
+GRPC_PY_PLUGIN=$(which grpc_python_plugin)
+if [ $? -ne 0 ]; then
+    echo "Could not find Python protoc plugin"
+    exit 2
+fi
+
+set -e
+
+THIS_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+PROTO_DIR=$THIS_DIR/../proto
+
+tmpdir=$(mktemp -d)
+pushd $tmpdir > /dev/null
+git clone --depth 1 https://github.com/googleapis/googleapis.git
+popd > /dev/null
+GOOGLE_PROTO_DIR=$tmpdir/googleapis
+
+PROTOS="\
+$PROTO_DIR/p4/v1/p4data.proto \
+$PROTO_DIR/p4/v1/p4runtime.proto \
+$PROTO_DIR/p4/config/v1/p4info.proto \
+$PROTO_DIR/p4/config/v1/p4types.proto \
+$GOOGLE_PROTO_DIR/google/rpc/status.proto \
+$GOOGLE_PROTO_DIR/google/rpc/code.proto"
+
+PROTOFLAGS="-I$GOOGLE_PROTO_DIR -I$PROTO_DIR"
+
+mkdir -p $BUILD_DIR/cpp_out
+mkdir -p $BUILD_DIR/grpc_out
+mkdir -p $BUILD_DIR/py_out
+
+set -o xtrace
+$PROTOC $PROTOS --cpp_out $BUILD_DIR/cpp_out $PROTOFLAGS
+$PROTOC $PROTOS --grpc_out $BUILD_DIR/grpc_out --plugin=protoc-gen-grpc=$GRPC_CPP_PLUGIN $PROTOFLAGS
+# With the Python plugin, it seems that I need to use a single command for proto
+# + grpc and that the output directory needs to be the same (because the grpc
+# plugin inserts code into the proto-generated files). But maybe I am just using
+# an old version of the Python plugin.
+$PROTOC $PROTOS --python_out $BUILD_DIR/py_out $PROTOFLAGS --grpc_out $BUILD_DIR/py_out --plugin=protoc-gen-grpc=$GRPC_PY_PLUGIN
+set +o xtrace
+
+rm -rf $tmpdir
+
+echo "SUCCESS"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # P4Runtime Specification
+
 This directory contains protobuf files, specifications and related artifacts for
 all versions of the P4Runtime API. Documentation and protobuf definitions are
 placed into two distinct top-level directories. In each of these directories,
@@ -25,6 +26,24 @@ provides a precise definition of the P4Runtime API via protobuf (.proto) files
 and accompanying documentation. The target audience for this includes system
 architects and developers who want to write controller applications for P4
 devices or switches.
+
+# Compiling P4Runtime Protobuf files
+
+You can use Docker to run the protoc compiler on the P4Runtime Protobuf files
+and generate the Protobuf & gRPC bindings for C++ and Python:
+
+```
+docker build -t p4runtime -f CI/Dockerfile .
+docker run -v <OUT>:/out/ -t p4runtime /p4runtime/CI/compile_protos.sh /out/
+```
+
+This will generate the bindings in the local `<OUT>` directory. **You need to
+provide the absolute path for `<OUT>`.** The default Docker user is root, so you
+may need to change the permissions manually for the generated files after the
+`docker run` command exits.
+
+These commands are the ones used by our CI system to ensure that the Protobuf
+files stay semantically valid.
 
 # Modification Policy
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,7 @@ latest working draft (master branch) can be found
 
 Additionally, you can access the HTML version of the spec for any given branch
 of this repository by using the following URL:
-https://s3-us-west-2.amazonaws.com/p4runtime/travis/<your_branch_nam>/P4Runtime-Spec.html.
+https://s3-us-west-2.amazonaws.com/p4runtime/travis/<your_branch_name>/P4Runtime-Spec.html.
 
 Unfortunately, because of how Travis encrypts environment variables (which are
 required to upload documents to S3), this does not work for branches in forked


### PR DESCRIPTION
Run protoc on the P4Runtime Protobuf files to ensure they are still
correct in case they are modified by a PR.