### PR TITLE
Minor fixes in spec

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -900,12 +900,12 @@ the scope of the P4Info message. See Table [#tab-format-p4-obj-ids].
 ~
 
 It is possible to statically set the least-significant 24 bits of the ID in the
-P4 program source by annotating the object with @id (see Table
-[#tab-exmpl-p4-obj-ids]. The compiler must honor the @id annotations when
+P4 program source by annotating the object with `@id` (see Table
+[#tab-exmpl-p4-obj-ids]. The compiler must honor the `@id` annotations when
 generating the P4Info message and must fail the compilation if
 statically-assigned ID suffixes lead to non-unique IDs (i.e. if the P4
 programmer tries to assign the same ID suffix to two different P4 objects of the
-same type by annotating them with the same @id value). Note that it is not
+same type by annotating them with the same `@id` value). Note that it is not
 possible for the P4 programmer to change the value of the 8-bit ID prefix, which
 encodes the object type.
 
@@ -1183,7 +1183,7 @@ specify additional information used by the device to process the data packet.
 
 Such additional information for packet-in and packet-out can be expressed by
 means of P4 headers carrying P4 standard annotations
-@controller_metadata("packet_in") and @controller_metadata("packet_out"),
+`@controller_header("packet_in")` and `@controller_header("packet_out")`,
 respectively. ControllerPacketMetadata messages capture the information
 contained within these special headers and are needed by the P4Runtime server to
 process packet-in and packet-out stream messages (see section on Packet I/O
@@ -3453,7 +3453,7 @@ PacketOut messages are sent by the client to the server.
 
 As introduced in the [Packet I/O](#sec-packet-i_o) section, such messages can
 carry arbitrary metadata specified by means of P4 headers with P4 standard
-annotation @controller_metadata. The expected metadata is also described in the
+annotation `@controller_header`. The expected metadata is also described in the
 P4Info using the ControllerPacketMetadata messages.
 
 Both PacketIn and PacketOut stream messages share the same fields and are
@@ -3714,7 +3714,7 @@ header PacketIn_t {
 }
 ~ End P4Example
 
-The header-level annotation @controller_header is a standard P4Runtime
+The header-level annotation `@controller_header` is a standard P4Runtime
 annotation that identifies a header type for a controller packet-out or
 packet-in. When the P4Runtime server in the target receives a packet-out from
 the controller over the P4Runtime stream channel, the server will expect

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -3844,28 +3844,34 @@ known at compile-time
 
 # References
 
-\[1\] [https://github.com/p4lang/PI/tree/master/proto](https://github.com/p4lang/p4runtime) -
-code repository for reference implementation
+* \[1\]
+  [https://github.com/p4lang/p4runtime](https://github.com/p4lang/p4runtime) -
+  code repository for reference implementation
 
-\[2\] [https://grpc.io](https://grpc.io) - gRPC main site
+* \[2\] [https://grpc.io](https://grpc.io) - gRPC main site
 
-\[3\] [https://developers.google.com/protocol-buffers](https://developers.google.com/protocol-buffers) - 
-protobufs code repository
+* \[3\]
+  [https://developers.google.com/protocol-buffers](https://developers.google.com/protocol-buffers) -
+  Protocol buffers site
 
-\[4\] [https://p4.org](https://p4.org/) - P4.org main site
+* \[4\] [https://p4.org](https://p4.org/) - P4.org main site
 
-\[5\] [http://openconfig.net](http://openconfig.net) - the OpenConfig project
+* \[5\] [http://openconfig.net](http://openconfig.net) - the OpenConfig project
 
-\[6\] [www.stratumproject.org](www.stratumproject.org) - the Stratum Project
+* \[6\] [www.stratumproject.org](www.stratumproject.org) - the Stratum Project
 
-\[7\] [https://github.com/p4lang/PI/tree/master/proto/p4info/xform](https://github.com/p4lang/PI/tree/master/proto/p4info/xform) - 
-P4Info transform utility
+* \[7\]
+  [https://github.com/p4lang/PI/tree/master/proto/p4info/xform](https://github.com/p4lang/PI/tree/master/proto/p4info/xform) -
+  P4Info transform utility
 
-\[8\] [https://p4.org/p4-spec/docs/P4-16-v1.0.0-spec.html#sec-p4-type](https://p4.org/p4-spec/docs/P4-16-v1.0.0-spec.html#sec-p4-type) - 
-Complex types in P4_16
+* \[8\]
+  [https://p4.org/p4-spec/docs/P4-16-v1.0.0-spec.html#sec-p4-type](https://p4.org/p4-spec/docs/P4-16-v1.0.0-spec.html#sec-p4-type) -
+  complex types in P4_16
 
-\[9\] [https://developers.google.com/protocol-buffers/docs/proto3#default](https://developers.google.com/protocol-buffers/docs/proto3#default) - 
-Default values for proto3 fields
+* \[9\]
+  [https://developers.google.com/protocol-buffers/docs/proto3#default](https://developers.google.com/protocol-buffers/docs/proto3#default) -
+  default values for proto3 fields
 
-
-\[10\] [https://github.com/p4lang/PI](https://github.com/p4lang/PI) - Legacy P4 Runtime repo
+* \[10\] [https://github.com/p4lang/PI](https://github.com/p4lang/PI) - Legacy
+  repository for P4Runtime Protobuf definitions, includes reference
+  implementation

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -368,7 +368,7 @@ caption: "P4Runtime Reference Architecture." }
 ![reference-architecture]
 ~
 [reference-architecture]: assets/reference-architecture.png \
-{ width: 100%; page-align: here }
+{ height: 7cm; page-align: here }
 
 ## Idealized Workflow
 
@@ -482,7 +482,7 @@ caption: "Use-Case: Single Embedded Controller" }
 ![single-embedded-controller]
 ~
 [single-embedded-controller]: assets/single-embedded-controller.png \
-{ height: 10cm; page-align: here }
+{ height: 7cm; page-align: forcehere }
 
 ## Single Remote Controller
 
@@ -496,7 +496,7 @@ caption: "Use-Case: Single Remote Controller" }
 ![single-remote-controller]
 ~
 [single-remote-controller]: assets/single-remote-controller.png \
-{ height: 10cm; page-align: here }
+{ height: 7cm; page-align: forcehere }
 
 ## Embedded + Single Remote Controller
 
@@ -518,7 +518,7 @@ caption: "Use-Case: Embedded Plus Single Remote Controller" }
 ~
 [embedded-plus-single-remote-controller]: \
 assets/embedded-plus-single-remote-controller.png \
-{ height: 10cm; page-align: here }
+{ height: 7cm; page-align: forcehere }
 
 ## Embedded + Two Remote Controllers
 
@@ -534,7 +534,7 @@ caption: "Use-Case: Embedded Plus Two Remote Controllers" }
 ~
 [embedded-plus-two-remote-controllers]: \
 assets/embedded-plus-two-remote-controllers.png \
-{ height: 10cm; page-align: here }
+{ height: 7cm; page-align: forcehere }
 
 ## Embedded Controller + Two High-Availability Remote Controllers
 
@@ -551,7 +551,7 @@ caption: "Use-Case: Embedded Plus Two Remote High-Availability Controllers" }
 ![embedded-plus-two-remote-ha-controllers]
 ~
 [embedded-plus-two-remote-ha-controllers]: assets/embedded-plus-two-remote-ha-controllers.png \
-{ height: 10cm; page-align: here }
+{ height: 7cm; page-align: forcehere }
 
 # Master-Slave Arbitration and Controller Replication {\
   #sec-master-slave-arbitration-and-controller-replication}
@@ -2994,7 +2994,7 @@ Figure [#fig-error-report] below illustrates how these messages fit together.
 ~ Figure { #fig-error-report; caption: "P4Runtime Error Report Mesage Format" }
 ![error-report]
 ~
-[error-report]: assets/error-report.png { width: 100%; page-align: here }
+[error-report]: assets/error-report.png { width: 80%; page-align: here }
 
 gRPC provides utility functions ExtractErrorDetails() and SetErrorDetails() (see
 [error_details.h](https://github.com/grpc/grpc/blob/master/include/grpc%2B%2B/support/error_details.h))
@@ -3642,7 +3642,7 @@ caption: "P4Runtime Metadata Translation for the Portable Switch Architeccture" 
 ![psa-metadata-translation]
 ~
 [psa-metadata-translation]: assets/psa-metadata-translation.png \
-{ height: 8cm; page-align: here }
+{ height: 7cm; page-align: here }
 
 Figure [#fig-psa-metadata-translation] above illustrates a motivating example,
 where a centralized controller is controlling two P4Runtime targets in a fabric.

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -301,7 +301,7 @@ message DirectMeter {
 
 // Any metadata associated with controller Packet-IO (Packet-In or Packet-Out)
 // is modeled as P4 headers carrying special annotations
-// @controller_metadata("packet_out") and @controller_metadata("packet_in")
+// @controller_header("packet_out") and @controller_header("packet_in")
 // respectively. There can be at most one header each with these annotations.
 // This message captures the info contained within these special headers,
 // and used in p4runtime.proto to supply the metadata.

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -527,7 +527,7 @@ message DigestList {
 
 // Any metadata associated with Packet-IO (controller Packet-In or Packet-Out)
 // needs to be modeled as P4 headers carrying special annotations
-// @controller_metadata("packet_out") and @controller_metadata("packet_in")
+// @controller_header("packet_out") and @controller_header("packet_in")
 // respectively. There can be at most one header each with these annotations.
 // These special headers are captured in P4Info ControllerPacketMetadata.
 message PacketMetadata {


### PR DESCRIPTION
* use list for references
* change size and placement for figures
* use backticks for `@id` and `@controller_header` in mdk file to avoid warnings
* fix typo in proto comments

See individual commit messages for more details.