### PR TITLE
Remove meter color-awareness information from P4Info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 # We check that the P4Runtime Protobuf files are correct (by compiling them with
 # protoc), then we generate the HTML for the spec.
 script:
-  - docker run -t p4runtime-ci /p4runtime/CI/compile_protos.sh /tmp/
+  - docker run -t p4runtime-ci /p4runtime/CI/compile_protos.sh /tmp/ || travis_terminate 1
   - docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-madoko:latest make
 
 after_success:

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1152,20 +1152,13 @@ Both `Meter` and `DirectMeter` messages share the following fields:
   extern instance.
 
 * `spec`, a message of type `MeterSpec` used to describe the capabilities of
-  this meter extern instance. The `MeterSpec` message defines the following
-  fields:
-
-    * `unit`, the meter rate unit, whose value can be any of the
-      `MeterSpec.Unit` enum:
-        * `UNSPECIFIED`: reserved value.
-        * `BYTES`, which signifies that this meter can be configured with rates
-          expressed in bytes/second.
-        * `PACKETS`, for rates expressed in packets/second.
-
-    * `type`, the type of meter according to RFC 2698, color-blind or
-      color-aware.  The value can be any of the `MeterSpec.Type` enum:
-        * `COLOR_UNAWARE` for a color-blind meter.
-        * `COLOR_AWARE` for a color-aware meter.
+  this meter extern instance. Currently, the `MeterSpec` message is used to
+  carry only the meter unit, which can be any of the `MeterSpec.Unit` enum
+  values:
+    * `UNSPECIFIED`: reserved value.
+    * `BYTES`, which signifies that this meter can be configured with rates
+      expressed in bytes/second.
+    * `PACKETS`, for rates expressed in packets/second.
 
 For indexed meters, the `Meter` message contains also a `size` field, an `int64`
 representing the maximum number of independent cells that can be held by this
@@ -2806,10 +2799,10 @@ entity for each of the instances, specifying the `counter_id` and
 Meters are an advanced mechanism for keeping statistics, involving stateful
 "marking" and usually "throttling" of packets based on configured rates of
 traffic. The PSA metering function is based on the *Two Rate Three Color Marker*
-(trTCM) defined in RFC 2698. The trTCM meters an arbitrary packet stream using
-two configured rates - the Peak Information Rate (PIR) and Committed Information
-Rate (CIR), and their associated burst sizes - and "marks" its packets as GREEN,
-YELLOW or RED based on the observed rate.
+(trTCM) defined in RFC 2698 [@RFC2698]. The trTCM meters an arbitrary packet
+stream using two configured rates - the Peak Information Rate (PIR) and
+Committed Information Rate (CIR), and their associated burst sizes - and "marks"
+its packets as GREEN, YELLOW or RED based on the observed rate.
 
 A meter may be configured as a direct or indirect instance, similar to a
 counter. The `MeterConfig` P4Runtime message represents meter configuration.

--- a/docs/v1/references.bib
+++ b/docs/v1/references.bib
@@ -121,3 +121,8 @@
     title = "Semantic versioning",
     url = "https://semver.org/"
 }
+
+@ONLINE { RFC2698,
+    title = "A Two Rate Three Color Marker",
+    url = "https://tools.ietf.org/html/rfc2698"
+}

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -249,12 +249,13 @@ message ActionProfile {
 }
 
 message CounterSpec {
-  // Corresponds to 'type' attribute for counter in P4 spec.
+  // Corresponds to 'type' constructor parameter for Counter / DirectCounter in
+  // PSA
   enum Unit {
     UNSPECIFIED = 0;
     BYTES = 1;
     PACKETS = 2;
-    BOTH = 3;  // not part of the P4 spec yet but will be in the future
+    BOTH = 3;
   }
   Unit unit = 1;
 }
@@ -274,19 +275,13 @@ message DirectCounter {
 }
 
 message MeterSpec {
-  // Corresponds to 'type' attribute for meter in P4 spec.
+  // Corresponds to 'type' constructor parameter for Meter / DirectMeter in PSA
   enum Unit {
     UNSPECIFIED = 0;
     BYTES = 1;
     PACKETS = 2;
   }
-  // Not part of the P4 spec yet but will be in the future.
-  enum Type {
-    COLOR_UNAWARE = 0;  // default value
-    COLOR_AWARE = 1;
-  }
   Unit unit = 1;
-  Type type = 2;
 }
 
 message Meter {


### PR DESCRIPTION
There doesn't seem to be any point in keeping this in P4Info at the
moment. First the semantics are murky because in PSA each execute call
on a meter is either color-aware or color-blind (i.e. it is not an
attribute of the meter object itself). Second, at the moment this
information cannot be leveraged in any way by a P4 client since
P4Runtime does not expose any knob to enable / disable color-awareness
on a per meter entry basis at runtime. Even if there was such a knob, it
would be hard to reconciliate it with PSA semantics: in PSA the same
meter can be "executed" in 2 different actions, in color-aware mode in
one and in color-blind mode in the other; these 2 action can use the
same indirect meter entry.

Fixes #58