### PR TITLE
Use a new Docker image with soffice to build the spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 # protoc), then we generate the HTML for the spec.
 script:
   - docker run -t p4runtime-ci /p4runtime/CI/compile_protos.sh /tmp/
-  - docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/madoko-debian:sid-with-fonts make
+  - docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-madoko:latest make
 
 after_success:
   - ls docs/v1/build

--- a/docs/tools/Dockerfile.madoko
+++ b/docs/tools/Dockerfile.madoko
@@ -1,0 +1,11 @@
+FROM p4lang/madoko-debian:sid-with-fonts
+LABEL maintainer="P4 API Working Group <p4-dev@lists.p4.org>"
+LABEL description="Dockerfile used for building the Madoko specification"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    apt-get install -y --no-install-recommends libreoffice && \
+    apt-get autoremove --purge -y && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
+WORKDIR /usr/src/p4-spec

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,0 +1,18 @@
+Dockerfile.madoko is used to build a Docker image which we use to render the
+P4Runtime specification (HTML & PDF) in Travis CI. The image can also be used
+locally to build the specification without having to worry about installing all
+the dependencies yourself.
+
+Only maintainers of this repository need to build the Docker image when a new
+image needs to be pushed to dockerhub. Contributors to the specification can
+simply pull the image from dockerhub and don't have to worry about building the
+image themselves. If you are a maintainer and you need to upload a new version
+of the Docker image to to dockerhub, you will need the following commands:
+```bash
+docker build -t p4rt-madoko -f Dockerfile.madoko .
+docker tag p4rt-madoko p4lang/p4rt-madoko:latest
+docker push p4lang/p4rt-madoko:latest
+```
+
+Note that you need to have write permissions to the p4lang dockerhub repository
+to push the image (and you need to be logged in).

--- a/docs/v1/README.md
+++ b/docs/v1/README.md
@@ -23,9 +23,9 @@ Files:
 ## Building
 
 The easiest way to render the Madoko specification documentation is to use the
-`p4lang/madoko-debian:sid-with-fonts` Docker` image:
+`p4lang/p4rt-madoko:latest` Docker` image:
 
-    docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/madoko-debian:sid-with-fonts make
+    docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-madoko:latest make
 
 ### Linux
 ```


### PR DESCRIPTION
The new Docker image includes LibreOffice (which we plan on using to
convert the .odg files), which means it is larger than before.