### PR TITLE
Move to canonical representation for serializable enums

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1881,11 +1881,15 @@ therefore use a human-readable string in `P4Data` to represent `enum` and
 `error` values.
 
 Serializable `enum` types have an underlying fixed-width unsigned integer
-representation (`bit<W>`). Integer values must be assigned to each member entry
-by the P4 programmer. `P4TypeInfo` includes the mapping between entry name and
-entry value. When providing serializable enum values through `P4Data`, one can
-either use the enum entry's name (`enum` human-readable string field) or its
-assigned value (`enum_value` bytestring field).
+representation (`bit<W>`). All named enum members must be assigned an integer
+value by the P4 programmer, but *not all* valid numeric values for the
+underlying type need to have a corresponding name. `P4TypeInfo` includes the
+mapping between entry name and entry value. When providing serializable enum
+values through `P4Data`, one must use the assigned integer value (`enum_value`
+bytestring field). P4Runtime does not provide a way for the client to use the
+name - even when the enum member has one - instead of the value, as it makes it
+easier for the server to respect the [read-write
+symmetry](#sec-read-write-symmetry) principle.
 
 ### User-defined types { #sec-user-defined-types}
 

--- a/proto/p4/v1/p4data.proto
+++ b/proto/p4/v1/p4data.proto
@@ -27,7 +27,7 @@ message P4Data {
     P4HeaderUnion header_union = 7;
     P4HeaderStack header_stack = 8;
     P4HeaderUnionStack header_union_stack = 9;
-    string enum = 10;  // can be used for all enums, serializable or not
+    string enum = 10;  // safe (non-serializable) enums only
     string error = 11;
     bytes enum_value = 12;  // serializable enums only
   }


### PR DESCRIPTION
In order to facilitate read-write symmetry. If we only have one valid
representation, it needs to be the bitvector one, as not all possible
numeric values have to be named.

Fixes #64