### PR TITLE
Rename Bazel proto rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,41 +25,41 @@ internal_copied_filegroup(
 load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_library")
 
 cpp_proto_library(
-  name = "p4types_proto_cc",
+  name = "p4types_cc_proto",
   protos = ["p4/config/v1/p4types.proto"],
   with_grpc = False,
 )
 
 cpp_proto_library(
-  name = "p4info_proto_cc",
+  name = "p4info_cc_proto",
   protos = ["p4/config/v1/p4info.proto"],
-  proto_deps = [":p4types_proto_cc"],
+  proto_deps = [":p4types_cc_proto"],
   imports = ["external/com_google_protobuf/src/"],
   inputs = ["@com_google_protobuf//:well_known_protos"],
   with_grpc = False,
 )
 
 cpp_proto_library(
-  name = "p4data_proto_cc",
+  name = "p4data_cc_proto",
   protos = ["p4/v1/p4data.proto"],
   with_grpc = False,
 )
 
 cpp_proto_library(
-  name = "p4runtime_proto_cc",
+  name = "p4runtime_cc_proto",
   protos = ["p4/v1/p4runtime.proto"],
-  proto_deps = [":p4info_proto_cc", ":p4data_proto_cc",
-                "@com_github_googleapis//:status_proto_cc"],
+  proto_deps = [":p4info_cc_proto", ":p4data_cc_proto",
+                "@com_github_googleapis//:status_cc_proto"],
   imports = ["external/com_google_protobuf/src/"],
   inputs = ["@com_google_protobuf//:well_known_protos"],
   with_grpc = False,
 )
 
 cpp_proto_library(
-  name = "p4runtime_grpc_cc",
+  name = "p4runtime_cc_grpc",
   protos = ["p4/v1/p4runtime.proto"],
-  proto_deps = [":p4info_proto_cc", ":p4data_proto_cc",
-                "@com_github_googleapis//:status_proto_cc"],
+  proto_deps = [":p4info_cc_proto", ":p4data_cc_proto",
+                "@com_github_googleapis//:status_cc_proto"],
   imports = ["external/com_google_protobuf/src/"],
   inputs = ["@com_google_protobuf//:well_known_protos"],
   with_grpc = True,
@@ -67,18 +67,18 @@ cpp_proto_library(
 
 load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_compile")
 
-# For some reasom, status_proto_py needs to be includes in both deps and
+# For some reasom, status_py_proto needs to be includes in both deps and
 # inputs. If it is not listed in inputs, the Python file is not generated for
 # status.proto.
 py_proto_compile(
-  name = "p4runtime_proto_py",
+  name = "p4runtime_py_grpc",
   protos = ["p4/config/v1/p4types.proto",
             "p4/config/v1/p4info.proto",
             "p4/v1/p4data.proto",
             "p4/v1/p4runtime.proto"],
-  deps = ["@com_github_googleapis//:status_proto_py"],
+  deps = ["@com_github_googleapis//:status_py_proto"],
   imports = ["external/com_google_protobuf/src/"],
   inputs = ["@com_google_protobuf//:well_known_protos",
-            "@com_github_googleapis//:status_proto_py"],
+            "@com_github_googleapis//:status_py_proto"],
   with_grpc = True,
 )

--- a/bazel/external/googleapis.BUILD
+++ b/bazel/external/googleapis.BUILD
@@ -6,7 +6,7 @@ load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_library")
 load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_compile")
 
 cpp_proto_library(
-    name = "status_proto_cc",
+    name = "status_cc_proto",
     protos = ["google/rpc/status.proto"],
     imports = ["external/com_google_protobuf/src/"],
     inputs = ["@com_google_protobuf//:well_known_protos"],
@@ -14,8 +14,24 @@ cpp_proto_library(
 )
 
 py_proto_compile(
-    name = "status_proto_py",
+    name = "status_py_proto",
     protos = ["google/rpc/status.proto"],
+    imports = ["external/com_google_protobuf/src/"],
+    inputs = ["@com_google_protobuf//:well_known_protos"],
+    with_grpc = False,
+)
+
+cpp_proto_library(
+    name = "code_cc_proto",
+    protos = ["google/rpc/code.proto"],
+    imports = ["external/com_google_protobuf/src/"],
+    inputs = ["@com_google_protobuf//:well_known_protos"],
+    with_grpc = False,
+)
+
+py_proto_compile(
+    name = "code_py_proto",
+    protos = ["google/rpc/code.proto"],
     imports = ["external/com_google_protobuf/src/"],
     inputs = ["@com_google_protobuf//:well_known_protos"],
     with_grpc = False,

--- a/proto/README.md
+++ b/proto/README.md
@@ -13,9 +13,9 @@ load("@com_github_p4lang_p4runtime//bazel:rules.bzl", "p4runtime_proto_repositor
 p4runtime_proto_repositories()
 ```
 3. Use the provided targets:
-    1. `p4types_proto_cc`, `p4info_proto_cc`, `p4data_proto_cc` and
-    `p4runtime_proto_cc` for Protobuf C++ libraries.
-    2. `p4runtime_grpc_cc` for P4Runtime with gRPC.
+    1. `p4types_cc_proto`, `p4info_cc_proto`, `p4data_cc_proto` and
+    `p4runtime_cc_proto` for Protobuf C++ libraries.
+    2. `p4runtime_cc_grpc` for P4Runtime with gRPC.
 
 If you want to use different versions of Protbuf, gRPC and
 rules_protobuf, you will be on your own.


### PR DESCRIPTION
We use the following convention:
 * `foo_[lang]_proto` for proto libraries
 * `foo_[lang]_grpc` for proto libraries with gRPC support

We also add code_cc_proto target.