### PR TITLE
Spec-wide review and formatting uniformization

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,10 @@ this FAQ.
 
 ### FAQ
 
+#### Should I wrap lines in the Madoko source files?
+
+Yes, at 80 charcters.
+
 #### How to write nested numbered lists in Madoko?
 
 It's easy but you cannot us x.y.z. to number the nested items otherwise it won't

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,55 @@ It seems that when defining the replacement rule, the name of the rule and the
 name of the block tag have to match, but the case doesn't matter (`p4example`
 and `P4Example`).
 
+#### Comments on Tex Header
+
+We have the following in Tex Header:
+```
+\setlength{\emergencystretch}{2em}
+```
+Without this, lines which include inline code tended to spill into the
+right-side margin (we do have some long names in P4Runtime) since `\texttt` does
+not allow hyphenation. Even after enabling hyphenation (see
+[StackExchange](https://tex.stackexchange.com/a/44362)), we were still seeing
+the same issue (except when setting the `font-size` to 100% instead of 75% for
+some reason). By setting `emergencystretch` we give Tex the option to do an
+extra pass when trying to fit an overfull box. See
+[StackExchange](https://tex.stackexchange.com/a/241355) for more
+information. Not sure what the "optimal" setting is.
+
+#### List formatting
+
+Indent each line in such a way that text is aligned for each bullet point:
+```
+1. aaaa
+   bbbb
+   cccc
+```
+or
+```
+* aaaa
+  bbbb
+```
+
+#### Inline code with backticks
+
+Use backticks for:
+
+* names of Protobuf messages / fields / RPCs / enum symbols
+* P4 code
+* name of variables when describing examples (pseudo-code or P4)
+
+Do not use backticks for:
+
+* PSA extern names
+* "P4Runtime" & "P4Info"
+
+#### What to capitalize?
+
+* "Protobuf"
+* Each significant word in a heading / section name
+* PSA extern names
+
 ## CI upload of built documents
 
 Travis takes care of uploading the built HTML version of the spec to AWS S3. The

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1,16 +1,16 @@
 Title : P4Runtime Specification
 Title Note: version 1.0.0-rc1
 Title Footer: &date;
-Author: The P4 Language Consortium
+Author: The P4.org API Working Group
 Heading depth: 5
 Pdf Latex: xelatex
 Document Class: [11pt]article
-Package: [top=1in, bottom=1.25in, left=1in, right=1in]{geometry}
+Package: [top=1in, bottom=1.25in, left=1in, right=1in]geometry
 Package: fancyhdr
 
 Tex Header:
   \setlength{\headheight}{30pt}
-  \renewcommand{\footrulewidth}{0.5pt}
+  \setlength{\emergencystretch}{2em}
 
 @if html {
 body.madoko {
@@ -198,7 +198,7 @@ prototext {
 
 ~ Begin Abstract
 P4 is a language for programming the data plane of network
-devices. The P4Runtime API is a control-plane specification for controlling the
+devices. The P4Runtime API is a control plane specification for controlling the
 data plane elements of a device or program defined by a P4 program. This
 document provides a precise definition of the P4Runtime API. The target audience
 for this document includes developers who want to write controller applications
@@ -209,13 +209,13 @@ for P4 devices or switches.
 [TOC=figures]
 [TOC=tables]
 
-# Introduction and scope
+# Introduction and Scope
 
 This document presents the complete specification for the P4Runtime API, a
 control plane interface intended for forwarding planes which are designed or
 described using the P4 programming language. The textual specification in this
 document disambiguates and augments the programmatic API definition expressed in
-protobuf format and available at [add a link to a "versioned" snapshot in the
+Protobuf format and available at [add a link to a "versioned" snapshot in the
 repository].
 
 ## P4 Language Version Applicability
@@ -244,7 +244,7 @@ The following are not in scope:
 
 * P4 Programming language
 
-* Descriptions of gRPC and protobufs in general
+* Descriptions of gRPC and Protobuf files in general
 
 * Control of elements outside the P4 language. For example,
 architecture-dependent elements such as ports, traffic management, etc. are
@@ -252,13 +252,13 @@ outside of the P4 language and are thus not covered by P4Runtime. Efforts are
 underway to standardize the control of these via gNMI and gNOI APIs, defined and
 maintained by OpenConfig project [[5](http://openconfig.net)]. An open source
 implementation of these APIs is also in progress as part of Stratum project
-[[6]](https://stratumproject.org). 
+[[6]](https://stratumproject.org).
 
-# Terms and definitions
+# Terms and Definitions
 
 * arbitration
   : Refers to the process through which P4Runtime ensures that at any given
-    time, there is a single master (i.e. a client with write access) for a given
+    time, there is a single master (&ie; a client with write access) for a given
     role. Also referred to as "master-slave arbitration".
 * client
   : The gRPC client is the software entity which controls the P4 target or
@@ -282,7 +282,7 @@ implementation of these APIs is also in progress as part of Stratum project
   : The part of the P4Runtime server which implements the calls to the device or
     target native "SDK" or backend.
 * IPC
-  : Inter-process Communication.
+  : Inter-Process Communication.
 * P4 Blob
   : A more colloquial term for P4 Device Config (Blob = Binary Large Object).
 * P4 Device Config
@@ -331,38 +331,38 @@ implementation of these APIs is also in progress as part of Stratum project
     the P4Runtime Service; often used interchangeably with "device".
 
 # Reference Architecture { #sec-reference-architecture}
-Figure [#fig-reference-architecture] below represents the P4Runtime Reference
+Figure [#fig-reference-architecture] represents the P4Runtime Reference
 Architecture. The device or target to be controlled is at the bottom, and one or
-more Controllers is shown at the top. A multi-master protocol allows more than
+more controllers is shown at the top. A multi-master protocol allows more than
 one controller to participate, and a role-based arbitration scheme ensures only
 one controller has write access to each r/w entity, or the pipeline config
 itself. Any controller may perform read access to any entity or the pipeline
 config. Later sections describe this in detail. For the sake of brevity, the
-term Controller may refer to one or more controllers.
+term controller may refer to one or more controllers.
 
 The P4Runtime API defines the messages and semantics of the interface between
 the client(s) and the server. The API is specified by the p4runtime.proto
-protobuf file, which is available on GitHub as part of the standard
-[[1](https://github.com/p4lang/p4runtime)]. It may be compiled via
-protoc to produce both client and server implementation stubs in a variety
-of languages. It is the responsibility of target implementers to instrument the
-server.
+Protobuf file, which is available on GitHub as part of the standard
+[[1](https://github.com/p4lang/p4runtime)]. It may be compiled via protoc - the
+Protobuf compiler - to produce both client and server implementation stubs in a
+variety of languages. It is the responsibility of target implementers to
+instrument the server.
 
 Reference implementations of a P4 Target supporting P4Runtime, as well as sample
 clients, may be available on the GitHub repository
 [[10]](https://github.com/p4lang/PI). A future goal may be to produce a
-reference gRPC server which can be instrumented in a generic way, e.g. via
-callbacks, thus reducing the burden of reinventing the wheel.
+reference gRPC server which can be instrumented in a generic way, &eg; via
+callbacks, thus reducing the burden of implementing P4Runtime.
 
-The Controller can access the P4 entities which are declared in the P4Info
-metadata. The P4Info structure is defined by p4info.proto,another protobuf
-file available as part of the standard.
+The controller can access the P4 entities which are declared in the P4Info
+metadata. The P4Info structure is defined by p4info.proto, another Protobuf file
+available as part of the standard.
 
-The Controller can also set the ForwardingPipelineConfig, which amounts to
-installing and running the compiled P4 program output, which is the
-p4_device_config protobuf message) and installing the associated P4Info
-metadata. Furthermore, the Controller can query the target for the
-ForwardingPipelineConfig to retrieve the device config and the P4Info.
+The controller can also set the `ForwardingPipelineConfig`, which amounts to
+installing and running the compiled P4 program output, which is included in the
+`p4_device_config` Protobuf message) and installing the associated P4Info
+metadata. Furthermore, the controller can query the target for the
+`ForwardingPipelineConfig` to retrieve the device config and the P4Info.
 
 
 ~ Figure { #fig-reference-architecture; \
@@ -374,26 +374,26 @@ caption: "P4Runtime Reference Architecture." }
 
 ## Idealized Workflow
 
-In the idealized workflow a P4 source program is compiled to produce both a P4
-device config and P4Info metadata. These comprise the ForwardingPipelineConfig.
-A P4 Controller chooses a configuration appropriate to a particular target and
-installs it via a SetForwardingPipelineConfig RPC. Metadata in the P4Info
-describes both the overall program itself (PkgInfo) as well as all entity
-instances derived from the P4 program - tables, counters, meters, etc. Each
+In the idealized workflow, a P4 source program is compiled to produce both a P4
+device config and P4Info metadata. These comprise the `ForwardingPipelineConfig`
+message. A P4 controller chooses a configuration appropriate to a particular
+target and installs it via a `SetForwardingPipelineConfig` RPC. Metadata in the
+P4Info describes both the overall program itself (`PkgInfo`) as well as all
+entity instances derived from the P4 program - tables and extern instances. Each
 entity instance has an associated numeric ID assigned by the P4 compiler which
 serves as a concise "handle" used in API calls.
 
-In this workflow, P4 compilers are developed for each unique type of target and
-produce P4Info and a target-specific device config. The P4Info schema is
-designed to be target architecture-independent, although the specific contents
-are likely to be architecture-dependent. The compiler ensures the code is
-compatible with the specific target and rejects code which is incompatible.
+In this workflow, P4 compiler backends are developed for each unique type of
+target and produce P4Info and a target-specific device config. The P4Info schema
+is designed to be target and architecture-independent, although the specific
+contents are likely to be architecture-dependent. The compiler ensures the code
+is compatible with the specific target and rejects code which is incompatible.
 
-Presumably, a Controller can access a library of P4 "packages" consisting of the
+Presumably, a controller can access a library of P4 "packages" consisting of the
 P4 device config and P4Info and install them at will onto the target. A
-Controller can also query the ForwardingPipelineConfig from the target via the
-GetForwardingPipelineRequest RPC. This can be useful to obtain the pipeline
-configuration from a running device to synchronize the Controller to its current
+controller can also query the `ForwardingPipelineConfig` from the target via the
+`GetForwardingPipelineRequest` RPC. This can be useful to obtain the pipeline
+configuration from a running device to synchronize the controller to its current
 state.
 
 ## P4 as a Behavioral Description Language
@@ -401,10 +401,10 @@ state.
 P4 can be considered a behavioral description of a switching device which may or
 may not execute "P4" natively. There is no requirement that a P4 compiler be
 used in the production of either the P4 device config or the P4Info. There is no
-absolute requirement that the target accept a SetForwardingPipelineRequest to
-change its pipeline "program." Some devices may be fixed in function.
+absolute requirement that the target accept a `SetForwardingPipelineRequest` to
+change its pipeline "program", as ome devices may be fixed in function.
 Furthermore, it is not necessary to have a P4 source program to begin with,
-since the controller does not use it. From the standpoint of Controller (not
+since the controller does not use it. From the standpoint of controller (not
 pipeline) implementers, the P4 source code is just helpful documentation. Some
 parties may wish to keep their P4 source code private. The minimum requirement
 is a P4Info file which can be loaded by a controller in order to render the
@@ -413,7 +413,7 @@ the P4Info file, the underlying implementation is moot.
 
 This leads to the notion that a good P4Info file should be complete and
 self-sufficient in terms of documentation, specifically the metadata in the
-PkgInfo message as well as the embedded doc messages. Nevertheless,
+`PkgInfo` message as well as the embedded `doc` messages. Nevertheless,
 a P4 program which describes the pipeline and produces the device config via a
 compiler is ideally available. The contents of the P4Info file will be described
 in later sections.
@@ -421,28 +421,28 @@ in later sections.
 ## Alternative Workflows
 
 Given the notions above concerning P4 code as behavioral description and P4Info
-as API metadata, some other possible workflows are as follows.These are just
+as API metadata, some other possible workflows are as follows. These are just
 examples and actual situations may vary.
 
-### P4 Source Available, Compiled Into P4Info but not Compiled into P4 Device Config
+### P4 Source Available, Compiled into P4Info but not Compiled into P4 Device Config
 
 In this situation, P4 source code is available mainly as a behavioral model and
 compiled to produce P4Info, but it is not compiled to produce the
-p4_device_config. The device's configuration might be derived via some other
+`p4_device_config`. The device's configuration might be derived via some other
 means to implement the P4 source code's intentions. The P4 code, if available,
 can be studied to understand the pipeline, and the P4Info can be used to
 implement the control plane.
 
-### No P4 Source Available; P4Info Available
+### No P4 Source Available, P4Info Available
 
 In this situation, P4Info is available but no P4 source is available for any
 number of reasons, the most likely of which are:
 
 1. The vendor or organization does not wish to divulge the P4 source code, to
-protect intellectual property or maintain security
+   protect intellectual property or maintain security.
 
 2. The target was not implemented using P4 code to begin with, although it still
-obeys the "contract" specified in the P4Info.
+   obeys the "contract" specified in the P4Info.
 
 ### Partial P4Info and P4 Source are Available
 
@@ -456,12 +456,12 @@ complete P4Info and possibly P4 source code.
 ### P4Info Role-Based Subsets
 
 In this situation, P4Info is selectively packaged into role-based subsets to
-allow some Controllers access to just the functionality required. For example, a
-Controller may only need read access to statistics counters and nothing more.
+allow some controllers access to just the functionality required. For example, a
+controller may only need read access to statistics counters and nothing more.
 
 # Controller Use-cases
 
-P4Runtime allows for more than one Controller. The mechanisms and semantics are
+P4Runtime allows for more than one controller. The mechanisms and semantics are
 described in a later section. Here we present a number of use-cases. Each
 use-case highlights a particular aspect of P4Runtime's flexibility and is not
 intended to be exhaustive. Real-world use-cases may combine various techniques
@@ -469,14 +469,14 @@ and be more complex.
 
 ## Single Embedded Controller
 
-Figure [#fig-single-embedded-controller] below shows perhaps the simplest
-use-case. A device or target has an embedded Controller which communicates to an
-on-board switch via P4Runtime. This might be appropriate for an embedded
-appliance which is not intended for SDN use-cases.
+Figure [#fig-single-embedded-controller] shows perhaps the simplest use-case. A
+device or target has an embedded controller which communicates to an on-board
+switch via P4Runtime. This might be appropriate for an embedded appliance which
+is not intended for SDN use-cases.
 
 P4Runtime was designed to be a viable embedded API. Complex controller
 architectures typically feature multiple processes communicating with some sort
-of IPC (Interprocess Communications). P4Runtime is thus both an ideal RPC and an
+of IPC (Inter-Process Communications). P4Runtime is thus both an ideal RPC and an
 IPC.
 
 ~ Figure { #fig-single-embedded-controller; \
@@ -488,7 +488,7 @@ caption: "Use-Case: Single Embedded Controller" }
 
 ## Single Remote Controller
 
-Figure [#fig-single-remote-controller] below shows a single remote Controller in
+Figure [#fig-single-remote-controller] shows a single remote Controller in
 charge of the P4 target. In this use-case, the device has no control of the
 pipeline, it just hosts the server. While this is possible, it is probably more
 practical to have a hybrid use-case as described in subsequent sections.
@@ -502,17 +502,16 @@ caption: "Use-Case: Single Remote Controller" }
 
 ## Embedded + Single Remote Controller
 
-Figure [#fig-embedded-plus-single-remote-controller] below illustrates the
-use-case of an embedded Controller plus a single remote Controller. Both
-Controllers are clients of the single server. The embedded controller is in
-charge of one set of P4 entities plus the pipeline configuration. The remote
-Controller is in charge of the remainder of the P4 entities. An equally-valid,
-alternative use-case could assign the pipeline configuration to the remote
-Controller.
+Figure [#fig-embedded-plus-single-remote-controller] illustrates the use-case of
+an embedded controller plus a single remote controller. Both controllers are
+clients of the single server. The embedded controller is in charge of one set of
+P4 entities plus the pipeline configuration. The remote controller is in charge
+of the remainder of the P4 entities. An equally-valid, alternative use-case,
+could assign the pipeline configuration to the remote controller.
 
 For example, to minimize round-trip times (RTT) it might make sense for the
-embedded Controller to manage the contents of a Fast-Failover table. The remote
-Controller might manage the contents of routing tables.
+embedded controller to manage the contents of a fast-failover table. The remote
+controller might manage the contents of routing tables.
 
 ~ Figure { #fig-embedded-plus-single-remote-controller; \
 caption: "Use-Case: Embedded Plus Single Remote Controller" }
@@ -524,10 +523,10 @@ assets/embedded-plus-single-remote-controller.png \
 
 ## Embedded + Two Remote Controllers
 
-Figure [#fig-embedded-plus-two-remote-controllers] below illustrates the case of
-an embedded Controller similar to the previous use-case,and two remote
-Controllers. One of the remote Controllers is responsible for some entities,
-e.g. routing tables, and the other remote controller is responsible for other
+Figure [#fig-embedded-plus-two-remote-controllers] illustrates the case of an
+embedded controller similar to the previous use-case, and two remote
+controllers. One of the remote controllers is responsible for some entities,
+&eg; routing tables, and the other remote controller is responsible for other
 entities, perhaps statistics tables. Role-based access divides the ownership.
 
 ~ Figure { #fig-embedded-plus-two-remote-controllers; \
@@ -540,9 +539,9 @@ assets/embedded-plus-two-remote-controllers.png \
 
 ## Embedded Controller + Two High-Availability Remote Controllers
 
-Figure [#fig-embedded-plus-two-remote-ha-controllers] below illustrates a single
-embedded Controller plus two remote Controllers in an active-standby HA
-(High-Availability) Configuration. Controller #1 is the active Controller and is
+Figure [#fig-embedded-plus-two-remote-ha-controllers] illustrates a single
+embedded controller plus two remote controllers in an active-standby HA
+(High-Availability) Configuration. Controller #1 is the active controller and is
 in charge of some entities. If it fails, Controller #2 takes over and manages
 the tables formerly owned by Controller #1. The mechanics of HA architectures
 are beyond the scope of this document, but the P4Runtime multi-master
@@ -558,202 +557,170 @@ caption: "Use-Case: Embedded Plus Two Remote High-Availability Controllers" }
 # Master-Slave Arbitration and Controller Replication {\
   #sec-master-slave-arbitration-and-controller-replication}
 
-P4Runtime interface allows multiple controllers to be connected to the P4Runtime
-server running on the switch at the same time for the following reasons:
+The P4Runtime interface allows multiple controllers to be connected to the
+P4Runtime server running on the device at the same time for the following
+reasons:
 
-1. Partitioning of the control plane: Multiple controllers may have orthogonal
-non overlapping "roles" (or "realms") and should be able to push forwarding
-entries simultaneously. The control plane can be partitioned into multiple roles
-and each role will have a set of controllers, one of which is the master and the
-rest are slaves.
+1. Partitioning of the control plane: Multiple controllers may have orthogonal,
+   non-overlapping, "roles" (or "realms") and should be able to push forwarding
+   entitites simultaneously. The control plane can be partitioned into multiple
+   roles and each role will have a set of controllers, one of which is the
+   master and the rest are slaves.
 
 2. Redundancy and fault tolerance: Supporting multiple controllers allows having
-one or more standby slave controllers, which take over controlling the switches
-in case the master controller goes offline.
+   one or more standby slave controllers, which take over controlling the
+   devices in case the master controller goes offline.
 
 To support multiple controllers, P4Runtime uses the same streaming channel
-(available via StreamChannel RPC) for session management. The workflow is
+(available via `StreamChannel` RPC) for session management. The workflow is
 described as follows:
 
-* Each controller is assigned a role_id and an election_id. The role_id defines
-the role (or realm) that the controller is part of. The election_id is unique
-per role and identifies the master for a specific role. At any point of time,
-the controller with the largest election_id for each role is the master and the
-rest are slaves. Note that the switch does not assign role_id and election_id to
-any controller. It is up to an arbitration mechanism outside of the switch to
-decide on the controller roles and the master and slave controllers for each
-role. The P4Runtime server running on the switch only keeps track of the role_id
-and election_id of the controllers to understand which connected controller is
-master at any point of time. 
+* Each controller is assigned a `role_id` and an `election_id`. The `role_id`
+  defines the role (or realm) that the controller is part of. The `election_id`
+  is unique per role and identifies the master for a specific role. At any point
+  in time, the controller with the largest `election_id` for each role is the
+  master and the rest are slaves. Note that the device does not assign a
+  `role_id` and `election_id` to any controller. It is up to an arbitration
+  mechanism outside of the device to decide on the controller roles and the
+  master and slave controllers for each role. The P4Runtime server running on
+  the device only keeps track of the `role_id` and `election_id` of the
+  controllers to determine which connected controller is master at any point of
+  time.
 
 * To start a controller session, a controller first opens a bidirectional stream
-channel to the switch via StreamChannel RPC for each device (aka target or node
-or switching chip). This is the first thing the controller does to identify
-itself to the P4Runtime server on the switch. This stream will be used for two
-purposes:
+  channel to the server via the `StreamChannel` RPC for each device. This is the
+  first thing the controller does to identify itself to the P4Runtime server on
+  the device. This stream will be used for two purposes:
 
-  a. **Session management:** As soon as the controller opens the stream channel,
-  it sends a StreamMessageRequest message to the switch. The controller populates
-  the MasterArbitrationUpdate field in this message using its role_id and
-  election_id:
+    * **Session management:** As soon as the controller opens the stream
+      channel, it sends a `StreamMessageRequest` message to the switch. The
+      controller populates the `MasterArbitrationUpdate` field in this message
+      using its `role_id` and `election_id`. Note that `status` field in the
+      `MasterArbitrationUpdate` is not populated by the controller. This field
+      is populated by the P4Runtime server when it sends a response back to the
+      client, as explained below.
 
-~ Begin Proto
-message Role {
-  // role_id for this role. Defined offline in agreement across the 
-  // entire control plane.
-  uint64 id = 1;
-  // Describes the role configuration.
-  google.protobuf.Any config = 2;
-}
+    * **Streaming of notifications (&eg; digests) and packet I/O:** The same
+      streaming channel will be used for streaming notifications, as well as for
+      packet-in and packet-out messages. Note that only the master controller
+      can participate in packet I/O. This feature is explained in more details
+      in the [Packet I/O](#sec-packet-i_o) section.
 
-message MasterArbitrationUpdate {
-  // Identifies the device (aka target or node or switching chip). 
-  uint64 device_id = 1;
-  // The role for which the mastership is being arbitrated. 
-  Role role = 2;
-  // The election_id (unique per role).
-  Uint128 election_id = 3;
-  // Switch populates this with OK for the client that is the master, 
-  // and with an error status for all other connected clients (at 
-  // every mastership change). The controller does not populate this 
-  // field.
-  google.rpc.Status status = 4;
-}
+* Note that the stream is opened per device. In case a switching platform has
+  multiple devices (&eg; multi-ASIC line card) which are all controlled via the
+  same P4Runtime server, it is possible to have different masters for different
+  devices. In this case, it is the responsibility of the P4Runtime server to
+  keep track of the master for each device (and role). More specifically, the
+  P4Runtime server will know which stream corresponds to the master controller
+  for each pair of (`device_id`, `role_id`) at any point of time.
 
-message StreamMessageRequest {
-  oneof update {
-    MasterArbitrationUpdate arbitration = 1;
-    PacketOut packet = 2;  // used for packet I/O
-  }
-}
+* The streaming channel between the controller and the server defines the
+  liveness of the controller session. The controller is considered "offline" or
+  "dead" as soon as its corresponding stream channel to the the switch is
+  broken, in which case the P4Runtime server quickly sets one of the slave
+  controllers with the highest `election_id` as master.
 
-message StreamMessageResponse {
-  oneof update {
-    MasterArbitrationUpdate arbitration = 1;
-    PacketIn packet = 2;  // used for packet I/O
-  }
-}
-~ End Proto
+* After the controller sends a `StreamMessageRequest` message to the P4Runtime
+  server, the server sends a `StreamMessageResponse` message back to the
+  controller, in which it populates the `MasterArbitrationUpdate`. The
+  controller must populate the `device_id`, `role`, and `election_id`
+  fields. The `election_id` field is set to the highest value, &ie; the value
+  for the current master. The server also populates the `status` field in the
+  `MasterArbitrationUpdate` (note that this field is not populated in the
+  `MasterArbitrationUpdate` received by the controller). The value of the status
+  message is one of the following:
+    * OK (with `status.code` set to `google.rpc.OK`) when the controller is
+      determined to be the master for a given (`device_id`, `role_id`).
+    * Non-OK (with `status.code` set to `google.rpc.ALREADY_EXISTS`) when the
+      controller is determined to be a slave for a given (`device_id`,
+      `role_id`).
 
-  Note that status field in the MasterArbitrationUpdate is not populated by the
-  controller. This field is populated by the P4Runtime server when it sends a
-  response back to the client, as explained below.
+## Default Role
 
-  b. **Packet I/O:** The same streaming channel will be used for packet in and
-  packet out as well. Note that only the master controller can participate in
-  packet I/O. This feature is explained in more details in the
- [Packet I/O](#sec-packet-i_o) section.
+A controller can omit the role message in `MasterArbitrationUpdate`. This
+implies the "default role", which corresponds to "full pipeline access". This
+also implies that a default role has a `role.id` of 0 (default). If using a
+default role, all RPCs from the controller (&eg; `Write`) must set the `role_id`
+to 0.
 
+## Role Config
 
-* Note that the stream is opened per device. In case a switch platform has
-multiple devices which are all controlled via the same P4Runtime server, it is
-possible to have different masters for different devices. In such case, it is
-the responsibility of the P4Runtime server to keep track of the master for each
-device (and role). More specifically, the P4Runtime server will know which
-stream corresponds to the master controller for each pair of (device_id,
-role_id) at any point of time.  
+The `role.config` field in the `MasterArbitrationUpdate` message sent by the
+controller describes the role configuration, &ie; which operations, P4 entities,
+behaviors, etc. are in the scope of a given role. An unset `role.config` implies
+"full pipeline access" as well (similar to the default role explained above).
 
-* The streaming channel between the controller and the switch defines the
-liveness of the controller session. The controller is considered "offline" or
-"dead" as soon as its corresponding stream channel to the the switch is broken,
-in which case the P4Runtime server quickly sets one of the slave controllers
-which has the highest election_id for any (device_id, role_id) as master.
+## Rules for Handling `MasterArbitrationUpdate` Messages Received from Controllers
 
-* After the controller sends a StreamMessageRequest message to the P4Runtime
-server, the server sends a StreamMessageResponse message back to the controller,
-in which it populates the MasterArbitrationUpdate message using the device_id,
-role, and election_id it previously received from the controller via the
-StreamMessageRequest message. The server also populates the status field in the
-MasterArbitrationUpdate (note that this field is not populated in the
-MasterArbitrationUpdate received by the controller). The value of the status
-message is one of the following:
+1. If the `MasterArbitrationUpdate` message is received for the first time (for
+   a newly connected controller):
 
-    1. OK (with status.code set to google.rpc.OK) when the controller is
-    determined to be the master for a given (device_id, role_id).
+    1. If `device_id` does not match any of the devices known to the P4Runtime
+       server, the server shall terminate the stream by returning a
+       `FAILED_PRECONDITION` error.
 
-    2. Non-OK (with status.code set to google.rpc.ALREADY_EXISTS) when the
-    controller is determined to be a slave for a given (device_id, role_id).
+    2. If the `election_id` is already used by another controller for the same
+       (`device_id`, `role_id`), the P4Runtime server shall terminate the stream
+       by returning an `INVALID_ARGUMENT` error.
 
-## Default role
-
-A controller can omit the role message in MasterArbitrationUpdate. This implies
-the "default role", which corresponds to "full pipeline access". This also
-implies that a default role has a role.id of 0 (default). If using a default
-role, all RPCs from the controller (e.g. Write) must set the role_id to 0.
-
-## Role config
-
-The role.config field in the MasterArbitrationUpdate message sent by the
-controller described the role configuration, i.e. what operations, P4 entities,
-behaviors, etc. are in the scope of a given role. An unset role.config implies
-full pipeline access as well (similar to the default role explained above).
-
-## Rules of handling MasterArbitrationUpdate messages received from controllers
-
-1. If MasterArbitrationUpdate message is received for the first time (for a
-newly connected controller):
-
-    1. If device_id does not match any of the devices, the P4Runtime server
-    shall terminate the stream by returning a FAILED_PRECONDITION error. 
-
-    2. If the election_id is already used by another controller for the same
-    (device_id, role_id), the P4Runtime server shall terminate the stream by
-    returning an INVALID_ARGUMENT error.
-
-    3. Otherwise, if the max number of clients per each (device_id, role_id)
-    exceeds the supported limit, the P4Runtime server shall terminate the stream
-    by returning a RESOURCE_EXHAUSTED error.
+    3. If the max number of clients for the given (`device_id`, `role_id`)
+       exceeds the supported limit, the P4Runtime server shall terminate the
+       stream by returning a `RESOURCE_EXHAUSTED` error.
 
     4. Otherwise, the controller is added to list of connected controllers for
-    the given (device_id, role_id) and the controller will be notified by
-    sending a StreamMessageResponse message back to it, as explained earlier.
+       the given (`device_id`, `role_id`) and the controller is notified by
+       sending a `StreamMessageResponse` message back to it, as explained
+       earlier.
 
-2. If MasterArbitrationUpdate message is received from an already connected
-controller:
+2. If the `MasterArbitrationUpdate` message is received from an already
+   connected controller:
 
-    5. If the device_id does not match the one already assigned to this stream,
-    the P4Runtime server shall terminate the stream by returning a
-    FAILED_PRECONDITION error.
+    1. If the `device_id` does not match the one already assigned to this
+       stream, the P4Runtime server shall terminate the stream by returning a
+       `FAILED_PRECONDITION` error.
 
-    6. Otherwise, if the role.id matches the current role_id assigned to this stream:
+    2. Otherwise, if the `role.id` matches the current `role_id` assigned to
+       this stream:
 
-        * If the election_id also matches the one assigned to this stream, the
-        server will accept role.config only if this controller is the master. If
-        the controller is not a master, the operation is a NOOP.
+        1. If the `election_id` also matches the one assigned to this stream,
+           the server will accept the (new) `role.config` only if this
+           controller is the current master. If the controller is not a master,
+           the operation is a no-op.
 
-        * Otherwise, if the election_id is already assigned to another
-        controller stream for the same (device_id, role_id), the P4Runtime
-        server shall terminate the stream by returning a INVALID_ARGUMENT error.
+        2. If the `election_id` is already assigned to another controller stream
+           for the same (`device_id`, `role_id`), the P4Runtime server shall
+           terminate the stream by returning an `INVALID_ARGUMENT` error.
 
-        * Otherwise, the P4Runtime server updates the election_id for this
-        controller. If this makes the client the new master, the server will
-        also accept the given role.config and follows the "mastership change
-        rule" explained in the section next.
+        3. Otherwise, the P4Runtime server updates the `election_id` for this
+           controller. If this makes the client the new master, the server will
+           also accept the given `role.config` and follow the "mastership change
+           rules" described in the [following section](#sec-master-change).
 
-    7. Otherwise (i.e. role.id is different from current role_id assigned to
-    this stream), the P4Runtime server moves the controller to the new role.
-    This controller will then be treated as if it was a new controller for the
-    new (device_id, role_id). The server accepts the given role.config only if
-    the client becomes master, in which case the servers also follow the
-    "mastership change rule" explained in the next section.
+    3. Otherwise (&ie; `role.id` is different from current `role_id` assigned to
+       this stream), the P4Runtime server moves the controller to the new role.
+       This controller will then be treated as a new controller for the new
+       (`device_id`, `role_id`). The server accepts the given `role.config` only
+       if the client becomes master, in which case the server also follows the
+       "mastership change rules" described in the [following
+       section](#sec-master-change).
 
-## Mastership change
+## Mastership Change { #sec-master-change}
 
-Mastership change refers to either one of these cases:
+"Mastership change" refers to either one of these cases:
 
-1. A new MasterArbitrationUpdate is received from an already connected
-controller for a given (device_id, role_id), which changes the controller
-mastership (the controller becomes master or slave).
+1. A new `MasterArbitrationUpdate` is received from an already connected
+   controller for a given (`device_id`, `role_id`), which changes the controller
+   mastership status (the controller becomes master or slave).
 
 2. A streaming channel for a given master controller breaks, forcing a new
-master to be elected.
+   master to be elected.
 
-In case of a mastership change, P4Runtime server shall send the election_id of
-the master to "all" the connected controllers for a given (device_id, role_id).
-The StreamMessageResponse sent back to all the connected controllers has a
-MasterArbitrationUpdate message populated with device_id, role, and election_id
-of the master, as well as an OK status for the master and non-OK status (with
-ALREADY_EXISTS status code) for slaves.   
+In case of a mastership change, P4Runtime server shall send the `election_id` of
+the master to *all* the connected controllers for a given (`device_id`,
+`role_id`).  The `StreamMessageResponse` sent back to all the connected
+controllers has a `MasterArbitrationUpdate` message populated with `device_id`,
+`role_id`, and `election_id` of the master, as well as an OK status for the
+master and non-OK status (with `ALREADY_EXISTS` error code) for slaves.
 
 # The P4Info Message
 
@@ -766,7 +733,7 @@ components.
 
 These messages appear nested within many other messages.
 
-### Documentation Message
+### `Documentation` Message
 
 Documentation is used to carry both brief and long descriptions of something.
 Good content within the Documentation is extremely helpful to P4Runtime
@@ -781,7 +748,7 @@ message Documentation {
   string description = 2;
 }
 ~ End Proto
-### Preamble Message
+### `Preamble` Message
 
 The preamble serves as the "descriptor" for each entity and contains the unique
 instance ID, name, alias, annotations and documentation.
@@ -814,18 +781,19 @@ message Preamble {
 }
 ~ End Proto
 
-## PkgInfo Message
+## `PkgInfo` Message
 
-The PkgInfo message contains package-level metadata which describes the overall
-P4 program itself, as opposed to P4 entities. PkgInfo can be extracted and used
-to facilitate "browsing" of available P4 programs from a library. Although all
-fields are technically "optional," every implementation should include as a
-minimum the name, version, doc and arch fields. The other fields are recommended
-to be included.
+The `PkgInfo` message contains package-level metadata which describes the
+overall P4 program itself, as opposed to P4 entities. `PkgInfo` can be extracted
+and used to facilitate "browsing" of available P4 programs from a
+library. Although all fields are technically "optional," every implementation
+should include as a minimum the name, version, doc and arch fields. The other
+fields are recommended to be included.
 
-Note, the known P4 compilers as of this writing don't emit PkgInfo as part of
-the P4Info output. In the meantime, a utility to post-process and insert PkgInfo
-can be used [[7]](https://github.com/p4lang/PI/tree/master/proto/p4info/xform).
+Note, the known P4 compilers as of this writing don't emit `PkgInfo` as part of
+the P4Info output. Until compiler support is added, a utility to post-process
+and insert `PkgInfo` can be used
+[[7]](https://github.com/p4lang/PI/tree/master/proto/p4info/xform).
 
 ~ Begin Proto
 
@@ -852,22 +820,24 @@ message PkgInfo {
   string description = 2;
 }
 ~ End Proto
-## ID allocation for P4Info objects
+## ID Allocation for P4Info Objects
 
 P4Info objects receive a unique ID, which is used to identify the object in
 P4Runtime messages. IDs are 32-bit unsigned integers which are assigned by the
 compiler during the P4Info generation process. IDs are assigned in such a way
 that is is possible based on the ID value alone to deduce the type of the object
-(e.g. table, action, counter, ...). The most significant 8 bits of the ID
+(&eg; table, action, counter, ...). The most significant 8 bits of the ID
 encodes the object type (as per Table [#tab-mapping-p4-obj-ids]. The
 p4info.proto file includes a mapping from object type to 8-bit prefix value,
-encoded as an enum definition `(p4.config.v1.P4Ids.Prefix)`. These values must
-be used (e.g. by the compiler) when allocating IDs. The remaining 24-bits must
+encoded as an enum definition (`p4.config.v1.P4Ids.Prefix`). These values must
+be used (&eg; by the compiler) when allocating IDs. The remaining 24-bits must
 be generated in such a way that the resultings IDs must be globally unique in
 the scope of the P4Info message. See Table [#tab-format-p4-obj-ids].
 
 ~ TableFigure { #tab-mapping-p4-obj-ids; \
-    caption: "Mapping of P4Info object type to 8-bit ID prefix value"; }
+    caption: "Mapping of P4Info object type to 8-bit ID prefix value"; \
+    breakable: true; \
+    page-align: forcehere; }
 |--------------------|----------------------------------------------------------------------|
 | 8-bit prefix value | P4 object type                                                       |
 +--------------------+----------------------------------------------------------------------+
@@ -897,7 +867,7 @@ the scope of the P4Info message. See Table [#tab-format-p4-obj-ids].
 |----------------------------|------------------------------------------|
 | MSB bit 31 ........ bit 24 | bit 23 ....................... bit 0 LSB |
 +:--------------------------:+:----------------------------------------:+
-| Object type prefix         | Generated suffix (e.g. by the compiler)  |
+| Object type prefix         | Generated suffix (&eg; by the compiler)  |
 +----------------------------+------------------------------------------+
 ~
 
@@ -905,7 +875,7 @@ It is possible to statically set the least-significant 24 bits of the ID in the
 P4 program source by annotating the object with `@id` (see Table
 [#tab-exmpl-p4-obj-ids]. The compiler must honor the `@id` annotations when
 generating the P4Info message and must fail the compilation if
-statically-assigned ID suffixes lead to non-unique IDs (i.e. if the P4
+statically-assigned ID suffixes lead to non-unique IDs (&ie; if the P4
 programmer tries to assign the same ID suffix to two different P4 objects of the
 same type by annotating them with the same `@id` value). Note that it is not
 possible for the P4 programmer to change the value of the 8-bit ID prefix, which
@@ -926,252 +896,235 @@ encodes the object type.
 +---------------------------------+------------------------------------------------------------+
 ~
 
-## P4Info objects
+## P4Info Objects
 
-### Table
+### `Table`
 
 Table messages are used to specify all possible match-action tables exposed to a
 control plane. This message contains the following fields:
 
-* preamble, a Preamble message with ID, name, and alias of this table
+* `preamble`, a `Preamble` message with the ID, name, and alias of this table.
 
-* match_fields, a repeated field of type MatchField representing the data to be
-used to construct the lookup key matched in this table. Each MatchField message
-is defined with the following fields:
+* `match_fields`, a repeated field of type `MatchField` representing the data to
+  be used to construct the lookup key matched in this table. Each `MatchField`
+  message is defined with the following fields:
 
-    * id, an uint32 identifier of this MatchField, unique in the scope of this
-    table. No rules are prescribed on the way MatchField IDs should be
-    allocated, as long as two MatchField of the same table do not have the same
-    ID.
+    * id, the `uint32` identifier of this `MatchField`, unique in the scope of
+      this table. No rules are prescribed on the way `MatchField` IDs should be
+      allocated, as long as two `MatchField` of the same table do not have the
+      same ID.
 
-    * name, a string representing the name of this MatchField.
+    * `name`, the string representing the name of this `MatchField`.
 
-    * annotations, a repeated string field, each one representing a P4
-    annotation associated to this match field.
+    * `annotations`, a repeated field of strings, each one representing a P4
+      annotation associated to this match field.
 
-    * bitwidth, an int32 value describing the size in bits of this match field.
+    * `bitwidth`, an `int32` value set to the size in bits of this match field.
 
-    * match_type, describing the match behavior applied to this field. Value
-    can be any from the MatchType enum which describes all possible PSA match
-    kinds, such as
+    * `match`, a `oneof` describing the match behavior for this field; it can be
+      either:
+        * `match_type`, an enum field of type `MatchType`, which includes all
+          possible PSA match kinds.
+        * `other_match_type`, a string field which can be used to encode any
+          architecture-specific match type.
 
-        * UNSPECIFIED, reserved
+    * `doc`, a `Documentation` message describing this match field.
 
-        * EXACT, to match bits exactly
+* `action_refs`, a repeated `ActionRef` field representing the set of possible
+  actions for this table. The `ActionRef` message is used to reference an action
+  specified in the same P4Info message and it includes the following fields:
+    * `id`, the `uint32` identifier of the action.
+    * `annotations`, a repeated string field, each one representing a P4
+      annotation associated to the action *reference* in this table.
 
-        * LPM, for longest-prefix match
+* `const_default_action_id`, if this table has a constant default action, this
+  field will carry the `uint32` identifier of that action, otherwise its value
+  will be 0. A default action is executed when a matching table entry is not
+  found for a given packet. Being constant means that the control plane cannot
+  set a different default action at runtime.
 
-        * TERNARY, for ternary match, using a mask
+* `const_default_action_has_mutable_params`, a boolean flag indicating whether
+  the parameters of the constant default action can be changed at runtime by the
+  control plane.
 
-        * RANGE, to represent min..max intervals
+* `implementation_id`, the `uint32` identifier of the "implementation" of this
+  table. 0 (default value) means that the table is a regular (direct) match
+  table. Otherwise, this field will carry the ID of an extern instance specified
+  in the same P4Info message (&eg; a PSA `ActionProfile` or `ActionSelector`
+  instance). The table is then referred to as an indirect match table.
 
-    * doc, a Documentation message describing this match field 
+* `direct_resource_ids`, repeated `uint32` identifiers for all the direct
+  resources attached to this table, such as `DirectMeter` and `DirectCounter`
+  instances, specified in the same P4Info message. In this version of the
+  P4Runtime specification only one direct resource of each type can be
+  associated to a table, hence for PSA programs this field is expected to have a
+  maximum size of 2.
 
-* action_refs, repeated ActionRef field representing the set of possible actions
-for this table. The ActionRef message is used to reference an action specified
-in the same P4Info message and it is defined by the following fields:
+* `size`, an `int64` describing the desired number of table entries that the
+  target should support for the table.  See the "Size" subsection within the
+  "Table Properties" section of the P4~16~ language specification for details
+  [[11]](https://p4.org/p4-spec/docs/P4-16-v1.1.0-draft.html#sec-table-props).
 
-    * id, an uint32 identifier of the action.
+* `idle_timeout_behavior`, which describes the behavior of the data plane when
+  the idle timeout of a table entry expires (see
+  [Idle-Timeout](#sec-idle-timeout) section). Value can be any of the
+  `IdleTimeoutBehavior` enum:
+    * `UNSPECIFIED`: reserved.
+    * `NO_TIMEOUT`, which means that idle timeout is not supported for this
+      table.
+    * `NOTIFY_CONTROL`, which means that the control plane should be notified of
+      the expiration of a table entry by means of a notification (see section on
+      [Table Idle Timeout Notifications](#sec-table-idle-timeout-notification)).
 
-    * annotations, a repeated string field, each one representing a P4
-    annotation associated to the action reference in this table.
+* `is_const_table`, a boolean flag indicating that the table is filled with
+  static entries and cannot be modified by the control plane at runtime.
 
-* const_default_action_id, if this table has a constant default action, this
-field will carry the uint32 identifier of such action, otherwise its value will
-be 0. A default action is executed when a matching table entry is not found for
-a given packet. Being constant means that the control plane cannot set a
-different default action at runtime.
+### `Action`
 
-* const_default_action_has_mutable_params, a boolean flag indicating if the
-parameters of the constant default action can be changed at runtime by the
-control plane. 
-
-* implementation_id, a uint32 identifier of the "implementation" of this table.
-0 (default value) means that the table is a regular (direct) match table.
-Otherwise, this field will carry the ID of an Action Profile or Action Selector
-PSA extern instance specified in the same P4Info message (the table is then
-referred to as an indirect match table).
-
-* direct_resource_ids, repeated uint32 identifiers of all direct resources
-attached to this table, such as DirectMeter (link to section) and DirectCounter
-(link to section), specified in the same P4Info message. In this version of the
-P4Runtime specification only one DirectMeter and only one DirectCounter can be
-associated to a table, hence this field is expected to have maximum size of 2.
-
-* size, an int64 describing the desired number of table entries that the target
-should support for the table.  See the "Size" subsection within the "Table
-Properties" section of the P4~16~ language specification for details
-[[11]](https://p4.org/p4-spec/docs/P4-16-v1.1.0-draft.html#sec-table-props).
-
-* idle_timeout_behavior, which describes the behavior of the data plane when the
-idle timeout of a table entry expires (see [Idle-Timeout](#sec-idle-timeout)
-section). Value can be any of the IdleTimeoutBehavior enum:
-
-    * UNSPECIFIED, reserved
-
-    * NO_TIMEOUT, means that idle timeout is not supported for this table
-
-    * NOTIFY_CONTROL, means that the control plane should be notified of the
-    expiration of a table entry by means of a notification (see section on
-    [Table Idle Timeout Notifications](#sec-table-idle-timeout-notification))
-
-* is_const_table, a boolean flag indicating that the table is filled with static
-entries that cannot be modified by the control plane at runtime
-
-### Action
-
-Action messages are used to specify all possible actions of all match-action
+`Action` messages are used to specify all possible actions of all match-action
 tables.
 
-The Action message defines the following fields:
+The `Action` message defines the following fields:
 
-* preamble, a Preamble message with ID, name, and alias of this action
+* `preamble`, a `Preamble` message with the ID, name, and alias of this action
 
-* params, a repeated field of Param messages representing the set of runtime
-parameters that should be provided by the control plane when inserting or
-modifying a table entry with this action. Each Param message contains the
-following fields:
+* `params`, a repeated field of `Param` messages representing the set of runtime
+  parameters that should be provided by the control plane when inserting or
+  modifying a table entry with this action. Each `Param` message contains the
+  following fields:
+    * `id`, the `uint32` identifier of this parameter. No rules are prescribed
+      on the way `Param` IDs should be allocated, as long as two `Param` of the
+      same action do not have the same ID.
+    * `name`, the string representing the name of this parameter.
+    * `annotations`, a repeated field of strings, each one representing a P4
+      annotation associated to this parameter.
+    * `bitwidth`, an `int32` value set to the size in bits of this parameter.
+    * `doc`, which describes this parameter using a `Documentation` message.
 
-    * id, a uint32 identifier of this parameter. No rules are prescribed on the
-    way Param IDs should be allocated, as long as two Param of the same action
-    do not have the same ID.
+### `ActionProfile`
 
-    * name, string representation of the name of this parameter
-
-    * annotations, repeated field of string, each one representing a P4
-    annotation associated to this parameter
-
-    * bitwidth, int32 representing the size in bit of this parameter
-
-    * doc, which describes this parameter using a Documentation message
-
-### ActionProfile
-
-ActionProfile messages are used to specify all available instances of Action
+`ActionProfile` messages are used to specify all available instances of Action
 Profile and Action Selector PSA externs.
 
 PSA Action Profiles are used to describe implementations of match-action tables
 where multiple table entries can share the same action instance. Indeed,
 differently from a regular match-action table where each entry contains the
 action specification, when using Action Profile-based tables, the control plane
-can insert entries each one with a reference to an Action Profile *member*,
-where each member then points to an action instance. The control plane is
-responsible for creating, modifying, or deleting members at runtime.
+can insert entries poiting to an Action Profile *member*, where each member then
+points to an action instance. The control plane is responsible for creating,
+modifying, or deleting members at runtime.
 
 PSA Action Selectors extend Action Profiles with the capability of bundling
 together multiple members into *groups*. Match-action table entries can point to
-a member or group reference. When processing a packet, if the table entry points
-to a group, a dynamic selection algorithm is used to select a member from the
-group and apply the corresponding action to the packet. The dynamic selection
+a member or group. When processing a packet, if the table entry points to a
+group, a dynamic selection algorithm is used to select a member from the group
+and apply the corresponding action to the packet. The dynamic selection
 algorithm is typically specified in the P4 program when instantiating the Action
 Selector, however it is not specified in the P4Info. The control plane is
 responsible for creating, modifying, or deleting both members and groups at
 runtime.
 
 While PSA defines Action Profile and Action Selector as two different externs,
-P4Info uses the same ActionProfile message to describe both.
+P4Info uses the same `ActionProfile` message to describe both.
 
-The ActionProfile message carries the following fields:
+The `ActionProfile` message includes the following fields:
 
-* preamble, a Preamble message with ID, name, and alias of this Action Profile
-or Selector
+* `preamble`, a `Preamble` message with the ID, name, and alias of this Action
+  Profile or Selector.
 
-* table_ids, a repeated field of uint32 identifiers used to reference tables
-which implementation uses this Action Profile or Selector.
+* `table_ids`, a repeated field of uint32 identifiers used to reference tables
+  whose implementation uses this Action Profile or Selector.
 
-* with_selector, a boolean flag indicating if this message describes an instance
-of a PSA Action Selector extern.
+* `with_selector`, a boolean flag indicating if this message describes an
+  instance of a PSA Action Selector extern.
 
-* size, an int64 representing the maximum number of members that this Action
-Profile or Selector can hold.
+* `size`, an `int64` representing the maximum number of *weighted* member
+  entries that this Action Profile or Selector can hold - across all selector
+  groups for an Action Selector.
 
-### Counter & DirectCounter
+* `max_group_size`, an `int32` representing the maximum number of *weighted*
+  member entries in any given Selector group, or 0 for an Action Profile.
 
-Counter and DirectCounter messages are used to specify all possible instances of
-Counter and Direct Counter PSA externs, respectively. Both externs are used to
-represent data plane counters that keep statistics such as the number of packets
-or bytes. The main difference between (indexed) counters and direct counters
-are:
+### `Counter` & `DirectCounter`
+
+`Counter` and `DirectCounter` messages are used to specify all possible
+instances of Counter and Direct Counter PSA externs, respectively. Both externs
+are used to represent data plane counters that keep statistics such as the
+number of packets or bytes. The main difference between (indexed) counters and
+direct counters is:
 
 * Indexed counters provide a fixed number of independent counter values, also
-called cells. Each cell can be read by the control plane using an integer index.
+  called cells. Each cell can be read by the control plane using an integer
+  index.
 
-* Direct counters are associated to match-action tables, providing as many cells
-as the number of entries in the table.
+* Direct counters are associated a given match-action table, providing as many
+  cells as the number of entries in the table.
 
-Both Counter and DirectCounter messages share the following fields:
+Both `Counter` and `DirectCounter` messages share the following fields:
 
-* preamble, a Preamble message with ID, name, and alias of this counter extern
-instance
+* `preamble`, a `Preamble` message with the ID, name, and alias of this counter
+  extern instance.
 
-* spec, a message of of type CounterSpec used to describe the capabilities of
-this counter. Currently, the CounterSpec message is used to carry only the
-counter unit, which can be any of the CounterSpec.Unit enum values:
+* `spec`, a message of of type `CounterSpec` used to describe the compile-time
+  configuration of this counter. Currently, the `CounterSpec` message is used to
+  carry only the counter unit, which can be any of the `CounterSpec.Unit` enum
+  values:
+    * `UNSPECIFIED`: reserved value.
+    * `BYTES`: byte counter.
+    * `PACKETS`: packet counter.
+    * `BOTH`: combination of both byte and packet counter.
 
-    * UNSPECIFIED, reserved value
+For indexed counters, the `Counter` message contains also a `size` field, an
+`int64` representing the maximum number of independent values that can be held
+by this counter array. Conversely, the `DirectCounter` message contains a
+`direct_table_id` field that carries the `unit32` identifier of the table to
+which this direct counter is attached.
 
-    * BYTES,byte counter
+### `Meter` & `DirectMeter`
 
-    * PACKETS, packet counter
-
-    * BOTH, combination of both byte and packet counter 
-
-For indexed counters, the Counter message contains also a size field, an int64
-representing the maximum number of independent values that can be held by this
-counter.
-
-Conversely, the DirectCounter message contains a direct_table_id field that
-carries the unit32 identifier of the table to which this direct counter is
-attached.
-
-### Meter & DirectMeter
-
-Meter and DirectMeter messages are used to specify all possible instances of
+`Meter` and `DirectMeter` messages are used to specify all possible instances of
 Meter and Direct Meter PSA externs. Both externs provide mechanism to keep data
 plane statistics typically used to mark or drop packets that exceed a given
 packet or bit rate. Similarly to counters, the main difference between (indexed)
-meters and direct meters are:
+meters and direct meters is:
 
 * Indexed meters provide a fixed number of independent meter values, also called
-cells. Each cell can be accessed by the control plane using an integer index,
-e.g. to set the rate threshold.
+  cells. Each cell can be accessed by the control plane using an integer index,
+  &eg; to set the rate threshold.
 
 * Direct meters are associated to match-action tables, providing as many cells
-as the number of entries in the table.
+  as the number of entries in the table.
 
-Both Meter and DirectMeter messages share the following fields:
+Both `Meter` and `DirectMeter` messages share the following fields:
 
-* preamble, a Preamble message with ID, name, and alias of this meter extern
-instance
+* `preamble`, a `Preamble` message with the ID, name, and alias of this meter
+  extern instance.
 
-* spec, a message of of type MeterSpec used to describe the capabilities of this
-meter extern instance. The MeterSpec message defines the following fields:
+* `spec`, a message of type `MeterSpec` used to describe the capabilities of
+  this meter extern instance. The `MeterSpec` message defines the following
+  fields:
 
-    * unit, the meter rate unit,whose value can be any of the MeterSpec.Unit enum:
+    * `unit`, the meter rate unit, whose value can be any of the
+      `MeterSpec.Unit` enum:
+        * `UNSPECIFIED`: reserved value.
+        * `BYTES`, which signifies that this meter can be configured with rates
+          expressed in bytes/second.
+        * `PACKETS`, for rates expressed in packets/second.
 
-        * UNSPECIFIED, reserved value
+    * `type`, the type of meter according to RFC 2698, color-blind or
+      color-aware.  The value can be any of the `MeterSpec.Type` enum:
+        * `COLOR_UNAWARE` for a color-blind meter.
+        * `COLOR_AWARE` for a color-aware meter.
 
-        * BYTES, signifies that this meter can be configured with rates
-        expressed in bytes/second
-
-        * PACKETS, for rates expressed in packet/second
-
-    * type, the type of meter according to RFC 2698, color-blind or color-aware.
-    Value can be any of the MeterSpec.Type enum:
-
-        * COLOR_UNAWARE, signifies a color-blind meter
-
-        * COLOR_AWARE, signifies a color-aware meter
-
-For indexed meters, the Meter message contains also a size field, an int64
+For indexed meters, the `Meter` message contains also a `size` field, an `int64`
 representing the maximum number of independent cells that can be held by this
-meter. Conversely, the DirectMeter message contains a direct_table_id field that
-carries the uint32 identifier of the table to which this Direct Meter PSA extern
-is attached.
+meter. Conversely, the `DirectMeter` message contains a `direct_table_id` field
+that carries the `uint32` identifier of the table to which this Direct Meter PSA
+extern is attached.
 
-### ControllerPacketMetadata
+### `ControllerPacketMetadata` { #sec-controller-packet-meta}
 
-ControllerPacketMetadata messages are used to describe any metadata associated
+`ControllerPacketMetadata` messages are used to describe any metadata associated
 with controller packet-in and packet-out. A packet-in is defined as a data plane
 packet that is sent by the P4Runtime server to the control plane for further
 inspection. Similarly, a packet-out is defined as a data packet generated by the
@@ -1186,36 +1139,34 @@ specify additional information used by the device to process the data packet.
 Such additional information for packet-in and packet-out can be expressed by
 means of P4 headers carrying P4 standard annotations
 `@controller_header("packet_in")` and `@controller_header("packet_out")`,
-respectively. ControllerPacketMetadata messages capture the information
+respectively. `ControllerPacketMetadata` messages capture the information
 contained within these special headers and are needed by the P4Runtime server to
 process packet-in and packet-out stream messages (see section on Packet I/O
 stream messages).
 
-A P4Info message can contain at most two ControllerPacketMetadata messages, one
-describing the packet-in header, and packet-out the other. Each message contains
-the following fields:
+A P4Info message can contain at most two `ControllerPacketMetadata messages`,
+one describing the packet-in header, and packet-out the other. Each message
+contains the following fields:
 
-* preamble, a Preamble message where preamble.name is set to "packet_in" and
-"packet_out" for packet-in and packet-out metadata, respectively.
+* `preamble`, a `Preamble` message where `preamble.name` is set to `"packet_in"`
+  and `"packet_out"` for packet-in and packet-out metadata, respectively.
 
-* metadata, a repeated field of type Metadata,where each Metadata message is
-defined by the following fields:
-
-    * id, a uint32 identifier of this metadata. No rules are prescribed on the
-    way metadata IDs should be allocated, as long as two Metadata of the same
-    ControllerPacketMetadata message do not have the same ID.
-
-    * name, a string representation of the name of this metadata. If the P4Info
-    message was generated from a P4 compiler, then this field is expected to be
-    set to the name of the P4 controller header field (see example below).
-
-    * annotations, a repeated string field, each one representing a P4
-    annotation associated to this metadata.
-
-    * bitwidth, an int32 representing the size in bit of this metadata.
+* `metadata`, a repeated field of type `Metadata`, where each `Metadata` message
+  includes the following fields:
+    * `id`, a `uint32` identifier of this metadata. No rules are prescribed on
+      the way metadata IDs should be allocated, as long as two `Metadata` of the
+      same `ControllerPacketMetadata` message do not have the same ID.
+    * `name`, a string representation of the name of this metadata. If the
+      P4Info message was generated from a P4 compiler, then this field is
+      expected to be set to the name of the P4 controller header field (see
+      example below).
+    * `annotations`, a repeated field of strings, each one representing a P4
+      annotation associated to this metadata.
+    * `bitwidth`, an `int32` representing the size in bit of this metadata.
 
 As an example, consider the following snippet of a P4 program where controller
-headers are specified and the corresponding ControllerPacketMetadata messages.
+headers are specified and we show the corresponding `ControllerPacketMetadata`
+messages.
 
 ~ Begin P4Example
 @controller_header("packet_out")
@@ -1271,74 +1222,87 @@ controller_packet_metadata {
 }
 ~End Prototext
 
-### ValueSet
+Note that the use of `@controller_header` is optional for Packet I/O. The P4
+program may define controller headers without this annotation and use them to
+encapsulate controller packets. However, in this case the client will be
+responsible for extracting the metadata from the serialized header in packet-in
+messages and for serializing the metadata when generating packet-out messages.
 
-ValueSet messages are used to specify all possible P4 Parser Value Sets. Parser
-Value Sets can be used by the control plane to specify at runtime matches used
-by the P4 parser to determine transitions from one state to another. For more
-information on Parser Value Sets, refer to the P4~16~ specification
+### `ValueSet`
+
+`ValueSet` messages are used to specify all possible P4 Parser Value
+Sets. Parser Value Sets can be used by the control plane to specify runtime
+matches used by the P4 parser to determine transitions from one state to
+another. For more information on Parser Value Sets, refer to the P4~16~
+specification
 [[12]](https://p4.org/p4-spec/docs/P4-16-v1.1.0-draft.html#sec-value-set).
 
-The ValueSet message defines the following fields:
+The `ValueSet` message defines the following fields:
 
-* preamble, a Preamble message with ID, name, and alias of this Value Set
+* `preamble`, a `Preamble` message with the ID, name, and alias of this Value
+  Set.
 
-* bitwidth, an int32 indicating the size in bit of the value to match
+* `bitwidth`, an `int32` set to the size in bits of the value matched in the
+  parser state.
 
-* size, an int32 representing the the maximum number of matches.
+* `size`, an int32 representing the maximum number of entries (values) in the
+  Value Set.
 
-### Register
+### `Register`
 
-Register messages are used to specify all possible instances of Register PSA externs.
+`Register` messages are used to specify all possible instances of Register PSA
+externs.
 
 Registers are stateful memories that can be read and written by data plane
 during packet forwarding. The control plane can also access registers at
 runtime.
 
-The Register message defines the following fields:
+The `Register` message defines the following fields:
 
-* preamble, a Preamble message with ID, name, and alias of this register instance.
+* `preamble`, a `Preamble` message with the ID, name, and alias of this register
+  instance.
 
-* type_spec, which specifies the data type hold by this register, expressed
-using a P4DataTypeSpec message (see section on [Representation of  Arbitrary P4
-Types](#sec-representation-of-arbitrary-p4-types)).
+* `type_spec`, which specifies the data type stored by this register, expressed
+  using a `P4DataTypeSpec` message (see section on [Representation of Arbitrary
+  P4 Types](#sec-representation-of-arbitrary-p4-types)).
 
-* size, an int32 value representing the total number of independent register
-cells available.
+* `size`, an `int32` value representing the total number of independent register
+  cells available.
 
-### Digest
+### `Digest`
 
-Digest messages are used to specify all possible instances of Packet Digest PSA
-externs.
+`Digest` messages are used to specify all possible instances of Packet Digest
+PSA externs.
 
 A packet digest is a mechanism to efficiently send notifications from the data
 plane to the control plane. This mechanism differs from packet-in which is
 generally used to send entire packets (headers plus payload), each one as a
-separate P4Runtime stream message. A digest for a packet has size typically much
-smaller than the packet itself, as it can be used to send only a subset of the
-headers or P4 metadata associated with the packet. To reduce the rate of
+separate P4Runtime stream message. A digest for a packet has a size typically
+much smaller than the packet itself, as it can be used to send only a subset of
+the headers or P4 metadata associated with the packet. To reduce the rate of
 messages sent to the control plane, a P4Runtime server can combine digests for
 multiple packets into larger messages.
 
-The Digest message defines the following fields:
+The `Digest` message defines the following fields:
 
-* preamble, a Preamble message with ID, name, and alias of this digest instance
+* `preamble`, a `Preamble` message with the ID, name, and alias of this digest
+  instance.
 
-* type_spec, which specifies the data type of a digest notification using a
-P4DataTypeSpec message (see section on [Representation of  Arbitrary P4
+* `type_spec`, which specifies the data type of an individual digest
+  notification using a `P4DataTypeSpec` message (see section on [Representation
+  of Arbitrary P4 Types](#sec-representation-of-arbitrary-p4-types)).
+
+## Support for Arbitrary P4 Types with P4TypeInfo
+
+See (see section on [Representation of Arbitrary P4
 Types](#sec-representation-of-arbitrary-p4-types)).
 
-## Support for arbitrary P4 types with P4TypeInfo
+# P4 Forwarding-Pipeline Configuration { #sec-p4-fwd-pipe-config}
 
-See (see section on [Representation of  Arbitrary P4
-Types](#sec-representation-of-arbitrary-p4-types)).
-
-# P4 Forwarding-Pipeline Configuration
-
-The *ForwardingPipelineConfig* captures data needed to realize a P4
+The `ForwardingPipelineConfig` captures data needed to realize a P4
 forwarding-pipeline and map various IDs passed in P4Runtime entity messages. It
 is formally called the "Device Configuration" and sometimes also referred to as
-the *P4 Blob*. It is defined as:
+the "P4 Blob". It is defined as:
 
 ~ Begin Proto
 message ForwardingPipelineConfig {
@@ -1347,18 +1311,19 @@ message ForwardingPipelineConfig {
 }
 ~ End Proto
 
-The p4info field captures the P4 program metadata as described by the P4Info.
-This message is the output of the P4-compiler and is target-agnostic.
+The `p4info` field captures the P4 program metadata as described by the P4Info.
+This message is the output of the P4 compiler and is target-agnostic.
 
-The p4_device_config is opaque binary data which contains the target-specific
+The `p4_device_config` is opaque binary data which contains the target-specific
 configuration to realize the P4 program. The P4 program running on a target is
-changed by loading a new *FowardingPipelineConfig* on that target.
+changed by loading a new `FowardingPipelineConfig` on that target.
 
-# General principles for message formatting
+# General Principles for Message Formatting
 
-## Set / Unset Protobuf field
+## Set / Unset Protobuf Field
 
-In Protobuf version 3 (proto3), the default value for a message field is "unset"
+In Protobuf version 3 (*proto3*), the default value for a message field is
+"unset"
 [[9]](https://developers.google.com/protocol-buffers/docs/proto3#default). An
 application, such as the P4Runtime client or server, is able to distinguish
 between an unset field and a field set to its default value. We use this
@@ -1441,37 +1406,37 @@ To ensure read-write symmetry, the rest of the doc tries to offer canonical
 representations for various data types, but this principle should be thought of
 where it falls short. Ensuring this will allow a client software to recover
 programmatically from failures that can affect the switch stack software,
-communication channel, or the client replicas. If Read RPC returns a
+communication channel, or the client replicas. If `Read` RPC returns a
 semantically-same but syntactically-different response then the client would
 have to canonicalize the read values to check its internal state, which only
 pushes the protocol's complexities to the client implementations.
 
-## Zero as reserved value
+## Zero as Reserved Value
 
 p4runtime.proto uses proto3 syntax, and so it does not allow not specifying a
-scalar data type, such as a uint32. Therefore, we usually reserve value 0 for
+scalar data type, such as a `uint32`. Therefore, we usually reserve value 0 for
 those fields to mean unset. In particular, 0 is not a valid P4 object ID and it
 is an error to specify 0 for any P4 object ID in a non-read request towards the
-switch, such as in a WriteRequest or a SetForwardingPipelineConfigRequest.
+switch, such as in a `WriteRequest` or a `SetForwardingPipelineConfigRequest`.
 
 ## Bytestrings { #sec-bytestrings}
 
 P4Runtime integer values may be too large to fit in Protobuf primitive data
 types (32-bit and 64-bit words). The P4 language does not put any limit on the
-size of integer values, whether unsigned (bit<W>) or signed (int<W>), and it is
-up to the P4 programmer to choose the appropriate sizes. Because of this
+size of integer values, whether unsigned (`bit<W>`) or signed (`int<W>`), and it
+is up to the P4 programmer to choose the appropriate sizes. Because of this
 flexibility, P4Runtime represents P4 integer values as binary strings, using the
 bytes Protobuf type. The correct bitwidth - as per the P4 program - of each
 integer variable exposed through P4Runtime is specified in the P4Info message
 and it is up to the server to ensure that the binary string provided by the
-client has the correct length. The server must return an INVALID_ARGUMENT error
-code otherwise. For each integer value, the expected length in bytes is obtained
-by rounding-up the bitwidth to the nearest byte: p4runtime_binary_string_length
-= (p4_bitwidth + 7) / 8.
+client has the correct length. The server must return an `INVALID_ARGUMENT`
+error code otherwise. For each integer value, the expected length in bytes is
+obtained by rounding-up the bitwidth to the nearest byte:
+`p4runtime_binary_string_length = (p4_bitwidth + 7) / 8`.
 
-For all binary strings, P4Runtime uses big-endian (i.e. network) byte-order. If
-the P4 integer type is not byte-aligned (p4runtime_binary_string_length !=
-p4_bitwidth * 8), P4Runtime expects the client to pad the value with unset bits
+For all binary strings, P4Runtime uses big-endian (&ie; network) byte-order. If
+the P4 integer type is not byte-aligned (`p4runtime_binary_string_length !=
+p4_bitwidth * 8`), P4Runtime expects the client to pad the value with unset bits
 before the most-significant bit of the value.
 
 For signed integer values (`int<W>` P4 type), P4Runtime uses the same two's
@@ -1496,21 +1461,21 @@ as valid binary strings for P4Runtime.
 |-----------|----------------|-------------------------|
 ~
 
-Representation of variable-length integer values (varbit<W> P4 type) is similar
-to the representation of fixed-width integers. We use a binary string, whose
-length is the *dynamic-length* of the expression. When the value is provided by
-the P4Runtime client, the server must verify that the length of the binary
-string is less than the maximum length specified in the P4 program, and return
-an INVALID_ARGUMENT error code otherwise.
+Representation of variable-length integer values (`varbit<W>` P4 type) is
+similar to the representation of fixed-width integers. We use a binary string,
+whose length is the *dynamic-length* of the expression. When the value is
+provided by the P4Runtime client, the server must verify that the length of the
+binary string is less than the maximum length specified in the P4 program, and
+return an `INVALID_ARGUMENT` error code otherwise.
 
-## Representation of arbitrary P4 types { #sec-representation-of-arbitrary-p4-types}
+## Representation of Arbitrary P4 Types { #sec-representation-of-arbitrary-p4-types}
 
-### Problem statement
+### Problem Statement
 
 The P4~16~ language includes more complex types than just binary strings
 [[8]](https://p4.org/p4-spec/docs/P4-16-v1.1.0-draft.html#sec-p4-type). Most of
-these complex data types can be exposed to the control-plane through table key
-expressions, value set lookup expressions, Register (PSA extern type) value
+these complex data types can be exposed to the control plane through table key
+expressions, Value Set lookup expressions, Register (PSA extern type) value
 types, etc... Not supporting these more complex types can be very
 limiting. Table [#tab-p4-type-usage] shows the different P4~16~ types and how
 they are allowed to be used, as per the P4~16~ specification.
@@ -1562,74 +1527,76 @@ header_union ip_t {
 Register<ip_t, bit<32> >(128) register_ip;
 ~ End P4Example
 
-One solution would be to use only binary string (bytes type) in p4runtime.proto
-and to define a custom serialization format for complex P4~16~ types. The
-serialization would maybe be trivial for header types but would require some
-work for header unions, header stacks, etc... For example, in the case of a PSA
-Register storing header unions, a client reading from that Register would need
-to receive information about which member header is valid, in addition to the
-binary contents of this header. Rather than coming-up with a serialization
-format from scratch, we decided to use a Protobuf representation for all P4~16~
-types.
+One solution would be to use only binary string (`bytes` type) in
+p4runtime.proto and to define a custom serialization format for complex P4~16~
+types. The serialization would maybe be trivial for header types but would
+require some work for header unions, header stacks, etc... For example, in the
+case of a PSA Register storing header unions, a client reading from that
+Register would need to receive information about which member header is valid,
+in addition to the binary contents of this header. Rather than coming-up with a
+serialization format from scratch, we decided to use a Protobuf representation
+for all P4~16~ types.
 
-### P4 type specifications in p4info.proto
+### P4 Type Specifications in p4info.proto
 
 In order for the P4Runtime client to generate correctly-formatted messages and
 for the P4Runtime service implementation to validate them, P4Info needs to
-specify the type of each P4 expression which is exposed to the control-plane. In
+specify the type of each P4 expression which is exposed to the control plane. In
 the Register example above, client and server need to know that each element of
-the register has type ip_t, which is a header union with 2 possible headers:
-ipv4 with type ipv4_t and ipv6 with type ipv6. Similarly, they need to know the
-field layout for both of these header types.
+the register has type `ip_t`, which is a header union with 2 possible headers:
+`ipv4` with type `ipv4_t` and `ipv6` with type `ipv6_t`. Similarly, they need to
+know the field layout for both of these header types.
 
-To achieve this we introduce 2 main protobuf messages: P4TypeInfo and
-P4DataTypeSpec.
+To achieve this we introduce 2 main Protobuf messages: `P4TypeInfo` and
+`P4DataTypeSpec`.
 
-P4TypeInfo is a top-level member of P4Info and includes Protobuf maps storing
+`P4TypeInfo` is a top-level member of P4Info and includes Protobuf maps storing
 the type specification for all the named types in the P4~16~ program. These
-named types are struct, header, header_union and enum; for each of these we have
-a type specification message, respectively P4StructTypeSpec, P4HeaderTypeSpec,
-P4HeaderUnionTypeSpec and P4EnumTypeSpec. We preserve P4 annotations for named
-types, which is useful to identify well-known headers, such as IPv4 or IPv6.
-P4TypeInfo also includes the list of parser errors for the program, as a
-P4ErrorTypeSpec message.
+named types are `struct`, `header`, `header_union`, `enum` and
+`serializable_enum`; for each of these we have a type specification message,
+respectively `P4StructTypeSpec`, `P4HeaderTypeSpec`, `P4HeaderUnionTypeSpec`,
+`P4EnumTypeSpec` and `P4SerializableEnumTypeSpec`. We preserve P4 annotations
+for named types, which is useful to identify well-known headers, such as IPv4 or
+IPv6.  `P4TypeInfo` also includes the list of parser errors for the program, as
+a `P4ErrorTypeSpec` message.
 
-P4DataTypeSpec is meant to be used in P4Info, everywhere where the P4Runtime
-client can provide a value for a P4~16~ expression. P4DataTypeSpec describes the
-compile-time of the expression as a Protobuf oneof, which can be:
+`P4DataTypeSpec` is meant to be used in P4Info, everywhere where the P4Runtime
+client can provide a value for a P4~16~ expression. `P4DataTypeSpec` describes
+the compile-time of the expression as a Protobuf `oneof`, which can be:
 
-* a string representing the name of the type in case of a named type (struct,
-header, header_union or enum),
+* a string representing the name of the type in case of a named type (`struct`,
+  `header`, `header_union`, `enum` or `serializable_enum`),
 
-* an empty Protobuf message for bool and error, or
+* an empty Protobuf message for `bool` and `error`, or
 
-* a Protobuf message for other anonymous types (bit<W>, int<W>, varbit<W>, tuple
-or stack). The "binary string" types (bit<W>, int<W>, and varbit<W>) are grouped
-together in the P4BitstringLikeTypeSpec message, since they are the only
-sub-types allowed in headers and values with one of these types are represented
-similarly in P4Runtime (with the Protobuf bytes type).
+* a Protobuf message for other anonymous types (`bit<W>`, `int<W>`, `varbit<W>`,
+  `tuple` or `stack`). The "binary string" types (`bit<W>`, `int<W>`, and
+  `varbit<W>`) are grouped together in the `P4BitstringLikeTypeSpec` message,
+  since they are the only sub-types allowed in headers and values with one of
+  these types are represented similarly in P4Runtime (with the Protobuf `bytes`
+  type).
 
-For all P4~16~ compound types (tuple, struct, header, and header_union), the
-order of members in the repeated field of the Protobuf type specification is
-guaranteed to be the same as the order of the members in the corresponding
-P4~16~ declaration. The same goes for the order of members of an enum or members
-of error, as well as for the order of entries in a stack.
+For all P4~16~ compound types (`tuple`, `struct`, `header`, and `header_union`),
+the order of `members` in the repeated field of the Protobuf type specification
+is guaranteed to be the same as the order of the members in the corresponding
+P4~16~ declaration. The same goes for the order of members of an `enum`
+(serializable or not) or members of `error`.
 
-### P4Data in p4runtime.proto
+### `P4Data` in p4runtime.proto
 
-P4Runtime uses the P4Data message to represent values with arbitrary types. The
-P4Runtime client must generate correct P4Data messages based on the type
-specification information included in P4Info. The P4Data message was designed to
-introduce little overhead compared to using binary strings in the most common
-case (P4~16~ bit<W> type).
+P4Runtime uses the `P4Data` message to represent values with arbitrary
+types. The P4Runtime client must generate correct `P4Data` messages based on the
+type specification information included in P4Info. The `P4Data` message was
+designed to introduce little overhead compared to using binary strings in the
+most common case (P4~16~ `bit<W>` type).
 
-Just like its P4Info counterpart - P4DataTypeSpec -, P4Data uses a Protobuf
-oneof to represent all possible values.
+Just like its P4Info counterpart - `P4DataTypeSpec` -, `P4Data` uses a Protobuf
+`oneof` to represent all possible values.
 
-The order of members in P4StructLike, the order of bitstrings in P4Header, and
-the order of entries in P4HeaderStack and P4HeaderUnionStack must match the
-order in the corresponding p4info.proto type specification and hence the order
-in the corresponding P4~16~ type declaration.
+The order of `members` in `P4StructLike`, the order of `bitstrings` in
+`P4Header`, and the order of `entries` in `P4HeaderStack` and
+`P4HeaderUnionStack` must match the order in the corresponding p4info.proto type
+specification and hence the order in the corresponding P4~16~ type declaration.
 
 ### Example
 
@@ -1653,8 +1620,7 @@ registers {
     alias: "register_ip"
   }
   type_spec {
-    header_~ Begin Proto
-union {
+    header_union {
       name: "ip_t"
     }
   }
@@ -1703,7 +1669,7 @@ type_info {
   }
 }
 ~ End Prototext
-Here's a p4.WriteRequest to set the value of register_ip[12]:
+Here's a `p4.WriteRequest` to set the value of `register_ip[12]`:
 
 ~ Begin Prototext
 update {
@@ -1729,32 +1695,40 @@ update {
 }
 ~ End Prototext
 
-### enum and error
+### `enum`, serializable `enum` and `error`
 
-We currently use the human-readable string type in P4Data to represent enum and
-error values. Indeed, the current P4~16~ specification does not specify any
-mechanism through which integer values are assigned to enum and error members -
-whether automatically by the compiler or by letting the programmer pick values.
-We may switch to an integer Protobuf type if the P4 language is updated to
-specify the underlying representation of enums, in which case we would also
-include a mapping from name to integer value in the P4TypeInfo message.
+P4~16~ supports 2 different classes of enumeration types: without underlying
+type (safe enum) and with underlying type (serializable enum or "unsafe" enum)
+[[14]](https://p4.org/p4-spec/docs/P4-16-v1.1.0-draft.html#sec-enum-types). For
+`enum` types with no underlying type - as well as `error` - there is no integer
+value associated with each symbolic member entry (whether assigned automatically
+by the compiler or directly in the P4 source). We therefore use a human-readable
+string in `P4Data` to represent `enum` and `error` values.
 
-### Trade-off for v1.0 release
+Serializable `enum` types have an underlying fixed-width unsigned integer
+representation (`bit<W>`). Integer values must be assigned to each member entry
+by the P4 programmer. `P4TypeInfo` includes the mapping between entry name and
+entry value. When providing serializable enum values through `P4Data`, one can
+either use the enum entry's name (`enum` human-readable string field) or its
+assigned value (`enum_value` bytestring field).
+
+### Trade-off for v1.0 Release
 
 For the v1.0 release of P4Runtime, it was decided not to replace occurrences of
-bytes with P4Data in the p4.FieldMatch message, which is used to represent table
-and value set entries. This is to avoid breaking pre-release implementations of
-P4Runtime. Similarly it has been decided to keep using bytes to provide action
-parameter values. However P4Data is used whenever appropriate for PSA externs
-and we encourage the use of P4Data in architecture-specific extensions.
+`bytes` with `P4Data` in the `p4.FieldMatch` message, which is used to represent
+table and Value Set entries. This is to avoid breaking pre-release
+implementations of P4Runtime. Similarly it has been decided to keep using
+`bytes` to provide action parameter values. However `P4Data` is used whenever
+appropriate for PSA externs and we encourage the use of `P4Data` in
+architecture-specific extensions.
 
-# P4 Entity Messages 
+# P4 Entity Messages { #sec-p4-entity-msgs}
 
 P4Runtime covers P4 entities that are either part of the P4~16~ language, or
 defined as PSA externs. The sections below describe the messages for each
 supported entity.
 
-## TableEntry
+## `TableEntry`
 
 The match-action table is the core packet-processing construct of the P4
 language. It consists of a collection of table entries, or flow rules, each
@@ -1765,96 +1739,96 @@ otherwise, a default action is applied. The exact behavior of P4 tables is
 described in the P4 specification.
 
 P4Runtime supports inserting, modifying, deleting and reading table entries with
-the TableEntry entity, which has the following fields:
+the `TableEntry` entity, which has the following fields:
 
-* table_id, which identifies the table instance; the table_id is determined by
-the P4Info message.
+* `table_id`, which identifies the table instance; the `table_id` is determined
+  by the P4Info message.
 
-* match, a repeated field of FieldMatch messages. Each element in the repeated
-field is used to provide a value for the corresponding element in the key
-property of the P4 table declaration.
+* `match`, a repeated field of `FieldMatch` messages. Each element in the
+  repeated field is used to provide a value for the corresponding element in the
+  key property of the P4 table declaration.
 
-* action, which indicates which of the table's actions to execute in case of
-match and with which argument values. 
+* `action`, which indicates which of the table's actions to execute in case of
+  match and with which argument values.
 
-* priority, a 32-bit integer used to order entries when the table's match key
-includes a ternary match.
+* `priority`, a 32-bit integer used to order entries when the table's match key
+  includes a ternary match.
 
-* controller_metadata, a 64-bit cookie value which is opaque to the target.
-There is no requirement of where this is stored, but it must be returned by the
-server along with the rest of the entry when the client performs a read on the
-entry.
+* `controller_metadata`, a 64-bit cookie value which is opaque to the
+  target. There is no requirement of where this is stored, but it must be
+  returned by the server along with the rest of the entry when the client
+  performs a read on the entry.
 
-* meter_config, which is used to read and write the configuration for the direct
-meter entry attached to this table entry, if any. See [Direct
-resources](#sec-direct-resources) section for more information.
+* `meter_config`, which is used to read and write the configuration for the
+  direct meter entry attached to this table entry, if any. See [Direct
+  resources](#sec-direct-resources) section for more information.
 
-* counter_data, which is used to read and write the value for the direct counter
-entry attached to this table entry, if any. See [Direct
-resources](#sec-direct-resources) section for more information.
+* `counter_data`, which is used to read and write the value for the direct
+  counter entry attached to this table entry, if any. See [Direct
+  resources](#sec-direct-resources) section for more information.
 
-* is_default_action, a boolean flag which indicates whether the table entry is
-the default entry for the table. See [Default entry](#sec-default-entry)
-section for more information.
+* `is_default_action`, a boolean flag which indicates whether the table entry is
+  the default entry for the table. See [Default entry](#sec-default-entry)
+  section for more information.
 
-* idle_timeout_ns and time_since_last_hit, which are two fields used to
-implement idle-timeout support for the table, if applicable. See
-[Idle-timeout](#sec-idle-timeout) section for more information.
+* `idle_timeout_ns` and `time_since_last_hit`, which are two fields used to
+  implement idle-timeout support for the table, if applicable. See
+  [Idle-timeout](#sec-idle-timeout) section for more information.
 
-The priority field must be set to a non-zero value if the match key includes a
-ternary match, i.e. if the P4Info entry for the table indicates that one or more
-of its match fields has a TERNARY or RANGE match type, or to zero otherwise. A
-higher priority number indicates that the entry must be given higher priority
-when performing a table lookup. Clients must allow multiple entries to be added
-with the same priority value.  If a packet can match multiple entries with the
-same priority, it is not deterministic in the data plane which entry a packet
-will match.  If a client wishes to make the matching behavior deterministic, it
-must use different priority values for any pair of table entries that the same
-packet matches.
+The `priority` field must be set to a non-zero value if the match key includes a
+ternary match (&ie; in the case of PSA if the P4Info entry for the table
+indicates that one or more of its match fields has a `TERNARY` or `RANGE` match
+type) or to zero otherwise. A higher priority number indicates that the entry
+must be given higher priority when performing a table lookup. Clients must allow
+multiple entries to be added with the same priority value.  If a packet can
+match multiple entries with the same priority, it is not deterministic in the
+data plane which entry a packet will match.  If a client wishes to make the
+matching behavior deterministic, it must use different priority values for any
+pair of table entries that the same packet matches.
 
-The match and priority fields are used to uniquely identify an entry within a
-table. Therefore, these fields cannot be modified after the entry has been
-inserted and must be provided for MODIFY and DELETE updates. When deleting an
-entry, these key fields (along with is_default_entry) are the only fields
+The `match` and `priority` fields are used to uniquely identify an entry within
+a table. Therefore, these fields cannot be modified after the entry has been
+inserted and must be provided for `MODIFY` and `DELETE` updates. When deleting
+an entry, these key fields (along with `is_default_entry`) are the only fields
 considered by the server. All other fields must be ignored, even if they have
 nonsensical values (such as an invalid action field).
 
-### Match format
+### Match Format
 
-The bytes fields in the FieldMatch message follows the format described in [
-Bytestrings](#sec-bytestrings).
+The bytes fields in the `FieldMatch` message follows the format described in
+[Bytestrings](#sec-bytestrings).
 
 For "don't care" matches, the P4Runtime client must omit the match value when
-building the match repeated field of the TableEntry message. This requirement
+building the match repeated field of the `TableEntry` message. This requirement
 leads to smaller Protobuf messages overall, while enabling a canonical
 representation for "don't care" matches, which is needed to ensure [read-write
-symmetry](#sec-read-write-symmetry). A "don't care" match for a specific match
-key field is defined as follows:
+symmetry](#sec-read-write-symmetry). For PSA match types, a "don't care" match
+for a specific match key field is defined as follows:
 
-* For a ternary match, it is logically equivalent to a mask of zeros.
+* For a `TERNARY` match, it is logically equivalent to a mask of zeros.
 
-* For a lpm match, it is logically equivalent to a prefix_len of zero.
+* For a `LPM` match, it is logically equivalent to a prefix_len of zero.
 
-* For a range match, it is logically equivalent to a range which includes all
-possible values for the field.
+* For a `RANGE` match, it is logically equivalent to a range which includes all
+  possible values for the field.
 
-Note that there is no "don't care" value for exact matches and therefore exact
-match fields can never be omitted from the TableEntry message.
+Note that there is no "don't care" value for `EXACT` matches and therefore exact
+match fields can never be omitted from the `TableEntry` message.
 
-For every member of the TableEntry repeated match field, field_id must be a
-valid id for the table as per the P4Info and one of the field in
-field_match_type must be set. We summarize additional constraints which depend
+For every member of the `TableEntry` repeated `match` field, `field_id` must be
+a valid id for the table as per the P4Info and one of the field in
+`field_match_type` must be set. We summarize additional constraints which depend
 on the match-type in the following list. If any one of them is violated, the
-P4Runtime server must return an INVALID_ARGUMENT error code.
+P4Runtime server must return an `INVALID_ARGUMENT` error code.
 
-* Exact match
+* `EXACT` match
     * Bytestring length of the value must match the width of the P4 field.
 
 ~ Begin Pseudo
 assert(match.exact().value().size() == field_bytes)
 ~ End Pseudo
 
-* Lpm match
+* `LPM` match
     * Bytestring length of the value (when present) must match the width of the
       P4 field.
     * "Don't care" match must be omitted.
@@ -1870,7 +1844,7 @@ trailing_zeros = countTrailingZeros(match.lpm().value())
 assert(trailing_zeros >= field_bits - pLen)
 ~ End Pseudo
 
-* Ternary match
+* `TERNARY` match
     * Bytestring length of the value (when present) and mask (when present) must
       match the width of the P4 field.
     * "Don't care" match must be omitted.
@@ -1888,7 +1862,7 @@ assert(mask != 0)
 assert(value & mask == value)
 ~ End Pseudo
 
-* Range match
+* `RANGE` match
     * Bytestring length of the low bound (when present) and high bound (when
       present) must match the width of the P4 field.
     * Low bound must be less than or equal to the high bound
@@ -1906,74 +1880,77 @@ assert(low <= high)
 assert(low != min_field_value && high != max_field_value)
 ~ End Pseudo
 
-### Action specification
+### Action Specification
 
-The TableEntry action field must be set for every INSERT and MODIFY update.
-Based on the implementation property value of the P4 table, the oneof in the
-TableAction message will either be:
+The `TableEntry` action field must be set for every `INSERT` and `MODIFY`
+update.  Based on the implementation property value of the P4 table, the `oneof`
+in the `TableAction` message will either be:
 
-* an Action specification for direct tables (with no implementation property)
+* an `Action` specification for direct tables (with no P4 `implementation`
+  property)
 
-* an action profile member id for indirect tables for which the implementation
-property is an action profile with no selector.
+* an action profile member id for indirect tables for which the `implementation`
+  property is an action profile with no selector.
 
-* An action profile member id or group id for indirect tables for which the
-implementation property is an action profile with selector.
+* an action profile member id or group id for indirect tables for which the
+  `implementation` property is an action profile with selector.
 
-The Action Protobuf message, which is used for direct tables only, has the
+The `Action` Protobuf message, which is used for direct tables only, has the
 following fields:
 
-* action_id, which identifies the action instance; the action_id is determined
-by the P4Info message and must match one of the possible action choices for the
-table.
+* `action_id`, which identifies the action instance; the `action_id` is
+  determined by the P4Info message and must match one of the possible action
+  choices for the table.
 
-* params: a repeated Protobuf field of action parameter values, each encoded as
-a Param message. For each parameter, param_id must be valid for the action (as
-per the P4Info)  and value must follow the format described in [
-Bytestrings](#sec-bytestrings). The P4Runtime client must provide a valid
-value for each parameter of the P4 action; we do not support default values for
-action parameters.
+* `params`: a repeated Protobuf field of action parameter values, each encoded
+  as a `Param` message. For each parameter, `param_id` must be valid for the
+  action (as per the P4Info) and value must follow the format described in
+  [Bytestrings](#sec-bytestrings). The P4Runtime client must provide a valid
+  value for each parameter of the P4 action; we do not support default values
+  for action parameters.
 
 For indirect tables, if the P4Runtime client provides a member or group id which
 has not been inserted in the corresponding action profile instance yet, the
-P4Runtime server must return a NOT_FOUND error code.
+P4Runtime server must return a `NOT_FOUND` error code.
 
 ### Default Entry { #sec-default-entry}
 
 According to the P4 specification, the default entry for a table is always set.
-It can be set at compile-time by the P4 programmer - or defaults to NoAction
-(which is a no-op) otherwise - and assuming it is not declared as const, can be
-modified by the P4Runtime client. Because the default entry is always set, we do
-not allow INSERT and DELETE updates on the default entry and the P4Runtime
-server must return an INVALID_ARGUMENT error code if the client attempts one.
+It can be set at compile-time by the P4 programmer - or defaults to `NoAction`
+(which is a no-op) otherwise - and assuming it is not declared as `const`, can
+be modified by the P4Runtime client. Because the default entry is always set, we
+do not allow `INSERT` and `DELETE` updates on the default entry and the
+P4Runtime server must return an `INVALID_ARGUMENT` error code if the client
+attempts one.
 
-The default entry is identified by setting the is_default_action boolean field
-to true. When this flag is set to true, the repeated match field must be empty
-and the priority field must be set to zero, otherwise the P4Runtime server must
-return an INVALID_ARGUMENT error code. When performing a MODIFY update on the
-default entry, the client can either provide a valid action for the table or
-leave the action field unset, in which case the default entry will be reset to
-its original value, as defined in the P4 program. If the default entry is
+The default entry is identified by setting the `is_default_action` boolean field
+to true. When this flag is set to true, the repeated `match` field must be empty
+and the `priority` field must be set to zero, otherwise the P4Runtime server
+must return an `INVALID_ARGUMENT` error code. When performing a `MODIFY` update
+on the default entry, the client can either provide a valid action for the table
+or leave the action field unset, in which case the default entry will be reset
+to its original value, as defined in the P4 program. If the default entry is
 constant (as indicated by the P4 program and the P4Info message), the server
-must return an PERMISSION_DENIED error code if the client attempts to modify it.
+must return an `PERMISSION_DENIED` error code if the client attempts to modify
+it.
 
 Apart from the above restrictions, the default entry is treated like a regular
 entry, including with regards to [direct resources](#sec-direct-resources).
 
 In this P4Runtime release, we have decided to restrict the default entry for
-indirect tables - tables with an ActionProfile or ActionSelector implementation
-property - to a constant NoAction action entry, with the hope that it would
-simplify the implementation of the P4Runtime service.
+indirect tables - tables with an ActionProfile or ActionSelector
+`implementation` property - to a constant NoAction action entry, with the hope
+that it would simplify the implementation of the P4Runtime service.
 
-### Wildcard reads
+### Wildcard Reads
 
-When performing a ReadRequest, the P4Runtime client can select all entries from
-one or all tables on the target and use several of the TableEntry fields to
-filter the results, much like when performing a SQL request. For each field that
-can be used to filter the result, the client may use the default value for the
-field to act as a wildcard. This default value is zero for scalar fields such as
-priority and "unset" for message fields such as match. The following fields may
-be used to select and filter results:
+When performing a `ReadRequest`, the P4Runtime client can select all entries
+from one or all tables on the target and use several of the `TableEntry` fields
+to filter the results, much like when performing a SQL request. For each field
+that can be used to filter the result, the client may use the default value for
+the field to act as a wildcard. This default value is zero for scalar fields
+such as `priority` and "unset" for message fields such as `match`. The following
+fields may be used to select and filter results:
 
 * `table_id`: If default (0), entries from all tables will be selected and no
   other filter can be used. Otherwise only the specified table will be
@@ -2000,7 +1977,7 @@ be used to select and filter results:
   considered.
 
 For example, in order to read all entries from all tables from device 3, the
-client can use the following ReadRequest message.
+client can use the following `ReadRequest` message.
 
 ~ Begin Prototext
 device_id: 3
@@ -2027,44 +2004,44 @@ entities {
 }
 ~ End Prototext
 
-### Direct resources { #sec-direct-resources}
+### Direct Resources { #sec-direct-resources}
 
-In addition to the DirectCounterEntry and DirectMeterEntry entities, P4Runtime
-support reading and writing direct resources as part of the TableEntry message.
-This is convenient for two reasons:
+In addition to the `DirectCounterEntry` and `DirectMeterEntry` entities,
+P4Runtime support reading and writing direct resources as part of the
+`TableEntry` message.  This is convenient for two reasons:
 
 * A table entry and its direct resources can be read with a single entity when
-doing a Read RPC call
+  doing a `Read` RPC call
 
 * The initial configuration for an entry's direct resources can be specified
-when the entry is inserted. This may enable the target to add the table entry
-and configure the direct resources in an atomic fashion if supported. When the
-table has a direct meter, this may help guarantee that the lifetime of the meter
-entry is the same as the lifetime of the table entry, and that there is no time
-gap during which dataplane traffic can "hit" the table entry without executing
-the appropriate meter entry.
+  when the entry is inserted. This may enable the target to add the table entry
+  and configure the direct resources in an atomic fashion if supported. When the
+  table has a direct meter, this may help guarantee that the lifetime of the
+  meter entry is the same as the lifetime of the table entry, and that there is
+  no time gap during which dataplane traffic can "hit" the table entry without
+  executing the appropriate meter entry.
 
 Once the table entry has been inserted, the P4Runtime client is free to use the
-DirectCounterEntry and DirectMeterEntry messages for read and write operations
-on DirectCounter and DirectMeter instances. For example, it is usually more
-convenient as well as more efficient to use DirectCounterEntry to query a
-counter entry value rather than use TableEntry, assuming the client is not
-interested in reading other table entry properties as well, such as the
+`DirectCounterEntry` and `DirectMeterEntry` messages for read and write
+operations on `DirectCounter` and `DirectMeter` instances. For example, it is
+usually more convenient as well as more efficient to use `DirectCounterEntry` to
+query a counter entry value rather than use `TableEntry`, assuming the client is
+not interested in reading other table entry properties as well, such as the
 controller metadata cookie or the action entry.
 
 The PSA specification states that when a table is assigned a direct resource
-(meter or counter), this direct resource does not need to be "executed" in every
-action bound to the table. It is an error to provide a direct resource
-configuration in a TableEntry message when programming an action that does not
-execute the direct resource, and the server must return an INVALID_ARGUMENT
+(meter or counter), this direct resource does *not* need to be "executed" in
+every action bound to the table. It is an error to provide a direct resource
+configuration in a `TableEntry` message when programming an action that does not
+execute the direct resource, and the server must return an `INVALID_ARGUMENT`
 error code.
 
 We leverage Protobuf's ability to differentiate between set and unset fields to
 give the P4Runtime client fined-grained control over how direct resources are
-read and written through the TableEntry message. The list below describes how
-the server must handle the meter_config and counter_data fields for read and
+read and written through the `TableEntry` message. The list below describes how
+the server must handle the `meter_config` and `counter_data` fields for read and
 write requests, based on whether the fields are set or not. We do not cover
-error cases in the list, i.e. we assume that we are dealing with a table which
+error cases in the list, &ie; we assume that we are dealing with a table which
 is assigned a direct counter / a direct meter, and that the action being used
 for the table entry "executes" the direct resource appropriately.
 
@@ -2105,67 +2082,68 @@ for the table entry "executes" the direct resource appropriately.
 
 In its default configuration, a meter returns the GREEN color for every packet
 when it is executed. This default configuration can be achieved by leaving the
-meter_config field unset when inserting **or modifying** a table entry. When
+`meter_config` field unset when inserting **or modifying** a table entry. When
 modifying a table entry, if the P4Runtime client wishes to maintain the same
-meter configuration, it needs to be provided again in the TableEntry message
-(i.e. the meter_config field must be set to match the existing configuration).
+meter configuration, it needs to be provided again in the `TableEntry` message
+(&ie; the `meter_config` field must be set to match the existing configuration).
 
 ### Idle-timeout { #sec-idle-timeout }
 
 P4Runtime supports idle timeout for table entries. When adding a table entry,
 the client can specify a Time-To-Live (TTL) value. If at any time during its
-lifetime, the data-plane entry is not "hit" (i.e. not selected by any packet
+lifetime, the data plane entry is not "hit" (&ie; not selected by any packet
 lookup) for a lapse of time greater or equal to its TTL, the P4Runtime must
-generate a stream notification - using the IdleTimeoutNotification message - to
-the master client, which can then take action, such as remove the idle table
+generate a stream notification - using the `IdleTimeoutNotification` message -
+to the master client, which can then take action, such as remove the idle table
 entry.
 
-Two fields of the TableEntry protobuf message are used to implement idle
+Two fields of the `TableEntry` Protobuf message are used to implement idle
 timeout.
 
-* idle_timeout_ns: the configured TTL for the table entry in nanoseconds. A
-value of 0 means that the entry never expires, i.e. no IdleTimeoutNotification
-message will ever be generated for this entry. When a client reads a TableEntry,
-this field will be included in the response and the value must match exactly the
-one set by the client when inserting or modifying the entry.
+* `idle_timeout_ns`: the configured TTL for the table entry in nanoseconds. A
+  value of 0 means that the entry never expires, &ie; no
+  `IdleTimeoutNotification` message will ever be generated for this entry. When
+  a client reads a `TableEntry`, this field will be included in the response and
+  the value must match exactly the one set by the client when inserting or
+  modifying the entry.
 
-* time_since_last_hit: a Protobuf message with a single field (elapsed_ns) used
-to indicate the time in nanoseconds elapsed since the last time the data-plane
-entry was hit. The time_since_last_hit field must be unset for a TableEntry
-write. When reading a table entry, time_since_last_hit must be set in the
-response if and only if it was set (to an empty message) in the request. If the
-field is set in the request, it must be set to the correct value in the response
-even if the TTL value for the entry is 0.
+* `time_since_last_hit`: a Protobuf message with a single field (`elapsed_ns`)
+  used to indicate the time in nanoseconds elapsed since the last time the
+  data plane entry was hit. The `time_since_last_hit` field must be unset for a
+  `TableEntry` write. When reading a table entry, `time_since_last_hit` must be
+  set in the response if and only if it was set (to an empty message) in the
+  request. If the field is set in the request, it must be set to the correct
+  value in the response even if the TTL value for the entry is 0.
 
 These fields can only be set if idle timeout is supported for the table, as per
 the P4Info message. If idle timeout is not supported by the table, the P4Runtime
-server must return an INVALID_ARGUMENT error code if at least one of these
+server must return an `INVALID_ARGUMENT` error code if at least one of these
 conditions is met:
 
-* idle_timeout_ns is set to a non-zero value, or
+* `idle_timeout_ns` is set to a non-zero value, or
+* `time_since_last_hit` is set
 
-* time_since_last_hit is set
-
-The target should do its best to approximate the idle_timeout_ns value provided
-by the client. For example, most targets may not be able to accomodate
+The target should do its best to approximate the `idle_timeout_ns` value
+provided by the client. For example, most targets may not be able to accomodate
 arbitrarily small values of TTL, in which case they should use the smallest
 value they can support, rather than reject the TableEntry write with an error
 code. Similarly, each target should do its best to provide reasonably-accurate
-values for time_since_last_hit.
+values for `time_since_last_hit`.
 
 For more information about idle timeout, in particular regarding
-IdleTimeoutNotification, please refer to the [Table idle timeout
+`IdleTimeoutNotification`, please refer to the [Table idle timeout
 notifications](#sec-table-idle-timeout-notification) section.
 
-## ActionProfileMember and ActionProfileGroup
+## `ActionProfileMember` & `ActionProfileGroup`
 
 P4Runtime defines an API for programming a PSA ActionProfile extern using
-ActionProfileMember messages. PSA ActionSelector extern can be programmed using
-both ActionProfileMember and ActionProfileGroup messages. PSA supports tables
-that can be implemented with an action profile or selector instance. Such tables
-are referred to as indirect tables, in contrast to direct tables, whose entries
-are directly bound to an action instance. The following P4 snippet illustrates
-an indirect table t for layer 3 routing, implemented with an action selector as.
+`ActionProfileMember` messages. PSA ActionSelector extern can be programmed
+using both `ActionProfileMember` and `ActionProfileGroup` messages. PSA supports
+tables that can be implemented with an action profile or selector instance. Such
+tables are referred to as indirect tables, in contrast to direct tables, whose
+entries are directly bound to an action instance. The following P4 snippet
+illustrates an indirect table `t` for L3 routing, implemented with an action
+selector `as`.
 
 ~ Begin P4Example
 ActionSelector(HashAlgorithm.crc32,
@@ -2189,48 +2167,49 @@ table t {
 }
 ~ End P4Example
 
-When programming table t in the example above, a P4Runtime client should specify
-the TableAction in the TableEntry to be a reference to either an action profile
-member or group. The reference is a uint32 identifier that uniquely identifies a
-member or group programmed in the action selector as.
+When programming table `t` in the example above, a P4Runtime client should
+specify the `TableAction` in the `TableEntry` to be a reference to either an
+action profile member or group. The reference is a `uint32` identifier that
+uniquely identifies a member or group programmed in the action selector `as`.
 
 If a table entry in an indirect table with ActionProfile implementation is hit,
 then the corresponding table action gives a member id. The member table is
 looked up with the member id, and the corresponding action specification is used
-to modify the packet or it's metadata.
+to modify the packet or its metadata.
 
 If a table entry in an indirect table with ActionSelector implementation is hit,
 then the corresponding table action gives either a member id or a group id. For
 a member id, the member table in the selector is looked up, and the
-corresponding action specification is used to modify the packet or it's
+corresponding action specification is used to modify the packet or its
 metadata. For a group id, a hash algorithm, defined in the P4 ActionSelector
 specification is used to obtain a member id from the set of members in the
 group. For example, the hash algorithm in the P4 example above is 32-bit CRC.
 The obtained member id is used to look up the member table in the selector and
-obtain the action specification, which is then used to modify the packet or it's
-metadata. 
+obtain the action specification, which is then used to modify the packet or its
+metadata.
 
 ### Action Profile Member Programming
 
 Action profile members are entries in the ActionProfile or ActionSelector and
-are referenced by a uint32 identifier that is bound to an action specification.
-An action profile member for an ActionProfile or ActionSelector extern instance
-may be bound only to the actions that appear in the actions attribute of the
-table implemented using the extern instance. If multiple table implementations
-share an extern instance, then the actions attributes of the tables must have an
-identical list of P4 actions. The IDs of the tables implemented with a selector
-will appear in P4Info as part of the ActionProfile message for the selector.
+are referenced by a `uint32` identifier that is bound to an action
+specification.  An action profile member for an ActionProfile or ActionSelector
+extern instance may be bound only to the actions that appear in the actions
+attribute of the table implemented using the extern instance. If multiple table
+implementations share an extern instance, then the actions attributes of the
+tables *must have an identical list of P4 actions*. The IDs of the tables
+implemented with a selector will appear in P4Info as part of the ActionProfile
+message for the selector.
 
-An ActionProfileMember entity update message has the following fields:
+An `ActionProfileMember` entity update message has the following fields:
 
-* action_profile_id is a uint32 identifier of the PSA ActionProfile or
-ActionSelector extern instance, as defined in P4Info.
+* `action_profile_id` is the `uint32` identifier of the PSA ActionProfile or
+  ActionSelector extern instance, as defined in P4Info.
 
-* member_id is a uint32 identifier of the action profile member entry being
-updated. 
+* `member_id` is the `uint32` identifier of the action profile member entry being
+  updated.
 
-* action is the specification of the P4 action instance bound to the action
-profile member entry.
+* `action` is the specification of the P4 action instance bound to the action
+  profile member entry.
 
 An action profle member may be inserted, modified or deleted as per the
 following semantics.
@@ -2254,33 +2233,34 @@ following semantics.
 ### Action Profile Group Programming
 
 Action profile groups are entries in an ActionSelector and are referenced by a
-uint32 identifier that is bound to a set of action profile members already
+`uint32` identifier that is bound to a set of action profile members already
 programmed in the selector. The action profile members in a group must be bound
 to actions of the same type.
 
-An ActionProfileGroup entity update message has the following fields:
+An `ActionProfileGroup` entity update message has the following fields:
 
-* `action_profile_id` is a uint32 identifier of the PSA ActionSelector extern
-instance, as defined in P4Info.
+* `action_profile_id` is the `uint32` identifier of the PSA ActionSelector
+  extern instance, as defined in P4Info.
 
-* `group_id` is a uint32 identifier of the action profile group entry being
-updated. 
+* `group_id` is the `uint32` identifier of the action profile group entry being
+  updated.
 
 * `members` is a repeated field defining the set of members that are part of the
-group. For each member in a group, the controller must define the following
-fields
-
+  group. For each member in a group, the controller must define the following
+  fields:
     * `member_id` for looking up the member table in the selector.
-
     * `weight` specifying the probability of the member's selection at runtime.
-
     * `watch` is the controller defined 32-bit port number that the member's
-    liveness depends on. At runtime, the member must be excluded from selection
-    if the this watch port is down.
+      liveness depends on. At runtime, the member must be excluded from
+      selection if the this watch port is down.
 
 * `max_size` is the maximum sum of all member weights for the group. This field
-is defined when the group is inserted, but it must not be changed in a `MODIFY`
-update.
+  is defined when the group is inserted, but it must not be changed in a
+  `MODIFY` update. It must not exceed the static `max_group_size` included in
+  P4Info. If the `max size` is not known at group creation-time, the client may
+  leave this field unset (default value 0), in which case the static
+  `max_group_size` value will be used and the group will be able to include up
+  to `max_group_size` weighted member entries.
 
 An action profile group may be inserted, modified or deleted as per the
 following semantics.
@@ -2301,18 +2281,16 @@ following semantics.
 - `DELETE`: Delete the group entry and deallocate the `group_id`. The group
   should not be referenced in the table action of any table entry.
 
-## CounterEntry and DirectCounterEntry
+## `CounterEntry` & `DirectCounterEntry`
 
 PSA defines Counters as a mechanism for keeping statistics of bytes and packets.
 Statistics may be updated as a result of an action associated with a table
-entry, or a direct invocation such as from a P4 control. The CounterData
-P4Runtime message can be used for all three types of PSA counters - PACKETS,
-BYTES and PACKETS_AND_BYTES - and consists of the following fields
+entry, or a direct invocation such as from a P4 control. The `CounterData`
+P4Runtime message can be used for all three types of PSA counters - `PACKETS`,
+`BYTES` and `PACKETS_AND_BYTES` - and consists of the following fields:
 
-* byte_count is a int64, corresponding to the number of octets.
-
-* packet_count is a int64, corresponding to the number of protocol-specific
-packets.
+* `byte_count` is an `int64`, corresponding to the number of octets.
+* `packet_count` is an `int64`, corresponding to the number of packets.
 
 ~ Begin Proto
 message CounterData {
@@ -2322,18 +2300,18 @@ message CounterData {
 ~ End Proto
 
 P4Runtime does not distinguish between the different PSA counter types, and
-allows for simultaneous updates of byte_count and packet_count fields, which is
-equivalent to specifying the counter type PACKETS_AND_BYTES. Counters may be
-defined as Direct or Indirect (indexed) instances.
+allows for simultaneous updates of `byte_count` and `packet_count` fields, which
+is equivalent to specifying the counter type `PACKETS_AND_BYTES`. Counters may
+be defined as direct or indirect (indexed) instances.
 
-### DirectCounterEntry
+### `DirectCounterEntry`
 
-A direct counter is a direct resource associated with a TableEntry
-see [Direct Resources](#sec-direct-resources)). The counter_data field of the
-TableEntry message can be used to initialize the counter value at the same time
-as the table entry is inserted. Once the table entry has been created, the
+A direct counter is a direct resource associated with a `TableEntry` (see
+[Direct Resources](#sec-direct-resources)). The `counter_data` field of the
+`TableEntry` message can be used to initialize the counter value at the same
+time as the table entry is inserted. Once the table entry has been created, the
 P4Runtime client may modify the associated direct counter entry using the
-DirectCounterEntry message. Once the table entry is deleted the associated
+`DirectCounterEntry` message. Once the table entry is deleted the associated
 direct counter entry can no longer be accessed.
 
 ~ Begin Proto
@@ -2343,44 +2321,46 @@ message DirectCounterEntry {
 }
 ~ End Proto
 
-A WriteRequest may only include an Update message of type MODIFY with a
-DirectCounterEntry, whose fields are to be specified by the client as follows:
+A `WriteRequest` may only include an `Update` message of type `MODIFY` with a
+`DirectCounterEntry`, whose fields are to be specified by the client as follows:
 
-* the table_entry.match field must match TableEntry.match of the table entry to
-which this direct counter entry is associated. If a matching TableEntry is not
-found, the server returns the error code NOT_FOUND.
+* the `table_entry.match` field must match `TableEntry.match` of the table entry
+  to which this direct counter entry is associated. If a matching `TableEntry`
+  is not found, the server returns the error code `NOT_FOUND`.
 
-* data is used to set the counter value to the value specified by the client.
-Note that if this protobuf field is not set, the counter value is not modified.
+* `data` is used to set the counter value to the value specified by the
+  client. Note that if this Protobuf field is not set, the counter value is not
+  modified.
 
-Specifying DirectCounterEntry in an Update message of type INSERT or DELETE is
-not allowed, and the server must return the error code INVALID_ARGUMENT in that
-case.
+Specifying `DirectCounterEntry` in an `Update` message of type `INSERT` or
+`DELETE` is not allowed, and the server must return the error code
+`INVALID_ARGUMENT` in that case.
 
-A client may use ReadRequest in two ways to read the contents of a
-DirectCounter.
+A client may use `ReadRequest` in two ways to read the contents of a
+`DirectCounter`:
 
 * As a direct resource associated with a table entry, request the server to
-return the counter value in the counter_data field of the TableEntry message
+return the counter value in the counter_data field of the `TableEntry` message
 (see [Direct resources](#sec-direct-resources)).
 
-* Explicitly request the counter value by including the DirectCounterEntry in
-the ReadRequest. The table_entry.match field must match the TableEntry whose
-counter is being read. If no such entry is found, the server returns the error
-code NOT_FOUND.
+* Explicitly request the counter value by including the `DirectCounterEntry` in
+the `ReadRequest`. The `table_entry.match` field must match the `TableEntry`
+whose counter is being read. If no such entry is found, the server returns the
+error code `NOT_FOUND`.
 
-### CounterEntry
+### `CounterEntry`
 
-An indirect or indexed counter is not associated with a specific TableEntry and
-may be updated independently of any action. It may be read or written using the
-P4Runtime CounterEntry message whose fields are defined as follows:
+An indirect or indexed counter is not associated with a specific `TableEntry`
+and may be updated independently of any action. It may be read or written using
+the P4Runtime `CounterEntry` message whose fields are defined as follows:
 
-* counter_id is a uint32, a unique identifier for the counter.
+* `counter_id` is a `uint32`, the unique identifier for the counter.
 
-* index is a protobuf that encapsulates a int64, used to index into the counter
-array.
+* `index` is a Protobuf message that encapsulates an `int64`, used to index into
+  the counter array.
 
-* data is a message of type CounterData, which represents the counter value.
+* `data` is a Protobuf message of type `CounterData`, which represents the
+  counter value.
 
 ~ Begin Proto
 message CounterEntry {
@@ -2390,71 +2370,61 @@ message CounterEntry {
 }
 ~ End Proto
 
-The CounterEntry can only be used in a WriteRequest with the MODIFY update type.
-The P4Runtime server must return an INVALID_ARGUMENT error code for update types
-INSERT and DELETE. By default all the counter entries in the array have default
-value 0.
+The `CounterEntry` can only be used in a `WriteRequest` with the `MODIFY` update
+type. The P4Runtime server must return an `INVALID_ARGUMENT` error code for
+update types `INSERT` and `DELETE`. By default all the counter entries in the
+array have default value 0.
 
 * `INSERT`: Server returns the error code `INVALID_ARGUMENT`.
 * `MODIFY`: Modify an indirect counter instance whose unique id is `counter_id`
-  and array index is specified by index. The counter value is set to the value
-  specified by the client in the data field. Note that the counter value is not
-  modified if this protobuf field is not set. If index is omitted all counter
-  values in the array will be set to the value provided by the client.
+  and array index is specified by `index`. The counter value is set to the value
+  specified by the client in the `data` field. Note that the counter value is
+  not modified if this Protobuf field is not set. If `index` is omitted all
+  counter values in the array will be set to the value provided by the client.
 * `DELETE`: Server returns the error code `INVALID_ARGUMENT`.
 
 A P4Runtime client may request to read the counter values of one or more
-indirect counter instances with a ReadRequest by including a CounterEntry entity
-for each of the instances, specifying the counter_id and index. Wildcard reads
-are also supported as follows.
+indirect counter instances with a `ReadRequest` by including a `CounterEntry`
+entity for each of the instances, specifying the `counter_id` and
+`index`. Wildcard reads are also supported as follows.
 
-* If the counter_id field is set to 0 (default), the server returns the counter
-values for all Indirect counter instances in the ReadResponse.
+* If the `counter_id` field is set to 0 (default), the server returns the
+  counter values for all indirect counter instances in the `ReadResponse`.
 
-* If the index field is not set, the server returns the counter values for all
-Indirect counters in the array identified by the unique id counter_id.
+* If the `index` field is not set, the server returns the counter values for all
+  indirect counters in the array identified by the unique id `counter_id`.
 
-## MeterEntry and DirectMeterEntry
+## `MeterEntry` & `DirectMeterEntry`
 
 Meters are an advanced mechanism for keeping statistics, involving stateful
 "marking" and usually "throttling" of packets based on configured rates of
-traffic. The PSA metering function is based on the Two Rate Three Color Marker
-(trTCM) defined in RFC 2698. The trTCM meters an IP packet stream using two
-configured rates - the Peak Information Rate (PIR) and Committed Information
+traffic. The PSA metering function is based on the *Two Rate Three Color Marker*
+(trTCM) defined in RFC 2698. The trTCM meters an arbitrary packet stream using
+two configured rates - the Peak Information Rate (PIR) and Committed Information
 Rate (CIR), and their associated burst sizes - and "marks" its packets as GREEN,
-YELLOW or RED based on the observed rate. 
+YELLOW or RED based on the observed rate.
 
-A meter may be configured as a Direct or Indirect instance, similar to a
-counter. The MeterConfig P4Runtime message represents meter configuration.
+A meter may be configured as a direct or indirect instance, similar to a
+counter. The `MeterConfig` P4Runtime message represents meter configuration.
 
 ~ Begin Proto
 message MeterConfig {
-  int64 cir = 1;
-  int64 cburst = 2;
-  int64 pir = 3;
-  int64 pburst = 4;
+  int64 cir = 1;  // Committed Information Rate
+  int64 cburst = 2;  // Committed Burst Size
+  int64 pir = 3;  // Peak Information Rate
+  int64 pburst = 4;  // Peak Burst Size
 }
 ~ End Proto
 
-The protobuf fields are defined as follows:
+### `DirectMeterEntry`
 
-* cir, a int64, representing the Committed Information Rate (CIR)
-
-* cburst, a int64, representing the committed burst size (CBS).
-
-* pir, a int64, representing the Peak Information Rate (PIR)
-
-* pburst, a int64, representing the peak burst size (PBS).
-
-### DirectMeterEntry
-
-A direct meter is a direct resource associated with a TableEntry
-(see [Direct resources](#sec-direct-resources)). The meter_config field of the
-TableEntry message can be used to initialize the meter configuration at the same
-time as the table entry is inserted. Once the table entry has been created, the
+A direct meter is a direct resource associated with a `TableEntry` (see [Direct
+resources](#sec-direct-resources)). The `meter_config` field of the `TableEntry`
+message can be used to initialize the meter configuration at the same time as
+the table entry is inserted. Once the table entry has been created, the
 P4Runtime client may modify the associated direct meter entry using the
-DirectMeterEntry message. Once the table entry is deleted the associated direct
-meter entry can no longer be accessed.
+`DirectMeterEntry` message. Once the table entry is deleted the associated
+direct meter entry can no longer be accessed.
 
 ~ Begin Proto
 message DirectMeterEntry {
@@ -2463,47 +2433,47 @@ message DirectMeterEntry {
 }
 ~ End Proto
 
-A WriteRequest may only include an Update message of type MODIFY with a
-DirectMeterEntry, whose fields are to be specified by the client as follows:
+A `WriteRequest` may only include an `Update` message of type `MODIFY` with a
+`DirectMeterEntry`, whose fields are to be specified by the client as follows:
 
-* the table_entry.match field must match the match key of the TableEntry message
-used to insert the entry and the associated direct meter entry. The action field
-is ignored in this case. If a matching TableEntry is not found, the server
-returns the error code NOT_FOUND.
+* the `table_entry.match` field must match the match key of the `TableEntry`
+  message used to insert the entry and the associated direct meter entry. The
+  action field is ignored in this case. If a matching `TableEntry` is not found,
+  the server returns the error code `NOT_FOUND`.
 
-* config is used to set the configuration for the meter entry to the value
-specified by the client. Note that if this protobuf field is not set, the meter
-config is set to execute the default behavior (GREEN for all packets).
+* `config` is used to set the configuration for the meter entry to the value
+  specified by the client. Note that if this Protobuf field is not set, the
+  meter config is set to execute the default behavior (GREEN for all packets).
 
-Specifying DirectMeterEntry in an Update message of type INSERT or DELETE is not
-allowed, and the server must return the error code INVALID_ARGUMENT in that
-case.
+Specifying `DirectMeterEntry` in an `Update` message of type `INSERT` or
+`DELETE` is not allowed, and the server must return the error code
+`INVALID_ARGUMENT` in that case.
 
-A client may use ReadRequest in two ways to read a DirectMeter config.
+A client may use `ReadRequest` in two ways to read a `DirectMeter` config.
 
 * As a direct resource associated with a table entry, request the server to
-return the meter config in the meter_config field of the TableEntry message (see
-[Direct resources](#sec-direct-resources)).
+  return the meter config in the `meter_config` field of the `TableEntry`
+  message (see [Direct resources](#sec-direct-resources)).
 
-* Explicitly request the meter configuration by including the DirectMeterEntry
-in the ReadRequest. The table_entry.match field must match the TableEntry whose
-meter config is being read. If no such entry is found, the server returns the
-error code NOT_FOUND.
+* Explicitly request the meter configuration by including the `DirectMeterEntry`
+  in the `ReadRequest`. The `table_entry.match` field must match the
+  `TableEntry` whose meter config is being read. If no such entry is found, the
+  server returns the error code `NOT_FOUND`.
 
-### MeterEntry
+### `MeterEntry`
 
-An indirect or indexed meter is not associated with a specific TableEntry and
+An indirect or indexed meter is not associated with a specific `TableEntry` and
 may be executed independently of any action. Its configuration may be read or
-written using the P4Runtime MeterEntry message whose fields are defined as
-follows
+written using the P4Runtime `MeterEntry` message whose fields are defined as
+follows:
 
-* meter_id is a uint32, a unique identifier for the meter.
+* `meter_id` is a `uint32`, the unique identifier for the meter.
 
-* index is a protobuf that encapsulates a int64, used to index into a meter
-array.
+* `index` is a Protobuf message that encapsulates an `int64`, used to index into
+  a meter array.
 
-* config is a message of type MeterConfig, which represents the meter
-configuration.
+* `config` is a Protobuf message of type `MeterConfig`, which represents the
+  meter configuration.
 
 ~ Begin Proto
 message MeterEntry {
@@ -2513,33 +2483,33 @@ message MeterEntry {
 }
 ~ End Proto
 
-The MeterEntry can only be used in a WriteRequest with the MODIFY update type.
-The P4Runtime server must return an INVALID_ARGUMENT error code for update types
-INSERT and DELETE. By default all the meter entries in the array have a default
-configuration (GREEN for all packets).
+The `MeterEntry` can only be used in a `WriteRequest` with the `MODIFY` update
+type.  The P4Runtime server must return an `INVALID_ARGUMENT` error code for
+update types `INSERT` and `DELETE`. By default all the meter entries in the
+array have a default configuration (GREEN for all packets).
 
-* `INSERT`: `INVALID_ARGUMENT` error
+* `INSERT`: Server returns the error code `INVALID_ARGUMENT`.
 * `MODIFY`: Modify an indirect meter instance whose unique id is `meter_id` and
-  array index is specified by index. The meter is reconfigured using the config
-  field specified by the client. Note that the meter configuration is set to the
-  default behavior (GREEN for all packets) if this protobuf field is not set. If
-  the index field is omitted all meter configurations in the array will be set
-  to the value provided by the client (or reset to the default value if config
-  is unset).
-* `DELETE`: `INVALID_ARGUMENT` error
+  array index is specified by `index`. The meter is reconfigured using the
+  `config` field specified by the client. Note that the meter configuration is
+  set to the default behavior (GREEN for all packets) if this Protobuf field is
+  not set. If the `index` field is omitted all meter configurations in the array
+  will be set to the value provided by the client (or reset to the default value
+  if `config` is unset).
+* `DELETE`: Server returns the error code `INVALID_ARGUMENT`.
 
 A P4Runtime client may request to read the configuration of one or more indirect
-meter instances with a ReadRequest by including a MeterEntry entity for each of
-the instances, specifying the meter_id and index. Wildcard reads are also
-supported as follows.
+meter instances with a `ReadRequest` by including a `MeterEntry` entity for each
+of the instances, specifying the `meter_id` and `index`. Wildcard reads are also
+supported as follows:
 
-* If the meter_id field is set to 0 (default), the server returns the
-configuration for all Indirect meter instances in the ReadResponse.
+* If the `meter_id` field is set to 0 (default), the server returns the
+  configuration for all indirect meter instances in the `ReadResponse`.
 
-* If the index field is not set, the server returns the configuration for all
-Indirect meters in the array identified by the unique id meter_id.
+* If the `index` field is not set, the server returns the configuration for all
+  indirect meters in the array identified by the unique id `meter_id`.
 
-## PacketReplicationEngineEntry
+## `PacketReplicationEngineEntry`
 
 The PSA Packet Replication Engine (PRE) is an extern that is implicitly
 instantiated in all PSA programs. The PRE is responsible for implementing
@@ -2547,12 +2517,12 @@ multicasting and cloning functionality in the dataplane. P4Runtime defines an
 API to program the PRE with multicast groups and clone sessions to allow
 replication of dataplane packets.
 
-### MulticastGroupEntry
+### `MulticastGroupEntry`
 
 Multicasting is achieved in PSA programs by setting the multicast_group ingress
 output metadata to a non-zero identifier. The number of replicas and their
 egress ports for the multicast group is programmed at runtime by the client
-using the MulticastGroupEntry API in P4Runtime. The following P4 program
+using the `MulticastGroupEntry` API in P4Runtime. The following P4 program
 illustrates a possible dataplane behavior of multicasting ARP packets in the
 ingress. Note that the dataplane type of the multicast group metadata is 10 bits
 on the PSA device in this example.
@@ -2569,7 +2539,7 @@ control arp_multicast(inout H hdr, inout M smeta) {
 ~ End P4Example
 
 At runtime, the client writes the following update in the target (shown in
-protobuf text format).
+Protobuf text format).
 
 ~ Begin Prototext
 type: INSERT
@@ -2593,11 +2563,11 @@ corresponding to SDN port numbers 5, 12, 18 and 24. For more discussion on the
 translation between SDN ports and PSA device ports, refer to the
 [PSA Metadata Translation](#sec-translation-of-port-numbers) section.
 
-The egress packets may be distinguished
-for further processing in the egress using the replica_id metadata. Note that a
-packet may not be both unicast and multicast; if the multicast group is set, it
-will override the unicast egress port. If the multicast_group metadata is set to
-a value that is not programmed in the PRE, then the packet is dropped.
+The egress packets may be distinguished for further processing in the egress
+using the `replica_id` metadata. Note that a packet may not be both unicast and
+multicast; if the multicast group is set, it will override the unicast egress
+port. If the multicast_group metadata is set to a value that is not programmed
+in the PRE, then the packet is dropped.
 
 A multicast group may be inserted, modified or deleted as per the following
 semantics.
@@ -2618,21 +2588,21 @@ semantics.
   operation. Any packets with their `multicast_group` metadata in the dataplane
   set to the deleted `multicast_group_id` will be dropped.
 
-### CloneSessionEntry
+### `CloneSessionEntry`
 
 PSA supports cloning of packets in both the ingress and egress pipeline. Ingress
 cloning creates a mirror of the packet as seen in the beginning of the ingress
 pipeline, while egress cloning creates a mirror of the packet as seen at the end
 of the egress pipeline. A packet is cloned in the dataplane by setting a
-clone_session_id identifier and a boolean flag clone in the packet metadata. The
-clone_session_id serves as a handle to the clone attributes, namely the egress
-port, replica id, packet length and class of service, that are programmed at
-runtime via P4Runtime CloneSessionEntry API.
+`clone_session_id` identifier and a boolean flag clone in the packet
+metadata. The `clone_session_id` serves as a handle to the clone attributes,
+namely the egress port, replica id, packet length and class of service, that are
+programmed at runtime via the P4Runtime `CloneSessionEntry` API.
 
 The following P4 program illustrates a possible dataplane behavior of sending
 clones of low TTL packets to the CPU for monitoring. Note that the dataplane
 type of the clone session metadata is 10 bits on the PSA device in this example.
-We assume that the clone_low_ttl control block is applied in the ingress
+We assume that the `clone_low_ttl` control block is applied in the ingress
 pipeline to create and ingress-to-egress clone.
 
 ~ Begin P4Example
@@ -2649,7 +2619,7 @@ control clone_low_ttl(inout H hdr, inout M smeta) {
 
 
 At runtime, the client writes the following update in the target (shown in
-protobuf text format).
+Protobuf text format).
 
 ~ Begin Prototext
 type: INSERT
@@ -2673,21 +2643,20 @@ of service value of 2. If the packet is larger than 4096 bytes, it will be
 truncated to carry at most 4096 bytes.
 
 The cloned replica will appear in the egress pipeline as independent packet with
-egress port set to CPU (corresponding to SDN or `0xFFFFFFFD`;
-see [Translation of Port Numbers](#sec-translation-of-port-numbers)).
-Note that the egress port must be a
-32-bit SDN port number and must refer to a singleton port.
+egress port set to CPU (corresponding to SDN port `0xFFFFFFFD`; see [Translation
+of Port Numbers](#sec-translation-of-port-numbers)). Note that the egress port
+must be a 32-bit SDN port number and must refer to a singleton port.
 
-Furthermore, even though the protobuf representation for clone session entry
-allows multiple clones to be specified (by the repeated replicas message), the
-current version of PSA allows creating only 1 clone of a packet in the ingress
-and egress. Therefore, a target may reject a clone session entry update that
-carries more than one replica. Cloning does not impact the original packet. If
-the clone_session_id metadata is set to a value that is not programmed in the
-PRE, then the clone is simply not created.
+Furthermore, even though the Protobuf representation for clone session entry
+allows multiple clones to be specified (by the repeated `replicas` message
+field), the current version of PSA allows creating only 1 clone of a packet in
+the ingress and egress. Therefore, a target may reject a clone session entry
+update that carries more than one replica. Cloning does not impact the original
+packet. If the `clone_session_id` metadata is set to a value that is not
+programmed in the PRE, then the clone is simply not created.
 
 A clone session may be inserted, modified or deleted as per the following
-semantics.
+semantics:
 
 * `INSERT`: Add a new clone session entry bound to an egress port. The
   `clone_session_id` is `uint32` type, must be unique across all clone session
@@ -2703,20 +2672,22 @@ semantics.
   packet should be truncated to the given value (in bytes). If the
   `packet_length_bytes` field is 0 (default), no truncation on the clone will be
   performed.
+
 * `MODIFY`: Modify the attributes of a given clone session entry, indexed by the
   given `clone_session_id`. Same restrictions as `INSERT` apply here.
+
 * `DELETE`: Delete the clone session indexed by the given
   `clone_session_id`. Other fields need not be provided for this operation. Any
   packet with their `clone_session_id` metadata in the dataplane set to the
   deleted `clone_session_id` will no longer be cloned.
 
-## ValueSetEntry
+## `ValueSetEntry`
 
-Parser value set is a construct in P4 that is used to support programmability of
-parser state transitions. A transition select statement in P4 can use parser
-value set to define a runtime programmable state transition as shown in the
+Parser Value Set is a construct in P4 that is used to support programmability of
+parser state transitions. A transition select statement in P4 can use a parser
+Value Set to define a runtime programmable state transition as shown in the
 example below. A runtime programmable set of TRILL ethtypes is used to
-transition the parser state machine to the parse_trill_types state.
+transition the parser state machine to the `parse_trill_types` state.
 
 ~ Begin P4Example
 state parse_l2 {
@@ -2732,7 +2703,7 @@ state parse_l2 {
 ~ End P4Example
 
 At runtime, the client writes the following update in the target (shown in
-protobuf text format).
+Protobuf text format).
 
 ~ Begin Proto
 type: INSERT
@@ -2745,20 +2716,20 @@ entity {
 }
 ~ End Proto
 
-As a result of the above P4Runtime programming, all packets with ethtype values
-of 0x22F3 and 0x893B will be parsed as per the state machine starting at the
-parse_trill_types state.
+As a result of the above P4Runtime programming, all packets with EtherType
+values of 0x22F3 and 0x893B will be parsed as per the state machine starting at
+the `parse_trill_types` state.
 
-A ValueSetEntry entity update message has the following fields:
+A `ValueSetEntry` entity update message has the following fields:
 
-* value_set_id is a uint32 identifier of the value_set instance, as defined in
-P4Info.
+* `value_set_id` is the `uint32` identifier of the value_set instance, as
+  defined in P4Info.
 
-* match is  a repeated field of type FieldMatch defining the set of matches
-(exact, LPM or ternary) that programmed in the value set
+* `match` is a repeated field of type `FieldMatch` defining the set of matches
+  that must be programmed in the Value Set.
 
-A parser value set may be inserted, modified or deleted as per the following
-semantics.
+A `ValueSetEntry` may be inserted, modified or deleted as per the following
+semantics:
 
 * `INSERT`: Write the given matches in the repeated field to the value set entry
   indexed by the given `value_set_id`. The maximum number of matches should not
@@ -2769,116 +2740,116 @@ semantics.
   `value_set_id`. Other fields need not be provided for this operation. Any
   parser transitions depending on the value set will no longer be taken.
 
-## RegisterEntry
+## `RegisterEntry`
 
 The PSA Register extern is a stateful memory array that can be read and written
-during packet forwarding. The RegisterEntry P4Runtime entity is used by the
+during packet forwarding. The `RegisterEntry` P4Runtime entity is used by the
 client to read and write the contents of a Register instance as part of
-control-plane operations.
+control plane operations.
 
-RegisterEntry has the following fields:
+`RegisterEntry` has the following fields:
 
-* register_id, which identifies the PSA Register extern instance which is being
-accessed by the client; the register_id is determined by the P4Info message.
+* `register_id`, which identifies the PSA Register extern instance which is
+  being accessed by the client; the `register_id` is specified by the P4Info
+  message.
 
-* index, which identifies the array offset which is being accessed. It is
-possible for the P4Runtime client to perform wildcard reads and writes on the
-register array by leaving the index field unset in the RegisterEntry message
-used for the request.
+* `index`, which identifies the array offset which is being accessed. It is
+  possible for the P4Runtime client to perform wildcard reads and writes on the
+  register array by leaving the index field unset in the `RegisterEntry` message
+  used for the request.
 
-* data: the data to be written to the array (if RegisterEntry is part of a
-WriteRequest message) or the data read from the array (if RegisterEntry is part
-of a ReadResponse message). The data field is a P4Data message and must match
-the format described by the type_spec field of the corresponding Register entry
-in the P4Info.
+* `data`: the data to be written to the array (if `RegisterEntry` is part of a
+  `WriteRequest` message) or the data read from the array (if `RegisterEntry` is
+  part of a `ReadResponse` message). The `data` field is a `P4Data` message and
+  must match the format described by the `type_spec` field of the corresponding
+  Register entry in the P4Info.
 
-## DigestEntry { #sec-digestentry }
+## `DigestEntry` { #sec-digestentry }
 
-A digest is one mechanism to send a message from the data-plane to the
-control-plane. It is traditionally used for MAC address learning: when a packet
-with an unknown source MAC address is received by the device, the control-plane
+A digest is one mechanism to send a message from the data plane to the
+control plane. It is traditionally used for MAC address learning: when a packet
+with an unknown source MAC address is received by the device, the control plane
 is notified and can populate the L2 forwarding tables accordingly.
 
-The DigestEntry P4Runtime entity is used to **configure** how the device must
-generate digest messages. The DigestEntry protobuf message is not used to carry
-digest data, which is done on the StreamChannel bidirectional stream using the
-DigestList (digest data sent by the target to the client) and DigestListAck
-(digest data acknowledgments sent by the client to the target) protobuf
-messages.
+The `DigestEntry` P4Runtime entity is used to **configure** how the device must
+generate digest messages. The `DigestEntry` Protobuf message is not used to
+carry digest data, which is done on the `StreamChannel` bidirectional stream
+using the `DigestList` (digest data sent by the target to the client) and
+`DigestListAck` (digest data acknowledgments sent by the client to the target)
+Protobuf messages.
 
-In this section, we refer to the data learned by a single data-plane call to
-Digest<T>::pack as a "digest message" and we use "digest list" to designate the
-list of digest messages bundled by the P4Runtime service in a single DigestList
-stream message. Note that all the digest messages in a single digest list
-correspond to the same P4 Digest extern instance. We say that 2 digest messages
-are "duplicate" if the data emitted by the data-plane is exactly the same as per
-P4 equality rules. We say that 2 digest messages are "distinct" if they are not
-duplicate.
+In this section, we refer to the data learned by a single data plane call to
+`Digest<T>::pack` as a "digest message" and we use "digest list" to designate
+the list of digest messages bundled by the P4Runtime service in a single
+`DigestList` stream message. Note that all the digest messages in a single
+digest list correspond to the same P4 Digest extern instance. We say that 2
+digest messages are "duplicate" if the data emitted by the data plane is exactly
+the same as per P4 equality rules. We say that 2 digest messages are "distinct"
+if they are not duplicate.
 
-DigestEntry has the following fields:
+`DigestEntry` has the following fields:
 
-* digest_id, which identifies the PSA Digest extern instance which emitted the
-data; the digest_id is determined by the P4Info message.
+* `digest_id`, which identifies the PSA Digest extern instance which emitted the
+  data; the `digest_id` is determined by the P4Info message.
 
-* config, a Protobuf message which includes different parameters to tune how
-digest messages are exchanged between server and client for a given digest_id;
-these parameters are:
+* `config`, a Protobuf message which includes different parameters to tune how
+  digest messages are exchanged between server and client for a given
+  `digest_id`; these parameters are:
 
-    * max_timeout_ns: the maximum server buffering delay in nanoseconds for an
-    outstanding digest message
+    * `max_timeout_ns`: the maximum server buffering delay in nanoseconds for an
+      outstanding digest message.
+    * `max_list_size`: the maximum digest list size - in number of digest
+      messages - sent by the server to the client as a single `DigestList`
+      Protobuf message.
+    * `ack_timeout_ns`: the timeout in nanoseconds that a server must wait for a
+      digest list acknowledgement from the client before new digest messages can
+      be generated for the same learned data.
 
-    * max_list_size: the maximum digest list size - in number of digest messages
-    - sent by the server to the client as a single DigestList Protobuf message
+Here is the significance of the different `Update` types for `DigestEntry`:
 
-    * ack_timeout_ns: the timeout in nanoseconds that a server must wait for a
-    digest list acknowledgement from the client before new digest messages can
-    be generated for the same learned data
-
-Here is the significance of the different Update types for DigestEntry:
-
-* `INSERT`: Enable server generation of DigestList messages for given digest
+* `INSERT`: Enable server generation of `DigestList` messages for given digest
   instance and use provided configuration parameters.
 * `MODIFY`: Use provided configuration parameters for given digest instance,
   learning must have been previously enabled for the instance.
-* `DELETE`: Disable server generation of DigestList messages for given digest
+* `DELETE`: Disable server generation of `DigestList` messages for given digest
   instance.
 
 A server should buffer digest messages until either:
 
-* max_timeout_ns time has passed since the first digest message was added to the
-empty buffer, or
+* `max_timeout_ns` time has passed since the first digest message was added to
+  the empty buffer, or
+* `max_list_size` *distinct* digest messages have been received from the
+  dataplane and added to the buffer
 
-* max_list_size **distinct** digest messages have been received from the
-dataplane and added to the buffer
-
-At which point the server must generate a DigestList stream message with the
+At which point the server must generate a `DigestList` stream message with the
 buffer contents and send it to the master client. All the messages in a digest
 list must be distinct, which means that duplicates must either be filtered-out
 directly by the device or in the P4Runtime server software.
 
-To avoid sending duplicate digest messages across different DigestList messages,
-which could make the channel busy, we define an acknowledgement mechanism
-through which the master client indicates that it has received the digest list
-and acted on it. The server must keep a "cache" containing the set of all digest
-messages that have been sent, but not acknowledged yet by the master client,
-up-to ack_timeout_ns in the past. The server must delete all cache entries for a
-given digest list when they are at least ack_timeout_ns old or when a matching
-DigestListAck message (i.e. with the same digest_id and list_id fields as the
-DigestList message) is received.
+To avoid sending duplicate digest messages across different `DigestList`
+messages, which could make the channel busy, we define an acknowledgement
+mechanism through which the master client indicates that it has received the
+digest list and acted on it. The server must keep a "cache" containing the set
+of all digest messages that have been sent, but not acknowledged yet by the
+master client, up-to `ack_timeout_ns` in the past. The server must delete all
+cache entries for a given digest list when they are at least `ack_timeout_ns`
+old or when a matching `DigestListAck` message (&ie; with the same `digest_id`
+and `list_id` fields as the `DigestList` message) is received.
 
 The acknowledgement mechanism described above is not used to implement some sort
 of reliable transport for digest messages. The loss of digest messages or
 acknowledgement messages is considered non-critical. The P4Runtime server may
-drop digest messages if they are generated from the data-plane faster than the
+drop digest messages if they are generated from the data plane faster than the
 server software, the channel or the client can handle. P4Runtime does not impose
-a limit on the number of in-flight, unacknowledged DigestList messages.
+a limit on the number of in-flight, unacknowledged `DigestList` messages.
 
-When max_timeout_ns is set to 0 and / or max_list_size is set to 1, the server
-must generate a DigestList message for every digest message generated by the
-data-plane which is not already in the cache. If ack_timeout_ns is set to 0, the
-cache must always be an empty set. If max_list_size is set to 0, there is no
-limit on the maximum size of digest lists: the server can use any non-zero value
-as long as it honors the max_timeout_ns configuration parameter.
+When `max_timeout_ns` is set to 0 and / or `max_list_size` is set to 1, the
+server must generate a `DigestList` message for every digest message generated
+by the data plane which is not already in the cache. If `ack_timeout_ns` is set
+to 0, the cache must always be an empty set. If `max_list_size` is set to 0,
+there is no limit on the maximum size of digest lists: the server can use any
+non-zero value as long as it honors the `max_timeout_ns` configuration
+parameter.
 
 The P4Runtime server may empty the digest message cache in case of a client
 mastership change.
@@ -2899,7 +2870,7 @@ send_buffer(Id digest_id) {
   buffer.clear();
 }
 
-// callback which handles data-plane digest messages from device
+// callback which handles data plane digest messages from device
 handle_dataplane_digest(Digest msg) {
   digest_id = msg.digest_id();
   buffer = buffers[digest_id];
@@ -2932,9 +2903,9 @@ while (true) {
 }
 ~ End CPP
 
-## ExternEntry
+## `ExternEntry`
 
-This is used to support a P4 extern entity that is not part of the PSA. It is
+This is used to support a P4 extern entity that is not part of PSA. It is
 defined as:
 
 ~ Begin Proto
@@ -2945,11 +2916,12 @@ message ExternEntry {
 }
 ~ End Proto
 
-The extern_type_id is assigned during compilation. It is likely that this id
+
+The `extern_type_id` is assigned during compilation. It is likely that this id
 will in fact come from a P4 annotation on the extern declaration and that each
 vendor will receive a prefix to avoid collisions. The extern entry itself is
 embedded as a proto
-[Any](https://developers.google.com/protocol-buffers/docs/proto3#any) to keep
+[[15]](https://developers.google.com/protocol-buffers/docs/proto3#any) to keep
 the protocol extensible.
 
 # Error Reporting Messages { #sec-error-reporting-messages}
@@ -2958,9 +2930,9 @@ P4Runtime is based on gRPC and all RPCs return a status to indicate success or
 failure. gRPC supports multiple language bindings; we use C++ binding below to
 explain how error reporting works in the failure case.
 
-gRPC uses
-[grpc::Status](https://github.com/grpc/grpc/blob/master/include/grpc%2B%2B/impl/codegen/status.h)
-class to represent the status returned by an RPC. It has 3 attributes:
+gRPC uses `grpc::Status`
+[[16]](https://github.com/grpc/grpc/blob/master/include/grpcpp/impl/codegen/status.h)
+to represent the status returned by an RPC. It has 3 attributes:
 
 ~ Begin CPP
 StatusCode code_;
@@ -2968,14 +2940,12 @@ grpc::string error_message_;
 grpc::string binary_error_details_;
 ~ End CPP
 
-The `code_` represents a canonical error (see
-[Code](https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto)
-enum or
-[grpc_status_code](https://github.com/grpc/grpc/blob/master/include/grpc/impl/codegen/status.h)
-for full list), and describes the overall RPC status. The `error_message_` is a
-developer-facing error message, which should be in English. The
-`binary_error_details_` carries a serialized
-[google.rpc.Status](https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto)
+The `code_` represents a canonical error
+[[17]](https://developers.google.com/maps-booking/reference/grpc-api/status_codes)
+and describes the overall RPC status. The `error_message_` is a developer-facing
+error message, which should be in English. The `binary_error_details_` carries a
+serialized `google.rpc.Status` message
+[[18]](https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto)
 message, which has 3 fields:
 
 ~ Begin Proto
@@ -2985,29 +2955,29 @@ repeated google.protobuf.Any details = 3;
 ~ End Proto
 
 The code and message fields must be the same as `code_` and `error_message_`
-fields from `*grpc::Status*` above. The details field is a list that consists of
-p4.Error messages that carry error details for individual elements inside
-batch-request RPCs (e.g. Write and Read). The `p4.Error` supports different
-target vendors to additionally express their own error codes in their chosen
-error-space.
+fields from `grpc::Status` above. The `details` field is a list that consists of
+`p4.Error` messages that carry error details for individual elements inside
+batch-request RPCs (&eg; `Write` and `Read`). The `p4.Error` also enables
+different target vendors to additionally express their own error codes in their
+chosen error-space.
 
-Figure [#fig-error-report] below illustrates how these messages fit together. 
+Figure [#fig-error-report] illustrates how these messages fit together.
 
 ~ Figure { #fig-error-report; caption: "P4Runtime Error Report Mesage Format" }
 ![error-report]
 ~
-[error-report]: assets/error-report.png { width: 80%; page-align: here }
+[error-report]: assets/error-report.png { width: 70%; page-align: here }
 
-gRPC provides utility functions ExtractErrorDetails() and SetErrorDetails() (see
-[error_details.h](https://github.com/grpc/grpc/blob/master/include/grpc%2B%2B/support/error_details.h))
+gRPC provides utility functions `ExtractErrorDetails()` and `SetErrorDetails()`
+[[19]](https://github.com/grpc/grpc/blob/master/include/grpcpp/support/error_details.h)
 to easily convert between `grpc::Status` and `google.rpc.Status`.
 
-Please see sections on individual P4Runtime RPCs for details on how `grpc::Status`
-is populated for reporting errors.
+Please see sections on individual P4Runtime RPCs for details on how
+`grpc::Status` is populated for reporting errors.
 
-# Write RPC
+# `Write` RPC
 
-The *Write* RPC updates one or more P4 entities on the target. The request is
+The `Write` RPC updates one or more P4 entities on the target. The request is
 defined as:
 
 ~ Begin Proto
@@ -3047,141 +3017,143 @@ message Update {
 ~ End Proto
 
 This is modeled as performing an update operation on the given entity against
-its entity container. The entity container is either a *logical* table (e.g.
-CounterEntry) or an actual table (e.g. TableEntry) in the P4 data plane. Each
-entity in the container is uniquely identified by its *key*. Please refer to *P4
-Entity Messages* section for details on what parts of the entity specification
-make up the *key* for each P4 entity.
+its entity container. The entity container is either a *logical* table (&eg;
+`CounterEntry`) or an actual table (&eg; `TableEntry`) in the P4 data
+plane. Each entity in the container is uniquely identified by its *key*. Please
+refer to the [P4 Entity Messages](#sec-p4-entity-msgs) section for details on
+what parts of the entity specification make up the *key* for each P4 entity.
 
-An *update* can be one of the following types:
+An `update` can be one of the following types:
 
-* **INSERT**: Inserts the given P4 entity in the entity container. If the entity
-already exists, an ALREDY_EXISTS error is returned, and the existing entity
-remains unchanged. The entity field always specifies the full state of the P4
-entity. If entity is malformed, an INVALID_ARGUMENT error is returned.
+* `INSERT`: Inserts the given P4 entity in the entity container. If the entity
+  already exists, an `ALREADY_EXISTS` error is returned, and the existing entity
+  remains unchanged. The `entity` field always specifies the full state of the
+  P4 entity. If entity is malformed, an `INVALID_ARGUMENT` error is returned.
 
-* **MODIFY**: Modifies the P4 entity to its new specified state. This uses
-*assign* or *full-snapshot* semantics, i.e. the entity field contains the
-complete new state of the entity, not a diff from its previous state. If entity
-is malformed, an INVALID_ARGUMENT error is returned. If the entity does not
-exist, a NOT_FOUND error is returned.
+* `MODIFY`: Modifies the P4 entity to its new specified state. This uses
+  *assign* or *full-snapshot* semantics, &ie; the entity field contains the
+  complete new state of the entity, not a diff from its previous state. If
+  entity is malformed, an `INVALID_ARGUMENT` error is returned. If the entity
+  does not exist, a `NOT_FOUND` error is returned.
 
-* **DELETE**: Deletes the specified P4 entity. If the entity does not exist, a
-NOT_FOUND error is returned. In order to delete, the entity specification only
-needs to include the key. Any non-key parts of entity are ignored.
+* `DELETE`: Deletes the specified P4 entity. If the entity does not exist, a
+  `NOT_FOUND` error is returned. In order to delete, the entity specification
+  only needs to include the key. Any non-key parts of entity are ignored.
 
-The Write RPC is idempotent, i.e. multiple invocations of the same RPC do not
+The `Write` RPC is idempotent, &ie; multiple invocations of the same RPC do not
 have any side effects. The end result (modified end state on P4Runtime server
 and P4 device) is always the same as the result of the initial invocation, even
 if the response differs.
 
 ## Batching and Ordering of Updates
 
-P4Runtime supports batching of Write operations. The list of updates in a
-WriteRequest is referred to as a *batch*. A batch can consist of arbitrary
+P4Runtime supports batching of `Write` operations. The list of updates in a
+`WriteRequest` is referred to as a *batch*. A batch can consist of arbitrary
 updates on an arbitrary set of P4 entities. It is not restricted to a particular
-entity or table (in the case of TableEntry entities).
+entity or table (in the case of `TableEntry` entities).
 
 The P4Runtime server may arbitrarily reorder message within a batch to maximize
-performance, and clients should not depend on a specific processing order (e.g.
+performance, and clients should not depend on a specific processing order (&eg;
 FIFO or inferring implicit dependencies within a batch). In particular, P4
-entities (e.g. table entries) may be inserted in the data plane in an order
-different than what is received in the *WriteRequest*.
+entities (&eg; table entries) may be inserted in the data plane in an order
+different than what is received in the `WriteRequest`.
 
-The *Write RPC* demarcates the batch boundary, and can be used to ensure
-ordering between dependent updates. When the Write RPC returns, it is required
+The `Write` RPC demarcates the batch boundary, and can be used to ensure
+ordering between dependent updates. When the `Write` RPC returns, it is required
 that all operations in the batch have been committed to hardware (P4 data
-plane). If two updates from the client depend on each other (e.g. inserting an
-*ActionProfileMember* followed by pointing a *TableEntry* to it), they should be
-separated across two batches (and therefore two Write RPCs). In other words, the
-client must wait until the dependent Write RPC is acknowledged before invoking a
-Write RPC that depends on it.
+plane). If two updates from the client depend on each other (&eg; inserting an
+`ActionProfileMember` followed by pointing a `TableEntry` to it), they should be
+separated across two batches (and therefore two `Write` RPCs). In other words,
+the client must wait until the dependent `Write` RPC is acknowledged before
+invoking a `Write` RPC that depends on it.
 
 P4Runtime is based on gRPC which provides a concurrent server design. A target
 implementation may support concurrent execution of a given RPC handler, or it
 may internally choose to serialize RPC processing (using locks, message queue,
-etc.). A client is free to invoke multiple outstanding Write RPCs. This is a
+etc.). A client is free to invoke multiple outstanding `Write` RPCs. This is a
 valid scenario if there are no dependent updates among these RPCs. However, if
 there are dependencies, the client should be aware that there is no way to
 guarantee their ordering, and this will lead to non-deterministic and/or
 erroneous behavior. Given the risk, most clients are advised to stick to a
-synchronous model where there can be at most one Write RPC in flight.
+synchronous model where there can be at most one Write `RPC` in flight.
 
 ## Batch Atomicity
 
 A P4Runtime server may arbitrarily reorder messages within a batch. The
-atomicity semantics of the batch operations are defined by the Atomicity enum. A
-P4Runtime server is required to support only the modes marked as *Required*
-below.
+atomicity semantics of the batch operations are defined by the `Atomicity`
+enum. A P4Runtime server is required to support only the modes marked as
+*Required* below:
 
-* *Required*: **CONTINUE_ON_ERROR**: This is the default behavior and the
-default enum value. Each operation within the batch must be attempted even if
-one or more encounter errors. Every dataplane packet is guaranteed to be
-processed according to table contents as they are between two individual
-operations of the batch, but there could be several packets processed that *see*
-each of these intermediate stages.
+* *Required*: `CONTINUE_ON_ERROR`: This is the default behavior and the default
+  enum value. Each operation within the batch must be attempted even if one or
+  more encounter errors. Every dataplane packet is guaranteed to be processed
+  according to table contents as they are between two individual operations of
+  the batch, but there could be several packets processed that *see* each of
+  these intermediate stages.
 
-* *Optional*: **ROLLBACK_ON_ERROR**: Operations within the batch are attempted
-in an arbitrary order (each committed to dataplane) until the target detects an
-error. At this point, the target must roll back the operations such that both
-software and dataplane state is consistent with the state before the batch was
-attempted. The resulting behavior is *all-or-none*, except the batch is not
-atomic from a data plane point of view. Every dataplane packet is guaranteed to
-be processed according to table contents as they are between two individual
-operations of the batch, but there could be several packets processed that *see*
-each of these intermediate stages. The details and design of the rollback
-mechanism are outside the scope of this specification. One possibility is to
-create a shadow copy of both the software and hardware state at the start, and
-restore it upon failure.
+* *Optional*: `ROLLBACK_ON_ERROR`: Operations within the batch are attempted in
+  an arbitrary order (each committed to dataplane) until the target detects an
+  error. At this point, the target must roll back the operations such that both
+  software and dataplane state is consistent with the state before the batch was
+  attempted. The resulting behavior is *all-or-none*, except the batch is not
+  atomic from a data plane point of view. Every dataplane packet is guaranteed
+  to be processed according to table contents as they are between two individual
+  operations of the batch, but there could be several packets processed that
+  *see* each of these intermediate stages. The details and design of the
+  rollback mechanism are outside the scope of this specification. One
+  possibility is to create a shadow copy of both the software and hardware state
+  at the start, and restore it upon failure.
 
-If this option is not supported, an UNIMPLEMENTED error is returned.
+If this option is not supported, an `UNIMPLEMENTED` error is returned.
 
-* *Optional*: **DATAPLANE_ATOMIC**: This is the strictest requirement where the
-entire batch must be atomic from a dataplane point of view. Every dataplane
-packet is guaranteed to be processed according to table contents before the
-batch began, or after the batch completes. The batch is therefore treated as a
-*transaction*. The details and design of how to achieve dataplane-atomicity is
-outside the scope of this specification. One possibility is to limit the target
-to half of the dataplane's table capacity at all times. At the start of the
-batch processing, the remaining half of the table capacity can be initialized
-with the current table state and used as a working area to commit all operations
-within the batch. At the end (if there were no errors), a simple pointer-swap
-like approach can be used to switch to this half of the table.
+* *Optional*: `DATAPLANE_ATOMIC`: This is the strictest requirement where the
+  entire batch must be atomic from a dataplane point of view. Every dataplane
+  packet is guaranteed to be processed according to table contents before the
+  batch began, or after the batch completes. The batch is therefore treated as a
+  *transaction*. The details and design of how to achieve dataplane-atomicity is
+  outside the scope of this specification. One possibility is to limit the
+  target to half of the dataplane's table capacity at all times. At the start of
+  the batch processing, the remaining half of the table capacity can be
+  initialized with the current table state and used as a working area to commit
+  all operations within the batch. At the end (if there were no errors), a
+  simple pointer-swap like approach can be used to switch to this half of the
+  table.
 
-If a P4Runtime server does not support this option at all, an UNIMPLEMENTED
+If a P4Runtime server does not support this option at all, an `UNIMPLEMENTED`
 error is returned at all times. If a P4Runtime supports some batches in an
-atomic way but not others, an UNIMPLEMENTED error is returned when the batch
+atomic way but not others, an `UNIMPLEMENTED` error is returned when the batch
 cannot be executed in a dataplane-atomic way.
 
-There is no expectation that a given batch must always use the same Atomicity
+There is no expectation that a given batch must always use the same `Atomicity`
 enum value. At any given time, the client is free to compose batches and assign
 atomicity mode as it sees fit. For example, for a set of entities, a client may
-decide to use DATAPLANE_ATOMIC at one time and default behavior
-(CONTINUE_ON_ERROR) at other times.
+decide to use `DATAPLANE_ATOMIC` at one time and default behavior
+(`CONTINUE_ON_ERROR`) at other times.
 
 ## Error Reporting
 
 Please see section [Error Reporting Messages](#sec-error-reporting-messages) for
 information on error reporting messages and guidelines. P4Runtime server will
-populate grpc::Status as follows:
+populate `grpc::Status` as follows:
 
-1. If all batch updates succeeded, set grpc::Status code_ to OK and do not
-populate any other field.
+1. If all batch updates succeeded, set `grpc::Status::code_` to `OK` and do not
+   populate any other field.
 
 2. If an error is encountered before even trying to attempt individual batch
-updates, set grpc::Status code_ that best describes that RPC-wide error. For
-example, use UNAVAILABLE if the P4Runtime service is not yet ready to handle
-requests. Set error_message_ to describe the issue. Do not set error_details in
-this case.
+   updates, set `grpc::Status::code_` that best describes that RPC-wide
+   error. For example, use `UNAVAILABLE` if the P4Runtime service is not yet
+   ready to handle requests. Set `error_message_` to describe the issue. Do not
+   set `error_details` in this case.
 
-3. Otherwise, if one or more updates in the batch (WriteRequest.updates) failed,
-set the grpc::Status code to UNKNOWN. For example, one update in the batch may
-fail with RESOURCE_EXHAUSTED and another with INVALID_ARGUMENT. A p4.Error
-message is used to capture the status of each and every update in the batch. The
-number of p4.Error messages packed into google.rpc.Status.details field should
-therefore always match the number of updates in the WriteRequest. If some of the
-updates were successful, the corresponding p4.Error should set the code to OK
-and omit other fields.
+3. Otherwise, if one or more updates in the batch (`WriteRequest.updates`)
+   failed, set `grpc::Status::code_` to `UNKNOWN`. For example, one update in
+   the batch may fail with `RESOURCE_EXHAUSTED` and another with
+   `INVALID_ARGUMENT`. A `p4.Error` message is used to capture the status of
+   each and every update in the batch. The number of `p4.Error` messages packed
+   into `google.rpc.Status.details` field should therefore always match the
+   number of updates in the `WriteRequest`. If some of the updates were
+   successful, the corresponding `p4.Error` should set the code to `OK` and omit
+   other fields.
 
 ~ Begin Prototext
 # Example of a grpc::Status returned for a Write RPC with a batch of 3 updates.
@@ -3209,9 +3181,10 @@ binary_error_details {
   }
 }
 ~ End Prototext
-# Read RPC
 
-The *Read* RPC retrieves one or more P4 entities from the P4Runtime server. The
+# `Read` RPC
+
+The `Read` RPC retrieves one or more P4 entities from the P4Runtime server. The
 request is defined as:
 
 ~ Begin Proto
@@ -3221,12 +3194,12 @@ message ReadRequest {
 }
 ~ End Proto
 
-The devide_id uniquely identifies the target P4 device. The entities field is a
-list of P4 entities, each acting as a query filter to be applied to P4 entity
-containers on the server.
+The `device_id` uniquely identifies the target P4 device. The `entities`
+repeated field is a list of P4 entities, each acting as a query filter to be
+applied to P4 entity containers on the server.
 
-The Read response consists of a sequence of messages (a gRPC stream) with each
-message defined as:
+The `Read `response consists of a sequence of messages (a gRPC `stream`) with
+each message defined as:
 
 ~ Begin Proto
 message ReadResponse {
@@ -3235,101 +3208,105 @@ message ReadResponse {
 }
 ~ End Proto
 
-The entities field is a list of P4 entities retrieved. The client reads from the
-returned stream until it is closed by the server when there are no more
-messages. To disambiguate that the stream was closed due to  this success case
-(as opposed to the stream closing due to a transport error), the complete flag
-is set to true only if no response message will follow this one.
+The `entities` repeated field is a list of P4 entities retrieved. The client
+reads from the returned stream until it is closed by the server when there are
+no more messages. To disambiguate that the stream was closed due to this success
+case (as opposed to the stream closing due to a transport error), the complete
+flag is set to true only if no response message will follow this one.
 
-**Nomenclature**
+## Nomenclature
 
-***request***: An element of p4.ReadRequest.entities repeated field.
-
-***batch*** : Refers to p4.ReadRequest.entities repeated field.
+* request
+  : An element of the `p4.ReadRequest.entities` repeated field.
+* batch
+  : Refers to the p4.ReadRequest.entities repeated field.
 
 Each *request* acts as a query filter for that entity type. If a *request* fully
-specifies the entity key, the Read operation should retrieve a single P4 entity.
-Please refer to *P4 Entity Messages* section for details on what parts of the
-entity specification make up the entity *key.*
+specifies the entity key, the `Read` operation should retrieve a single P4
+entity.  Please refer to the [P4 Entity Messages](#sec-p4-entity-msgs) section
+for details on what parts of the entity specification make up the entity *key.*
 
 ## Wildcard Reads
 
 P4Runtime allows wildcard read of P4 entities. A *request* may omit or use
 default values for parts of the entity key to achieve wildcard behavior. Please
-refer to *P4 Entity Messages* section for details on what parts of the entity
-can be wildcarded in a given *request*.
+refer to the [P4 Entity Messages](#sec-p4-entity-msgs) section for details on
+what parts of the entity can be wildcarded in a given *request*.
 
 For example, in a *request* of type CounterEntry:
 
-* A default counter_id implies a request to read all counter-entries for all
-indirect counters.
-
-* A particular (non-default) counter_id in conjunction with index unset implies
-a request to read all counter-entries for the given indirect counter ID.
+* A default `counter_id` implies a request to read all counter-entries for all
+  indirect counters.
+* A particular (non-default) `counter_id` in conjunction with `index` unset
+  implies a request to read all counter-entries for the given indirect counter
+  ID.
 
 ## Batch Processing
 
 A P4Runtime server may arbitrarily reorder requests within a batch to maximize
-performance ali(this matches Write RPC semantics). Also, there is no requirement
-that a particular entity type *request* appear only once in the batch.
+performance. There is no requirement that a particular entity type *request*
+appears only once in the batch.
 
 A P4Runtime server will process the batch as follows:
 
-1. Lock state (preventing new Writes) and validate each *request* in the batch
+1. Lock state (preventing new writes) and validate each *request* in the batch:
 
-    1. If it is a valid *request*, perform the read
+    1. If it is a valid *request*, perform the read;
 
-        1. If the read was successful, return the entities read in ReadResponse
-        stream
-        2. If the read failed (exception/critical-error), prepare a p4.Error
-        with code set to INTERNAL
+        1. If the read was successful, return the entities read in
+           `ReadResponse` stream.
+        2. If the read failed (exception / critical-error), prepare a `p4.Error`
+           with code set to `INTERNAL`.
 
     2. If the *request* is invalid (invalid-argument, not-supported, etc.),
-    prepare a p4.Error with relevant canonical code to capture the error
+       prepare a `p4.Error` with relevant canonical code to capture the error.
 
-2. Unlock the state (allowing new Writes)
+2. Unlock the state (allowing new writes);
 
-3. Close the ReadResponse stream and return a grpc::Status as follows:
+3. Close the `ReadResponse` stream and return a `grpc::Status` as follows:
 
-    1. If no errors were encountered, set code to OK and do not populate any
-    other field.
+    1. If no errors were encountered, set code to `OK` and do not populate any
+       other field.
 
-    2. Otherwise, the overall code should be set to UNKNOWN. See section [Error
-    Reporting Messages](#sec-error-reporting-messages) for information on error
-    reporting messages and guidelines. Assemble a list of p4.Error messages
-    (from step 1 above) such that each element reflects the status of the
-    request in the batch at the same location (1:1 correspondence). This list
-    should be packed into google.rpc.Status.details field. This behavior also
-    matches Write RPC.
+    2. Otherwise, the overall code should be set to `UNKNOWN`. See section
+       [Error Reporting Messages](#sec-error-reporting-messages) for information
+       on error reporting messages and guidelines. Assemble a list of `p4.Error`
+       messages (from step 1 above) such that each element reflects the status
+       of the request in the batch at the same location (1:1
+       correspondence). This list should be packed into
+       `google.rpc.Status.details` field. This behavior also matches `Write`
+       RPC.
 
-**Example**: If client asked to read {a,b,c,d} and 'b' and 'd' *requests* didn't
-validate, switch will return entities corresponding to 'a' and 'c', followed by
-a status {p4.Error(OK), p4.Error(xxx), p4.Error(yyy), p4.Error(OK)} in the
-'details' field.
+### Example
 
-The P4Runtime server is not required to perform any optimization (e.g. merge two
+If a client asked to read `{a,b,c,d}` and `b` and `d` *requests* didn't
+validate, switch will return entities corresponding to `a` and `c`, followed by
+a status `{p4.Error(OK), p4.Error(xxx), p4.Error(yyy), p4.Error(OK)}` in the
+`details` field.
+
+The P4Runtime server is not required to perform any optimization (&eg; merge two
 *requests* in the *batch* if one is a subset of other). As a result of this, it
-is possible for the *ReadResponse* to contain the same entity more than once. If
+is possible for the `ReadResponse` to contain the same entity more than once. If
 performance is a concern, the P4Runtime client should handle this merging.
 
 There is no requirement that each request in the batch will correspond to one
-*ReadResponse* message in the stream. The stream-based design for response
+`ReadResponse` message in the stream. The stream-based design for response
 message is to avoid memory pressure on the P4Runtime server when the Read
 results in a very large number of entities to be returned. The P4Runtime server
 is free to break them apart across multiple response messages as it sees fit.
 
-A P4Runtime server must be prepared to handle multiple concurrent Read RPCs.
+A P4Runtime server must be prepared to handle multiple concurrent `Read` RPCs.
 This could be from the same or multiple clients. P4Runtime is based on gRPC
 which provides a concurrent server design. A server implementation that supports
 concurrent RPC handlers may choose to maximize performance by using a
 multi-reader lock (also known as multiple readers/single-writer lock).
-Conversely (e.g. in a single-threaded architecture), it may choose to serialize
-Read RPC processing.
+Conversely (&eg; in a single-threaded architecture), it may choose to serialize
+`Read` RPC processing.
 
-# SetForwadingPipelineConfig RPC
+# `SetForwadingPipelineConfig` RPC
 
 A P4Runtime client may configure the P4Runtime target with a new P4 pipeline by
-invoking the SetForwardingPipelineConfig RPC. The request is defined as:
+invoking the `SetForwardingPipelineConfig RPC`. The request is defined as:
 
 ~ Begin Proto
 message SetForwardingPipelineConfigRequest {
@@ -3349,64 +3326,67 @@ message SetForwardingPipelineConfigRequest {
 }
 ~ End Proto
 
-The device_id uniquely identifies the target P4 device. An INVALID_ARGUMENT
-error is returned if the device_id is not recognized the P4Runtime server.
+The `device_id` uniquely identifies the target P4 device. An `INVALID_ARGUMENT`
+error is returned if the `device_id` is not recognized the P4Runtime server.
 
-The role_id uniquely identifies a P4Runtime client role. More details on P4
+The `role_id` uniquely identifies a P4Runtime client role. More details on P4
 controller roles are provided in the section on multi-controller usage. An
-INVALID_ARGUMENT error is returned if the role_id does not match any role_id
+`INVALID_ARGUMENT` error is returned if the role_id does not match any `role_id`
 negotiated as part of master arbitration on the stream channel.
 
-The election_id is a 128 bit identifier used to determine the instance in case
-of replicated controllers.
+The `election_id` is a 128-bit identifier used to determine the controller
+instance in case of replicated controllers.
 
-The action is the type of configuration action requested, can be one of:
+The action is the type of configuration action requested, it can be one of:
 
-* VERIFY: verifies that the target can realize the given config. The forwarding
-state in the target is not modified. Returns an INVALID_ARGUMENT error if config
-is not provided or if the provided config cannot be realized.
+* `VERIFY`: verifies that the target can realize the given config. The
+  forwarding state in the target is not modified. Returns an `INVALID_ARGUMENT`
+  error if config is not provided or if the provided config cannot be realized.
 
-* VERIFY_AND_SAVE : saves the config if the P4Runtime target can realize it. The
-forwarding state in the target is not modified. However, any subsequent
-read/write requests must refer to fields in the new config. Returns an
-INVALID_ARGUMENT error if the forwarding config is not provided of if the
-provided config cannot be realized.
+* `VERIFY_AND_SAVE`: saves the config if the P4Runtime target can realize
+  it. The forwarding state in the target is not modified. However, any
+  subsequent `Read` / `Write` requests must refer to fields in the new
+  config. Returns an `INVALID_ARGUMENT` error if the forwarding config is not
+  provided of if the provided config cannot be realized.
 
-* VERIFY_AND_COMMIT : saves and realizes the given config if the P4Runtime
-target can realize it. The forwarding state in the target is cleared, and the
-device stops forwarding action. Returns an INVALID_ARGUMENT error if the
-forwarding config is not provided of if the provided config cannot be realized.
+* `VERIFY_AND_COMMIT`: saves and realizes the given config if the P4Runtime
+  target can realize it. The forwarding state in the target is cleared, and the
+  device stops forwarding action. Returns an `INVALID_ARGUMENT` error if the
+  forwarding config is not provided of if the provided config cannot be
+  realized.
 
-* COMMIT : realizes the last saved, but not yet committed, config. The
-forwarding state in the target is updated by replaying the write requests to the
-target device since the last config was saved. Config should not be provided for
-this action type. Returns an INVALID_ARGUMENT error if no saved config is found
-or if a config is provided with this message.
+* `COMMIT`: realizes the last saved, but not yet committed, config. The
+  forwarding state in the target is updated by replaying the write requests to
+  the target device since the last config was saved. Config should not be
+  provided for this action type. Returns an `INVALID_ARGUMENT` error if no saved
+  config is found or if a config is provided with this message.
 
-* RECONCILE_AND_COMMIT : verifies, saves and realizes the given config, while
-preserving the forwarding state in the target. This is an advanced use case to
-enable changes to the P4 forwarding pipeline configuration with minimal traffic
-loss. P4Runtime does not impose any constraints on the duration of the traffic
-loss. The support for this option is not expected to be uniform across all
-P4Runtime targets. A target that does not support this option may return an
-UNIMPLEMENTED error. For targets that support this option, an INVALID_ARGUMENT
-error is returned if no config is provided, or if the existing forwarding state
-cannot be preserved for the given config by the target.
+* `RECONCILE_AND_COMMIT`: verifies, saves and realizes the given config, while
+  preserving the forwarding state in the target. This is an advanced use case to
+  enable changes to the P4 forwarding pipeline configuration with minimal
+  traffic loss. P4Runtime does not impose any constraints on the duration of the
+  traffic loss. The support for this option is not expected to be uniform across
+  all P4Runtime targets. A target that does not support this option may return
+  an `UNIMPLEMENTED` error. For targets that support this option, an
+  `INVALID_ARGUMENT` error is returned if no config is provided, or if the
+  existing forwarding state cannot be preserved for the given config by the
+  target.
 
-The config field is a message of type ForwardingPipelineConfig that carries the
-P4Info and the opaque target-dependent forwarding configuration data or device
-config, generated by the P4 compiler for the target. See section
-Forwarding-Pipeline Configuration for details.
+The `config` field is a message of type `ForwardingPipelineConfig` that carries
+the P4Info and the opaque target-dependent forwarding configuration data or
+device config, generated by the P4 compiler for the target. See the
+[Forwarding-Pipeline Configuration](#sec-p4-fwd-pipe-config) section for
+details.
 
 A P4Runtime server running on an atypical device may not support
-SetForwardingPipelineConfig (e.g. the forwarding-pipeline config is part of
+`SetForwardingPipelineConfig` (&eg; the forwarding-pipeline config is part of
 device software image, or is supplied using a different mechanism). In such
-cases, the RPC should return an UNIMPLEMENTED error.
+cases, the RPC should return an `UNIMPLEMENTED` error.
 
-# GetForwardingPipelineConfig RPC
+# `GetForwardingPipelineConfig` RPC
 
 The forwarding-pipeline configuration of the target can be retrieved by invoking
-the GetForwardingPipelineConfig RPC. The request is defined as:
+the `GetForwardingPipelineConfig RPC`. The request is defined as:
 
 ~ Begin Proto
 message GetForwardingPipelineConfigRequest {
@@ -3414,10 +3394,10 @@ message GetForwardingPipelineConfigRequest {
 }
 ~ End Proto
 
-The device_id uniquely identifies the target P4 device. An INVALID_ARGUMENT
-error is returned if the device_id is not recognized the P4Runtime server.
+The `device_id` uniquely identifies the target P4 device. An `INVALID_ARGUMENT`
+error is returned if the `device_id` is not recognized by the P4Runtime server.
 
-The response contains the *P4ForwardingPipelineConfig* for the specified device:
+The response contains the `P4ForwardingPipelineConfig` for the specified device:
 
 ~ Begin Proto
  message GetForwardingPipelineConfigResponse {
@@ -3425,40 +3405,40 @@ The response contains the *P4ForwardingPipelineConfig* for the specified device:
 }
 ~ End Proto
 
-The ForwardingPipelineConfig consists of P4Info and the opaque target-dependent
-p4_device_config. If a P4Runtime server is in a state where the
-forwarding-pipeline config is not known, the top-level config field will be
-unset in the response. Examples are (i) a server that only allows configuration
-via SetFowardingPipelineConfig but this RPC hasn't been invoked yet, (ii) a
-server that is configured using a different mechanism but this configuration
-hasn't yet occured.
+The `ForwardingPipelineConfig` consists of P4Info and the opaque
+target-dependent `p4_device_config`. If a P4Runtime server is in a state where
+the forwarding-pipeline config is not known, the top-level `config` field will
+be unset in the response. Examples are (i) a server that only allows
+configuration via `SetFowardingPipelineConfig` but this RPC hasn't been invoked
+yet, (ii) a server that is configured using a different mechanism but this
+configuration hasn't yet occured.
 
 Once a forwarding-pipeline config is installed on the device (either via
-SetFowardingPipelineConfig or a different mechanism), some P4Runtime servers may
-not support retrieval of P4-device-config. In such cases,
-config.p4_device_config will be empty/unset in the response. However, all
+`SetFowardingPipelineConfig` or a different mechanism), some P4Runtime servers
+may not support retrieval of the target-dependent config, in which case
+`config.p4_device_config` will be empty / unset in the response. However, all
 P4Runtime servers are required to return P4Info in this scenario.
 
-If a P4Runtime server supports both SetForwardingPipelineConfig as well as
-returning the p4_device_config, there should be read-write symmetry between
-SetForwardingPipelineConfig and GetForwardingPipelineConfig RPCs.
+If a P4Runtime server supports both `SetForwardingPipelineConfig` as well as
+returning the `p4_device_config`, there should be read-write symmetry between
+`SetForwardingPipelineConfig` and `GetForwardingPipelineConfig` RPCs.
 
 # P4Runtime Stream Messages
 
 ## Packet I/O { #sec-packet-i_o}
 
-P4Runtime supports controller packet-in and packet-out by means of PacketIn and
-PacketOut stream messages, respectively.
+P4Runtime supports controller packet-in and packet-out by means of `PacketIn`
+and `PacketOut` stream messages, respectively.
 
-PacketIn messages are sent by the P4Runtime server to the client. Conversely,
-PacketOut messages are sent by the client to the server.
+`PacketIn` messages are sent by the P4Runtime server to the client. Conversely,
+`PacketOut` messages are sent by the client to the server.
 
-As introduced in the [Packet I/O](#sec-packet-i_o) section, such messages can
-carry arbitrary metadata specified by means of P4 headers with P4 standard
-annotation `@controller_header`. The expected metadata is also described in the
-P4Info using the ControllerPacketMetadata messages.
+As introduced in the [`ControllerPacketMetadata`](#sec-controller-packet-meta)
+section, such messages can carry arbitrary metadata specified by means of P4
+headers annotated with `@controller_header`. The expected metadata is described
+in the P4Info using the `ControllerPacketMetadata` messages.
 
-Both PacketIn and PacketOut stream messages share the same fields and are
+Both `PacketIn` and `PacketOut` stream messages share the same fields and are
 defined as follows:
 
 ~ Begin Proto
@@ -3481,39 +3461,38 @@ message PacketMetadata {
 }
 ~ End Proto
 
-`payload` is used to carry the full packet content, including the headers.
+* `payload` is used to carry the full packet content, including the headers.
 
-`metadata` is a repeated field of PacketMetadata messages used to carry the
-arbitrary controller metadata. The size and value of such metadata field needs
-to consistent with what specified in the the corresponding P4Info
-ControllerPacketMetadata. Indeed, when a P4Runtime client (or server) generates
-a PacketOut (or PacketIn) message, it needs to populate the metadata field with
-as many values as in ControllerPacketMetadata.metadata for the packet-out (or
-packet-in) case. Each PacketMetadata.value is expected to have length in bytes
-obtained by rounding-up the bitwidth value of the corresponding
-ControllerPacketMetadata.metadata to the nearest byte.
-
-### Server implementation for Packet I/O handling
+* `metadata` is a repeated field of `PacketMetadata` messages used to carry the
+  arbitrary controller metadata. The size and value of such metadata field needs
+  to consistent with what specified in the the corresponding P4Info
+  `ControllerPacketMetadata`. Indeed, when a P4Runtime client (or server)
+  generates a `PacketOut` (or `PacketIn`) message, it needs to populate the
+  metadata field with as many values as in `ControllerPacketMetadata.metadata`
+  for the packet-out (or packet-in) case. Each `PacketMetadata.value` is
+  expected to have a length in bytes obtained by rounding-up the bitwidth value
+  of the corresponding `ControllerPacketMetadata.metadata` to the nearest byte.
 
 ## Master Arbitration Update
 
-As explained earlier in this document, the controller uses the StreamChannel RPC
-for session management as well as Packet I/O. In fact, before a controller
-becomes able to do packet I/O or program any forwarding entry (via Write RPC),
+As explained earlier in this document, the controller uses the `StreamChannel`
+RPC for session management as well as Packet I/O. In fact, before a controller
+becomes able to do Packet I/O or program any forwarding entry (via `Write` RPC),
 it needs to start a controller session and becomes a "master". To do so, the
-controller first opens a bidirectional stream channel to the switch via
-StreamChannel RPC for each device (aka target or node or switching chip) and
-sends a StreamMessageRequest message to the switch. The controller populates the
-MasterArbitrationUpdate field in this message using its role_id and election_id
-and the device_id of the device, as explained in detail in the 
-[Master-Slave Arbitration and Controller Replication](#sec-master-slave-arbitration-and-controller-replication)
-section. For any (device_id, role_id), the controller
-with the highest election_id is the master and the rest are slaves.
-MasterArbitrationUpdate message is defined as follows:
+controller first opens a bidirectional stream channel to the server via
+`StreamChannel` for each device and sends a `StreamMessageRequest` message. The
+controller populates the `MasterArbitrationUpdate` field in this message using
+its `role_id` and `election_id` and the `device_id` of the device, as explained
+in detail in the [Master-Slave Arbitration and Controller
+Replication](#sec-master-slave-arbitration-and-controller-replication)
+section. For any given (`device_id`, `role_id`), the controller with the highest
+`election_id` is the master and the rest are slaves.
+
+The `MasterArbitrationUpdate` message is defined as follows:
 
 ~ Begin Proto
 message Role {
-  // role_id for this role. Defined offline in agreement across the 
+  // role_id for this role. Defined offline in agreement across the
   // entire control plane.
   uint64 id = 1;
   // Describes the role configuration.
@@ -3521,71 +3500,67 @@ message Role {
 }
 
 message MasterArbitrationUpdate {
-  // Identifies the device (aka target or node or switching chip). 
+  // Identifies the device (aka target or node or switching chip).
   uint64 device_id = 1;
-  // The role for which the mastership is being arbitrated. 
+  // The role for which the mastership is being arbitrated.
   Role role = 2;
   // The election_id (unique per role).
   Uint128 election_id = 3;
-  // Switch populates this with OK for the client that is the master, 
-  // and with an error status for all other connected clients (at 
-  // every mastership change). The controller does not populate this 
+  // Switch populates this with OK for the client that is the master,
+  // and with an error status for all other connected clients (at
+  // every mastership change). The controller does not populate this
   // field.
   google.rpc.Status status = 4;
 }
 ~ End Proto
 
-Note that status field in the MasterArbitrationUpdate is not populated by the
-controller. This field is populated by the P4Runtime server when it sends a
-StreamMessageResponse message back to the controller, in which it populates the
-MasterArbitrationUpdate message using the device_id, role, and election_id it
-previously received from the controller. The server also populates the status
-field in the MasterArbitrationUpdate with the following statuses:
+Note that `status` field in the `MasterArbitrationUpdate` is not populated by
+the controller. This field is populated by the P4Runtime server when it sends a
+`StreamMessageResponse` message back to the controller, in which it populates
+the `MasterArbitrationUpdate` message using the `device_id`, `role`, and
+`election_id` it previously received from the controller. The server also
+populates the `status` field in the `MasterArbitrationUpdate` as follows:
 
-* OK (with status.code set to google.rpc.OK) when the controller is determined
-to be the master for a given (device_id, role_id).
+* OK (with `status.code` set to `google.rpc.OK`) when the controller is
+  determined to be the master for a given (`device_id`, `role_id`).
 
-* Non-OK (with status.code set to google.rpc.ALREADY_EXISTS) when the controller
-is determined to be a slave for a given (device_id, role_id).
+* Non-OK (with `status.code` set to `google.rpc.ALREADY_EXISTS`) when the
+  controller is determined to be a slave for a given (`device_id`, `role_id`).
 
 ## Digest Messages
 
-### DigestList
-
-### DigestListAck
-
-See [DigestEntry](#sec-digestentry) section.
+See the [DigestEntry](#sec-digestentry) section.
 
 ## Table Idle Timeout Notification { #sec-table-idle-timeout-notification}
 
 When a table supports idle timeout (as per the P4Info message), the master
 client can specify a TTL value for each entry in the table (see
-[Idle-timeout](#sec-idle-timeout) section). If the data-plane entry is not
-hit for a lapse of time greater or equal to the TTL, the P4Runtime server must
-generate a IdleTimeoutNotification message on the StreamChannel bi-directional
-stream to the master client. The master client can then take the action of its
-choice, most likely remove the idle entry.
+[Idle-timeout](#sec-idle-timeout) section). If the data plane entry is not hit
+for a lapse of time greater or equal to the TTL, the P4Runtime server must
+generate an `IdleTimeoutNotification message` on the `StreamChannel`
+bi-directional stream to the master client. The master client can then take the
+action of its choice, most likely remove the idle entry.
 
-The IdleTimeoutNotification Protobuf message has the following fields:
+The `IdleTimeoutNotification` Protobuf message has the following fields:
 
-* timestamp: timestamp at which the P4Runtime server generated the message (in
-nanoseconds since Epoch) as per the server's local clock.
+* `timestamp`: timestamp at which the P4Runtime server generated the message (in
+  nanoseconds since Epoch) as per the server's local clock.
 
-* table_entry: a repeated field of entries which have expired. Each individual
-entry is identified by a single TableEntry message. For each TableEntry, the
-"key" fields (table_id, match and priority) must be set, along with the
-controller_metadata field. Other fields may be set by the server but should be
-ignored by the client.
+* `table_entry`: a repeated field of entries which have expired. Each individual
+  entry is identified by a single `TableEntry` message. For each `TableEntry`,
+  the *key* fields (`table_id`, `match` and `priority`) must be set, along with
+  the `controller_metadata` field. Other fields may be set by the server but
+  should be ignored by the client.
 
 Because we use a repeated Protobuf field, the P4Runtime server may elect to
-coalesce several idle timeout notifications in the same IdleTimeoutNotification
-message if it deems it appropriate. The server should not hold on to individual
-idle notifications for a significant amount of time just for the sake of
-coalescing as many as possible in a single message. For example, if the
-P4Runtime server periodically scans the device for idle data-plane entries, we
-recommend not delaying notifications by more than one scanning interval. The
-P4Runtime server must not send an IdleTimeoutNotification message with an empty
-table_entry repeated field.
+coalesce several idle timeout notifications in the same
+`IdleTimeoutNotification` message if it deems it appropriate. The server should
+not hold on to individual idle notifications for a significant amount of time
+just for the sake of coalescing as many as possible in a single message. For
+example, if the P4Runtime server periodically scans the device for idle data
+plane entries, we recommend not delaying notifications by more than one scanning
+interval. The P4Runtime server must not send an `IdleTimeoutNotification`
+message with an empty `table_entry` repeated field.
 
 After generating an idle notification, the P4Runtime server must "reset" the
 timer for the corresponding entry, which means a new notification will be
@@ -3625,11 +3600,11 @@ while (true) {
 }
 ~ End CPP
 
-# Portability considerations
+# Portability Considerations
 
 ## PSA Metadata Translation { #sec-psa-metadata-translation}
 
-The **Portable Switch Architecture** (PSA) defines standard metadata, whose
+The *Portable Switch Architecture* (PSA) defines standard metadata, whose
 dataplane types are different on different PSA targets. In order to enable
 uniform programming of multiple PSA targets, a centralized remote controller may
 define its own types and numbering of such PSA standard metadata. For such
@@ -3656,17 +3631,19 @@ of all targets in its domain. A mapping from the controller's 32 bit port
 numbers to a target's 9-bit or 10-bit port numbers is input to the switch via
 the non-forwarding switch config data that is delivered separately to the
 switch.
+
 ### Translation of Port Numbers { #sec-translation-of-port-numbers}
 
 In order to support the above SDN use case, P4Runtime requires translation of
 port metadata values between the controller's space and the PSA device's space
 as needed. Such translation is enabled by identifying a P4 entity (match field,
-action parameter or header field) as being a  PSA port metadata type. For this
+action parameter or header field) as being a PSA port metadata type. For this
 purpose, PSA defines the port metadata field type using special P4 types, namely
-PortId_t and PortInHeader_t, instead of standard P4 bitstrings. The P4Info for
-all P4 entities of the special PSA port types use a controller-defined 32-bit
-type instead of the dataplane bitwidth defined in the P4 program. The following
-PSA port metadata types are defined in psa.p4 for the PSA device in Switch 1.
+`PortId_t` and `PortInHeader_t`, instead of standard P4 bitstrings. The P4Info
+for all P4 entities of the special PSA port types use a controller-defined
+32-bit type instead of the dataplane bitwidth defined in the P4 program. The
+following PSA port metadata types are defined in *psa.p4* for the PSA device in
+Switch 1.
 
 ~ Begin P4Example
 type PortId_t bit<9>;
@@ -3724,7 +3701,7 @@ packet-out metadata (egress_port) value of type 32-bits from the given set of
 SDN port values in the switch config. The server will then translate the SDN
 port value into the device-specific port value from the mapping provided in the
 switch config. Note that even though the type of the header field is 32-bit
-(PortIdInHeader_t)to support byte aligned headers, the actual dataplane value
+(`PortIdInHeader_t`) to support byte aligned headers, the actual dataplane value
 will fit in the smaller device specific bitwidth. Any subsequent reference to
 the egress_port field in the dataplane will use the translated value.
 
@@ -3754,30 +3731,28 @@ table t {
 }
 ~ End P4Example
 
-Table t has an exact match on PSA standard metadata ingress port
-(istd.ingress_port). Since the field is of type PortId_t, the P4Info
+Table `t` has an exact match on PSA standard metadata ingress port
+(`istd.ingress_port`). Since the field is of type `PortId_t`, the P4Info
 representation of the match field will present a 32-bit bitwidth to the
 controller, regardless of the dataplane port type. A P4Runtime write request
-for a table entry in t from the controller will have the values of the match
+for a table entry in `t` from the controller will have the values of the match
 field set to the controller-specific port value. The P4Runtime server should
 intercept the write request and use the switch configuration data to translate
 the SDN port value to respective device-specific value. In the dataplane, the
 packet metadata will carry the device specific value and, hence, match the right
-table entry. Similarly, when a read response for table t is returned to the
+table entry. Similarly, when a read response for table `t` is returned to the
 controller, the P4Runtime server should translate the device-specific port
 values to the corresponding controller-specific values.
 
 Note that it may be infeasible to translate the value-mask pair for ternary
-matches and the value-prefix-length pair for lpm matches. Therefore, the
-P4Runtime server may require that the port match be effectively either exact
-(0xFFFFFFFF mask for ternary and prefix-length of 32 for lpm) or don't care (0
-mask for ternary and 0 prefix length for lpm). Translation may also be
-infeasible for match of type range unless the low and high fields of the range
-match are identical, thereby defaulting to an exact match.
+matches: `EXACT`, `TERNARY` or `RANGE` match kinds.  P4Runtime server may
+require that for these match kinds the port match be either *de facto* "exact"
+(0xFFFFFFFF mask for `TERNARY`, prefix-length of 32 for `LPM`, or same low and
+high bounds for `RANGE`) or "don't care".
 
 ### Translation of Action Parameters
 
-PortId_t type parameters can be part of a P4 action definition as shown in the
+`PortId_t` type parameters can be part of a P4 action definition as shown in the
 example below:
 
 ~ Begin P4Example
@@ -3795,12 +3770,13 @@ table t {
 }
 ~ End P4Example
 
-The controller may write entries in table t with action a to set the egress port
-as shown in the P4 code above. The action parameter p  is of type PortId_t,
-which leads to a 32-bit bitwidth for p being exposed in P4Info. Furthermore, the
-type will be a signal to the P4Runtime server that translation is required for
-this parameter. The P4Runtime server will use the switch configuration to
-translate action parameter values between the controller and the target device.
+The controller may write entries in table `t` with action `a` to set the egress
+port as shown in the P4 code above. The action parameter `p` is of type
+`PortId_t`, which leads to a 32-bit bitwidth for `p` being exposed in
+P4Info. Furthermore, the type will be a signal to the P4Runtime server that
+translation is required for this parameter. The P4Runtime server will use the
+switch configuration to translate action parameter values between the controller
+and the target device.
 
 ### Port Translation for PSA Extern APIs
 
@@ -3817,30 +3793,30 @@ functionality on the target device.
 
 The Packet Replication Engine (PRE) API in P4Runtime supports cloning and
 multicasting to a set of ports. The egress port fields defined in the PRE
-multicast entry and clone session entry are of type uint32 to carry a 32-bit SDN
-number of the port(s). The P4Runtime server will translate these SDN port
+multicast entry and clone session entry are of type `uint32` to carry a 32-bit
+SDN number of the port(s). The P4Runtime server will translate these SDN port
 numbers to device-specific port numbers for multicasting and cloning in the
 dataplane.
 
 # P4Runtime Versioning
 
-# Extending P4Runtime for non-PSA architectures
+# Extending P4Runtime for non-PSA Architectures
 
-# Lifetime of a session
+# Lifetime of a Session
 
-# Known-limitations of P4Runtime v1.0
+# Known-limitations of P4Runtime v1.0.0
 
-* FieldMatch and action Param only supports bitstrings (not the more general
-P4Data)
+* `FieldMatch` and action `Param` only supports bitstrings (not the more general
+  P4Data).
 
 * Support for PSA Random & Timestamp externs is postponed to a future minor
-version update
+  version update.
 
 * P4Info does not include information about which of a table's actions execute
-which direct resource(s)
+  which direct resource(s).
 
-* The default action for indirect match tables is restricted to a const NoAction
-known at compile-time
+* The default action for indirect match tables is restricted to a `const
+  NoAction` known at compile-time.
 
 # Acknowledgements
 
@@ -3886,3 +3862,20 @@ known at compile-time
 
 * \[13\] [https://p4.org/p4-spec/docs/P4-16-v1.1.0-draft.html](https://p4.org/p4-spec/docs/P4-16-v1.1.0-draft.html) -
   P4~16~ 1.1.0 specification
+
+* \[14\] [https://p4.org/p4-spec/docs/P4-16-v1.1.0-draft.html#sec-enum-types](https://p4.org/p4-spec/docs/P4-16-v1.1.0-draft.html#sec-enum-types) -
+  enums in P4~16~
+
+* \[15\] [https://developers.google.com/protocol-buffers/docs/proto3#any](https://developers.google.com/protocol-buffers/docs/proto3#any) -
+  the Any Protobuf message
+
+* \[16\] [https://github.com/grpc/grpc/blob/master/include/grpcpp/impl/codegen/status.h](https://github.com/grpc/grpc/blob/master/include/grpcpp/impl/codegen/status.h) -
+  the gRPC `Status` class
+
+* \[17\] [https://developers.google.com/maps-booking/reference/grpc-api/status_codes](https://developers.google.com/maps-booking/reference/grpc-api/status_codes) -
+  the gRPC canonical status codes
+
+* \[18\] [https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto](https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto) -
+  status.proto
+
+* \[19\] [https://github.com/grpc/grpc/blob/master/include/grpcpp/support/error_details.h](https://github.com/grpc/grpc/blob/master/include/grpcpp/support/error_details.h)

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -402,7 +402,7 @@ P4 can be considered a behavioral description of a switching device which may or
 may not execute "P4" natively. There is no requirement that a P4 compiler be
 used in the production of either the P4 device config or the P4Info. There is no
 absolute requirement that the target accept a `SetForwardingPipelineRequest` to
-change its pipeline "program", as ome devices may be fixed in function.
+change its pipeline "program", as some devices may be fixed in function.
 Furthermore, it is not necessary to have a P4 source program to begin with,
 since the controller does not use it. From the standpoint of controller (not
 pipeline) implementers, the P4 source code is just helpful documentation. Some
@@ -1010,9 +1010,9 @@ PSA Action Profiles are used to describe implementations of match-action tables
 where multiple table entries can share the same action instance. Indeed,
 differently from a regular match-action table where each entry contains the
 action specification, when using Action Profile-based tables, the control plane
-can insert entries poiting to an Action Profile *member*, where each member then
-points to an action instance. The control plane is responsible for creating,
-modifying, or deleting members at runtime.
+can insert entries pointing to an Action Profile *member*, where each member
+then points to an action instance. The control plane is responsible for
+creating, modifying, or deleting members at runtime.
 
 PSA Action Selectors extend Action Profiles with the capability of bundling
 together multiple members into *groups*. Match-action table entries can point to
@@ -1807,7 +1807,7 @@ for a specific match key field is defined as follows:
 
 * For a `TERNARY` match, it is logically equivalent to a mask of zeros.
 
-* For a `LPM` match, it is logically equivalent to a prefix_len of zero.
+* For an `LPM` match, it is logically equivalent to a prefix_len of zero.
 
 * For a `RANGE` match, it is logically equivalent to a range which includes all
   possible values for the field.
@@ -3817,8 +3817,6 @@ dataplane.
 
 * The default action for indirect match tables is restricted to a `const
   NoAction` known at compile-time.
-
-# Acknowledgements
 
 # References
 

--- a/docs/v1/README.md
+++ b/docs/v1/README.md
@@ -62,15 +62,6 @@ build you can invoke the make.bat script.
 
 # TODO
 ## Formating Fixups TODO
-Following is a list of outstanding document formatting chores.  Some are left
-over as a result of converting from Google Docs to Madoko for the initial
-1.0.0-rc1 version. Others are Madoko-PDF rendering issues which may require
-hand-tweaking or workarounds.
-
-* Correct internal links e.g. to section references. Reference tags need to be
-  added to sections, and the links to them need to be replaced.
-* Surround `tokens` with backticks. All the Courier font formatting in the gDocs
-  was lost.
 
 ## Content TODO
 Following are major content items which are missing or incomplete:

--- a/docs/v1/p4.json
+++ b/docs/v1/p4.json
@@ -15,7 +15,7 @@
     "extraKeywords": [],
 
     "typeKeywords": [
-        "bool", "bit", "const", "enum", "entries", "error", "header", "header_union", "in", "inout", "int", "match_kind", "out", "tuple", "struct", "varbit", "void"
+        "bool", "bit", "const", "enum", "entries", "error", "header", "header_union", "in", "inout", "int", "match_kind", "out", "tuple", "struct", "varbit", "void", "type"
     ],
 
     "extraTypeKeywords": [],


### PR DESCRIPTION
I made sure that the formatting was somewhat uniform across the whole
document and I added backticks for inline code. I updated the README to
include some of the rules (arbitrary?) I tried to follow.

Fixes #26