### PR TITLE
Attempt at adding Bazel rules for protos

### DIFF
--- a/BAZEL_NOTES.md
+++ b/BAZEL_NOTES.md
@@ -1,0 +1,53 @@
+### Bazel version?
+
+0.14.1
+
+### Why use pubref/rules_protobuf instead of native rules?
+
+The only Bazel native rules I am aware of are `proto_library` and
+`cc_proto_library`. These work well despite an issue with `proto_source_root` in
+the `proto_library` rule. However, there is no native support for Python and
+gRPC (any language?) at this time (Bazel 0.14), which is why we use
+pubref/rules_protobuf. The `cc_grpc_library` that ships with gRPC (v1.13.1) is
+also buggy.
+
+### What is the `proto_source_root` issue?
+
+I originally had the BUILD file in the proto package and I was setting
+`proto_source_root` to "proto" in the proto_library rules. However it wasn't
+working because of a Bazel issue.
+See https://github.com/bazelbuild/bazel/issues/4544 for the issue.
+See
+https://github.com/bazelbuild/bazel/commit/e8956648d1c94a3a51e1aba5d229d1f27bdf8e35
+for the fix.
+So instead I moved the rules to the root BUILD file and I am borrowing
+internal_copied_filegroup from protobuf.bzl to "remove" the "proto" prefix from
+my paths.
+The `proto_source_root` fix may be available in Bazel 0.15.x.
+
+### What is the issue with `cc_grpc_library` in the gRPC repo?
+
+It doesn't work with generated protos (which is what we have because of the
+`proto_source_root` issue). See https://github.com/grpc/grpc/issues/16178.
+
+### Why use these versions of Protobuf and gRPC?
+
+We pull in patched versions of Protobuf (v3.2.0) and gRPC (v1.3.2). These are
+quite old but they are the ones we have been using for a while in p4lang. The
+version doesn't really matter though: more recent versions should be compatible
+at the Protobuf protocol level. When using p4runtime as an external dependency
+in a Bazel project, one should be able to pull more recent versions of
+pubref/rules_protobuf, Protobuf and gRPC; hopefully the BUILD rules should still
+work. Maybe we could consider moving to a more recent pubref/rules_protobuf by
+default. I'd rather wait for better / working versions of the native rules.
+
+### Why did we need to patch Protobuf and gRPC?
+
+The versions we use are quite old. They needed to be patched for recent Bazel
+versions (e.g. `depset` vs `set`).
+
+### Wouldn't it be better to invoke protoc manually in the BUILD file?
+
+It would probably be less dependent on the versions of Bazel, Protobuf and
+gRPC. And not much more verbose. We could switch to invoking protoc directly if
+the current rules are too much of a headache to maintain.

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,84 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+load("@com_google_protobuf//:protobuf.bzl", "internal_copied_filegroup")
+
+P4RUNTIME_PROTO_MAP = {
+    "p4types": "p4/config/v1/p4types.proto",
+    "p4info": "p4/config/v1/p4info.proto",
+    "p4data": "p4/v1/p4data.proto",
+    "p4runtime": "p4/v1/p4runtime.proto",
+}
+
+P4RUNTIME_PROTOS = ["proto/" + s for s in P4RUNTIME_PROTO_MAP.values()]
+
+# Strip "proto" prefix from protos. Theya re copied to $GENDIR.
+internal_copied_filegroup(
+    name = "_copy_protos",
+    srcs = P4RUNTIME_PROTOS,
+    dest = "",
+    strip_prefix = "proto",
+    visibility = ["//visibility:private"],
+)
+
+load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_library")
+
+cpp_proto_library(
+  name = "p4types_proto_cc",
+  protos = ["p4/config/v1/p4types.proto"],
+  with_grpc = False,
+)
+
+cpp_proto_library(
+  name = "p4info_proto_cc",
+  protos = ["p4/config/v1/p4info.proto"],
+  proto_deps = [":p4types_proto_cc"],
+  imports = ["external/com_google_protobuf/src/"],
+  inputs = ["@com_google_protobuf//:well_known_protos"],
+  with_grpc = False,
+)
+
+cpp_proto_library(
+  name = "p4data_proto_cc",
+  protos = ["p4/v1/p4data.proto"],
+  with_grpc = False,
+)
+
+cpp_proto_library(
+  name = "p4runtime_proto_cc",
+  protos = ["p4/v1/p4runtime.proto"],
+  proto_deps = [":p4info_proto_cc", ":p4data_proto_cc",
+                "@com_github_googleapis//:status_proto_cc"],
+  imports = ["external/com_google_protobuf/src/"],
+  inputs = ["@com_google_protobuf//:well_known_protos"],
+  with_grpc = False,
+)
+
+cpp_proto_library(
+  name = "p4runtime_grpc_cc",
+  protos = ["p4/v1/p4runtime.proto"],
+  proto_deps = [":p4info_proto_cc", ":p4data_proto_cc",
+                "@com_github_googleapis//:status_proto_cc"],
+  imports = ["external/com_google_protobuf/src/"],
+  inputs = ["@com_google_protobuf//:well_known_protos"],
+  with_grpc = True,
+)
+
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_compile")
+
+# For some reasom, status_proto_py needs to be includes in both deps and
+# inputs. If it is not listed in inputs, the Python file is not generated for
+# status.proto.
+py_proto_compile(
+  name = "p4runtime_proto_py",
+  protos = ["p4/config/v1/p4types.proto",
+            "p4/config/v1/p4info.proto",
+            "p4/v1/p4data.proto",
+            "p4/v1/p4runtime.proto"],
+  deps = ["@com_github_googleapis//:status_proto_py"],
+  imports = ["external/com_google_protobuf/src/"],
+  inputs = ["@com_google_protobuf//:well_known_protos",
+            "@com_github_googleapis//:status_proto_py"],
+  with_grpc = True,
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,6 @@
+workspace(name = "com_github_p4lang_p4runtime")
+
+load("//bazel:deps.bzl", "p4runtime_deps")
+p4runtime_deps()
+load("//bazel:rules.bzl", "p4runtime_proto_repositories")
+p4runtime_proto_repositories()

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -17,5 +17,5 @@ def p4runtime_deps():
            name = "com_github_googleapis",
            remote = "https://github.com/googleapis/googleapis",
            commit = "37cc0e5acae50ee91f00827a7010c3b07dfa5311",
-           build_file = "bazel/external/googleapis.BUILD",
+           build_file = "@com_github_p4lang_p4runtime//bazel/external:googleapis.BUILD",
        )

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,0 +1,21 @@
+"""Load dependencies needed to compile p4runtime as a 3rd-party consumer."""
+
+load("//bazel:workspace_rule.bzl", "remote_workspace")
+
+def p4runtime_deps():
+    """Loads dependencies need to compile p4runtime."""
+
+    if "org_pubref_rules_protobuf" not in native.existing_rules():
+        remote_workspace(
+            name = "org_pubref_rules_protobuf",
+            remote = "https://github.com/p4lang/rules_protobuf.git",
+            tag = "0.8.0-patched",
+    )
+
+    if "com_github_googleapis" not in native.existing_rules():
+       remote_workspace(
+           name = "com_github_googleapis",
+           remote = "https://github.com/googleapis/googleapis",
+           commit = "37cc0e5acae50ee91f00827a7010c3b07dfa5311",
+           build_file = "bazel/external/googleapis.BUILD",
+       )

--- a/bazel/external/BUILD
+++ b/bazel/external/BUILD
@@ -1,0 +1,1 @@
+exports_files(["googleapis.BUILD"])

--- a/bazel/external/googleapis.BUILD
+++ b/bazel/external/googleapis.BUILD
@@ -1,0 +1,22 @@
+package(
+    default_visibility = [ "//visibility:public" ],
+)
+
+load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_library")
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_compile")
+
+cpp_proto_library(
+    name = "status_proto_cc",
+    protos = ["google/rpc/status.proto"],
+    imports = ["external/com_google_protobuf/src/"],
+    inputs = ["@com_google_protobuf//:well_known_protos"],
+    with_grpc = False,
+)
+
+py_proto_compile(
+    name = "status_proto_py",
+    protos = ["google/rpc/status.proto"],
+    imports = ["external/com_google_protobuf/src/"],
+    inputs = ["@com_google_protobuf//:well_known_protos"],
+    with_grpc = False,
+)

--- a/bazel/rules.bzl
+++ b/bazel/rules.bzl
@@ -1,0 +1,34 @@
+load("@org_pubref_rules_protobuf//protobuf:rules.bzl", "proto_repositories")
+load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_repositories")
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_repositories")
+
+def p4runtime_proto_repositories():
+    """ Load proto repositories through org_pubref_rules_protobuf. """
+
+    PROTOBUF_RULES_OVERRIDE = {
+        "com_google_protobuf": {
+            "rule": "http_archive",
+            "url": "https://github.com/p4lang/protobuf/archive/v3.2.0-patched.zip",
+            "sha256": "",
+            "strip_prefix": "protobuf-3.2.0-patched",
+        },
+        "com_google_grpc_base": {
+            "rule": "http_archive",
+            "url": "https://github.com/p4lang/grpc/archive/v1.3.2-patched.zip",
+            "sha256": "",
+            "strip_prefix": "grpc-1.3.2-patched",
+        },
+    }
+
+    proto_repositories(
+        overrides = PROTOBUF_RULES_OVERRIDE,
+    )
+
+    cpp_proto_repositories(
+        overrides = PROTOBUF_RULES_OVERRIDE,
+    )
+
+    py_proto_repositories(
+        omit_cpp_repositories = True,
+        excludes = ["com_google_protobuf"],
+    )

--- a/bazel/workspace_rule.bzl
+++ b/bazel/workspace_rule.bzl
@@ -1,0 +1,121 @@
+_strict = False
+
+def _build_http_archive(
+    name,
+    remote,
+    branch = None,
+    commit = None,
+    tag = None,
+    build_file = None,
+    ):
+  if not remote.startswith("https://github.com"):
+    # This is only currently support for github repos
+    return False
+
+  # Fix remote suffix
+  if remote.endswith(".git"):
+    remote = remote[:-4]
+  elif remote.endswith("/"):
+    remote = remote[:-1]
+
+  # Tranform repo URL to archive URL
+  repo_name = remote.split("/")[-1]
+  if tag:
+    urls = ["%s/archive/v%s.zip" % (remote, tag)]
+    prefix = repo_name + "-" + tag
+  if commit or branch:
+    ref = commit if commit else branch
+    urls = ["%s/archive/%s.zip" % (remote, ref)]
+    prefix = repo_name + "-" + ref
+
+  # Generate http_archive rule
+  if build_file:
+    native.new_http_archive(
+      name = name,
+      urls = urls,
+      strip_prefix = prefix,
+      build_file = build_file,
+    )
+  else:
+    native.http_archive(
+      name = name,
+      urls = urls,
+      strip_prefix = prefix,
+    )
+  return True
+
+def _build_git_repository(
+    name,
+    remote,
+    branch = None,
+    commit = None,
+    tag = None,
+    build_file = None,
+    ):
+
+  # Strip trailing / from remote
+  if remote.endswith("/"):
+    remote = remote[:-1]
+
+  # Generate the git_repository rule
+  if build_file:
+    native.new_git_repository(
+      name = name,
+      remote = remote,
+      branch = branch,
+      commit = commit,
+      tag = tag,
+      build_file = build_file,
+    )
+  else:
+    native.git_repository(
+      name = name,
+      remote = remote,
+      branch = branch,
+      commit = commit,
+      tag = tag,
+    )
+  return True
+
+def remote_workspace(
+    name,
+    remote,
+    branch = None,
+    commit = None,
+    tag = None,
+    build_file = None,
+    use_git = False,
+    ):
+  ref_count = 0
+  if branch:
+    ref_count += 1
+  if commit:
+    ref_count += 1
+  if tag:
+    ref_count += 1
+
+  if ref_count == 0:
+    fail("one of branch, commit or tag must be set for " + name)
+  elif ref_count > 1:
+    fail("only one of branch, commit, or tag can be set for " + name)
+
+  if commit and len(commit) != 40:
+    fail("You must use the full commit hash for " + name)
+    use_git = True
+    print("using git for ", name, remote)
+
+  if _strict and branch:
+    print("Warning: external workspace, %s, " % name +
+          "should refer to a specific tag or commit (currently: %s)" % branch)
+
+  # Prefer http_archive
+  if not use_git and _build_http_archive(
+      name, remote, branch, commit, tag,build_file):
+    return
+
+  # Fall back to git_repository
+  if _build_git_repository(
+      name, remote, branch, commit, tag,build_file):
+    return
+
+  fail("could not generate remote workspace for " + name)

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,1 +1,21 @@
 # P4Runtime protobuf definition files
+
+## Using Bazel rules
+
+Supported Bazel versions: 0.13, 0.14
+
+1. Import this project, for example using `git_repository`.
+2. Import dependencies in your `WORKSPACE`:
+```
+load("@com_github_p4lang_p4runtime//bazel:deps.bzl", "p4runtime_deps")
+p4runtime_deps()
+load("@com_github_p4lang_p4runtime//bazel:rules.bzl", "p4runtime_proto_repositories")
+p4runtime_proto_repositories()
+```
+3. Use the provided targets:
+    1. `p4types_proto_cc`, `p4info_proto_cc`, `p4data_proto_cc` and
+    `p4runtime_proto_cc` for Protobuf C++ libraries.
+    2. `p4runtime_grpc_cc` for P4Runtime with gRPC.
+
+If you want to use different versions of Protbuf, gRPC and
+rules_protobuf, you will be on your own.


### PR DESCRIPTION
An attempt at #4

We import rules to invoke protoc from pubref/rules_protobuf. The
alternatives would have been 1) try to use native Bazel rules only and
rules from the gRPC reprository, or 2) invoke protoc directly in the
BUILD file.
1) is an issue because of multiple issues with the native & gRPC rules.
2) may actually be the best solution, in terms of usability and
compatibility with different versions of protobuf, gRPC and Bazel.

See BAZEL_NOTES.md for a more comprehensive discussion.