### PR TITLE
Add reserved SDN port numbers to P4Runtime

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -4050,11 +4050,11 @@ out-of-band switch configuration mechanism - to use to translate between the SDN
 value and the dataplane value. The second argument is the bitwidth of the SDN
 representation of the translated entity (32-bit in the case of ports).
 
-Both PSA device port number 0 and SDN port number 0 are invalid. Any unicast
-packet with egress port 0 will be dropped in the PRE. A PSA device will define
-its CPU and recirculate ports in the device specific port number space.
-P4Runtime reserves device-independent and controller-specific 32-bit constants
-for the CPU port and the recirculate port as follows:
+An SDN port number of 0 is invalid (while 0 may be a valid device port number
+depending on the PSA device). A PSA device may define its CPU and recirculation
+ports in the device-specific port number space. P4Runtime reserves
+device-independent and controller-specific 32-bit constants for the CPU port and
+the recirculation port as follows:
 
 ~ Begin Proto
 enum SdnPort {
@@ -4072,6 +4072,11 @@ enum SdnPort {
   SDN_PORT_CPU = 0xFFFFFFFD;
 }
 ~ End Proto
+
+The switch config will map `SDN_PORT_RECIRCULATE` and `SDN_PORT_CPU` - as well
+as any SDN port number corresponding to a "regular" front-panel port - to the
+corresponding device-specific values, in order to enable the P4Runtime server to
+perform the translation.
 
 The sub-sections below detail the translation mechanics for different usage of
 PSA port types in P4 programs.
@@ -4188,7 +4193,7 @@ is used to implement fast-failover in the target, where the P4Runtime server can
 locally prune the member from the group if a port is down. This pruning does not
 require intervention from the controller. Conversely, if the port comes back up,
 the P4Runtime server can re-enable the member in the group. The watch field is
-of type uint32 to carry a 32-bit SDN number of the port being watched. The
+of type `uint32` to carry a 32-bit SDN number of the port being watched. The
 P4Runtime server will translate the given watch port number into the
 device-specific dataplane port number for implementing the fast-failover
 functionality on the target device.

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -400,8 +400,8 @@ message PacketReplicationEngineEntry {
 
 // Used for replicas created for cloning and multicasting actions.
 message Replica {
-  uint64 egress_port = 1;
-  uint64 instance = 2;
+  uint32 egress_port = 1;
+  uint32 instance = 2;
 }
 
 // The (egress_port, instance) pair must be unique for each replica in a given
@@ -411,7 +411,7 @@ message Replica {
 // each replica's egress input metadata will be set to the respective values
 // programmed in the multicast group entry.
 message MulticastGroupEntry {
-  uint64 multicast_group_id = 1;
+  uint32 multicast_group_id = 1;
   repeated Replica replicas = 2;
 }
 
@@ -429,10 +429,10 @@ message MulticastGroupEntry {
 // packet_length_bytes field is 0, no truncation on the clone(s) will be
 // performed.
 message CloneSessionEntry {
-  uint64 session_id = 1;
+  uint32 session_id = 1;
   repeated Replica replicas = 2;
-  uint64 class_of_service = 3;
-  uint64 packet_length_bytes = 4;
+  uint32 class_of_service = 3;
+  int32 packet_length_bytes = 4;
 }
 
 //------------------------------------------------------------------------------
@@ -665,4 +665,19 @@ message Error {
   // Optional: Allows reporting back additional target-specific details on the
   // error.
   google.protobuf.Any details = 5;
+}
+
+//------------------------------------------------------------------------------
+// Reserved controller-specified SDN port numbers for reference.
+enum SdnPort {
+  SDN_PORT_UNKNOWN = 0;
+  // SDN ports are numbered starting form 1.
+  SDN_PORT_MIN = 1;
+  // 0xFFFFFEFF: The maximum value of an SDN port (physical or logical).
+  SDN_PORT_MAX = -257;
+  // Reserved SDN port numbers (0xFFFFFF00 - 0xFFFFFFFF)
+  // 0xFFFFFFFA: Recirculate the packet back to ingress
+  SDN_PORT_RECIRCULATE = -6;
+  // 0xFFFFFFFD: Send to CPU
+  SDN_PORT_CPU = -3;
 }


### PR DESCRIPTION
Also fixed the Protobuf type for some standard (translated) PSA metadata
entities, such as multicast group id. The Protobuf type is determined by
the bitwidth of the translated type. It is somewhat independent of the
corresponding PSA InHeader_t types.

Fixes #49
Fixes #51