### PR TITLE
Typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It is updated every time a new commit is pushed to the master branch.
 
 ## Overview
 P4 is a language for programming the data plane of network devices. The
-P4Runtime API is a control-plane specification for controlling the data plane
+P4Runtime API is a control plane specification for controlling the data plane
 elements of a device or program defined by a P4 program. This repository
 provides a precise definition of the P4Runtime API via protobuf (.proto) files
 and accompanying documentation. The target audience for this includes system

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -203,12 +203,12 @@ prototext {
 [TITLE]
 
 ~ Begin Abstract
-P4 is a language for programming the data plane of network
-devices. The P4Runtime API is a control plane specification for controlling the
-data plane elements of a device or program defined by a P4 program. This
-document provides a precise definition of the P4Runtime API. The target audience
-for this document includes developers who want to write controller applications
-for P4 devices or switches.
+P4 is a language for programming the data plane of network devices. The
+P4Runtime API is a control plane specification for controlling the data plane
+elements of a device defined or described by a P4 program. This document
+provides a precise definition of the P4Runtime API. The target audience for this
+document includes developers who want to write controller applications for P4
+devices or switches.
 ~ End Abstract
 
 [TOC]
@@ -245,7 +245,7 @@ P4Runtime:
 * Runtime control of architecture-specific (non-PSA) externs, through an
   extension mechanism.
 * Basic session management for Software-Defined Networking (SDN) use-cases,
-  including support for controller replication to enable control-plane
+  including support for controller replication to enable control plane
   redundancy.
 * Partition of the P4 forwarding elements into different roles, which can be
   assigned to different control entities.
@@ -272,7 +272,7 @@ The following are not in scope of P4Runtime:
   [@OpenConfig]. An open source implementation of these APIs is also in progress
   as part of the Stratum project [@Stratum].
 * Protobuf message definitions for runtime control of non-PSA externs. While
-  P4Runtime includes an extension mechanism to support addditional P4
+  P4Runtime includes an extension mechanism to support additional P4
   architectures, it does not define the syntax or semantics of any additional
   control message for externs introduced by non-PSA architectures.
 
@@ -517,8 +517,8 @@ is not intended for SDN use-cases.
 
 P4Runtime was designed to be a viable embedded API. Complex controller
 architectures typically feature multiple processes communicating with some sort
-of IPC (Inter-Process Communications). P4Runtime is thus both an ideal RPC and an
-IPC.
+of IPC (Inter-Process Communications). P4Runtime is thus both an ideal RPC and
+an IPC.
 
 ~ Figure { #fig-single-embedded-controller; \
 caption: "Use-Case: Single Embedded Controller" }
@@ -604,7 +604,7 @@ reasons:
 
 1. Partitioning of the control plane: Multiple controllers may have orthogonal,
    non-overlapping, "roles" (or "realms") and should be able to push forwarding
-   entitites simultaneously. The control plane can be partitioned into multiple
+   entities simultaneously. The control plane can be partitioned into multiple
    roles and each role will have a set of controllers, one of which is the
    master and the rest are slaves. Role definition, &ie; how P4 entities get
    assigned to each role, is **out-of-scope** of this document.
@@ -893,7 +893,7 @@ encodes the object type (as per Table [#tab-mapping-p4-obj-ids]). The
 p4info.proto file includes a mapping from object type to 8-bit prefix value,
 encoded as an enum definition (`p4.config.v1.P4Ids.Prefix`). These values must
 be used (&eg; by the compiler) when allocating IDs. The remaining 24-bits must
-be generated in such a way that the resultings IDs must be globally unique in
+be generated in such a way that the resulting IDs must be globally unique in
 the scope of the P4Info message. Table [#tab-format-p4-obj-ids] shows the ID
 layout.
 
@@ -1378,7 +1378,7 @@ The `Digest` message defines the following fields:
 
 `Extern` messages are used to specify all extern instances across all extern
 types for a non-PSA architecture. This is useful when extending P4Runtime to
-support a new architetcure. Each architecture-specific extern type corresponds
+support a new architecture. Each architecture-specific extern type corresponds
 to at most one `Extern` message instance in P4Info. The `Extern` message defines
 the following fields:
 
@@ -1437,7 +1437,7 @@ This message is the output of the P4 compiler and is target-agnostic.
 
 The `p4_device_config` is opaque binary data which contains the target-specific
 configuration to realize the P4 program. The P4 program running on a target is
-changed by loading a new `FowardingPipelineConfig` on that target.
+changed by loading a new `ForwardingPipelineConfig` on that target.
 
 The `cookie` field is opaque data which may be used by a control plane to
 uniquely identify a forwarding-pipeline configuration among others managed by
@@ -1950,15 +1950,15 @@ distinction in the P4Info message, in particular for the purposes of
 declaration can be annotated with `@p4runtime_translation` to indicate that the
 type exposed to the P4Runtime client is different from the original P4 type. One
 important use-case is for [port numbers](#sec-translation-of-port-numbers),
-whose underlying dataplane representation may vary on different targets, but for
-which it may be convenient to present a unified representation and numbering
-scheme to the control-plane. **The `@p4runtime_translation` annotation can only
+whose underlying data plane representation may vary on different targets, but
+for which it may be convenient to present a unified representation and numbering
+scheme to the control plane. **The `@p4runtime_translation` annotation can only
 be used if the underlying P4 built-in type is a fixed-width unsigned bitstring
-type (`bit<W>`)** and the type exposed to the control-plane will also be a
+type (`bit<W>`)** and the type exposed to the control plane will also be a
 fixed-width unsigned bitstring, with a potentially different bitwidth. It takes
 two parameters: a *URI* (Uniform Resource Identifier) which uniquely identifies
 the translation being performed on entities of the new type to the P4Runtime
-server and the *bitwidth* of the bitstring type exposed to the control-plane. It
+server and the *bitwidth* of the bitstring type exposed to the control plane. It
 is recommended that the URI includes at least the P4 architecture name and the
 type name.
 
@@ -2405,7 +2405,7 @@ P4Runtime support reading and writing direct resources as part of the
   and configure the direct resources in an atomic fashion if supported. When the
   table has a direct meter, this may help guarantee that the lifetime of the
   meter entry is the same as the lifetime of the table entry, and that there is
-  no time gap during which dataplane traffic can "hit" the table entry without
+  no time gap during which data plane traffic can "hit" the table entry without
   executing the appropriate meter entry.
 
 Once the table entry has been inserted, the P4Runtime client is free to use the
@@ -2511,7 +2511,7 @@ conditions is met:
 * `time_since_last_hit` is set
 
 The target should do its best to approximate the `idle_timeout_ns` value
-provided by the client. For example, most targets may not be able to accomodate
+provided by the client. For example, most targets may not be able to accommodate
 arbitrarily small values of TTL, in which case they should use the smallest
 value they can support, rather than reject the TableEntry write with an error
 code. Similarly, each target should do its best to provide reasonably-accurate
@@ -2807,7 +2807,7 @@ action selector implementations [@PSAActionSelector]:
 For 1., if a client tries to `INSERT` or `MODIFY` a group with members bound to
 different actions, the server should return `UNIMPLEMENTED` if not supported by
 the target. This applies to the one shot style of programming as well. We
-recommend that control-plane implementations take into account this possible
+recommend that control plane implementations take into account this possible
 limitation and be designed so as not to rely on this feature for the sake of
 portability.
 
@@ -3069,9 +3069,9 @@ supported as follows:
 
 The PSA Packet Replication Engine (PRE) is an extern that is implicitly
 instantiated in all PSA programs. The PRE is responsible for implementing
-multicasting and cloning functionality in the dataplane. P4Runtime defines an
+multicasting and cloning functionality in the data plane. P4Runtime defines an
 API to program the PRE with multicast groups and clone sessions to allow
-replication of dataplane packets.
+replication of data plane packets.
 
 ### `MulticastGroupEntry`
 
@@ -3079,9 +3079,9 @@ Multicasting is achieved in PSA programs by setting the `multicast_group`
 ingress output metadata to a non-zero identifier. The number of replicas and
 their egress ports for the multicast group is programmed at runtime by the
 client using the `MulticastGroupEntry` API in P4Runtime. The following P4
-program illustrates a possible dataplane behavior of multicasting ARP packets in
-the ingress. Note that the dataplane type of the multicast group metadata is 10
-bits on the PSA device in this example.
+program illustrates a possible data plane behavior of multicasting ARP packets
+in the ingress. Note that the data plane type of the multicast group metadata is
+10 bits on the PSA device in this example.
 
 ~ Begin P4Example
 control arp_multicast(inout H hdr, inout M smeta) {
@@ -3102,7 +3102,7 @@ type: INSERT
 entity {
   packet_replication_engine_entry {
     multicast_group_entry {
-      muticast_group_id : 1
+      multicast_group_id : 1
       replicas { egress_port : 5 instance: 1 }
       replicas { egress_port : 12 instance: 2 }
       replicas { egress_port : 18 instance: 3 }
@@ -3146,7 +3146,7 @@ semantics.
   here.
 * `DELETE`: Delete the multicast group indexed by the given
   `multicast_group_id`. The replicas need not be provided for this
-  operation. Any packets with their `multicast_group` metadata in the dataplane
+  operation. Any packets with their `multicast_group` metadata in the data plane
   set to the deleted `multicast_group_id` will be dropped.
 
 ### `CloneSessionEntry`
@@ -3154,7 +3154,7 @@ semantics.
 PSA supports cloning of packets in both the ingress and egress pipeline. Ingress
 cloning creates a mirror of the packet as seen in the beginning of the ingress
 pipeline, while egress cloning creates a mirror of the packet as seen at the end
-of the egress pipeline. A packet is cloned in the dataplane by setting a
+of the egress pipeline. A packet is cloned in the data plane by setting a
 `clone_session_id` identifier and a boolean flag `clone` in the packet
 metadata. The `clone_session_id` serves as a handle to the clone attributes,
 namely a set `replicas` of `(egress port, instance)` pairs to which
@@ -3162,8 +3162,8 @@ cloned packets should be sent, a packet length, and class of
 service. These are programmed at runtime via the P4Runtime
 `CloneSessionEntry` API.
 
-The following P4 program illustrates a possible dataplane behavior of sending
-clones of low TTL packets to the CPU for monitoring. Note that the dataplane
+The following P4 program illustrates a possible data plane behavior of sending
+clones of low TTL packets to the CPU for monitoring. Note that the data plane
 type of the clone session metadata is 10 bits on the PSA device in this example.
 We assume that the `clone_low_ttl` control block is applied in the ingress
 pipeline to create and ingress-to-egress clone.
@@ -3201,7 +3201,7 @@ entity {
 As a result of the above P4Runtime programming, the target device will create
 one replica of a low TTL packet from the ingress to the egress. Note that the
 clone session ID of the programmed PRE entry is identical to the value used in
-the dataplane in this example (no numerical translation, which is the default
+the data plane in this example (no numerical translation, which is the default
 for values of type `CloneSessionId_t` [@PSATranslation]). The clone will be
 treated for scheduling in the PRE with a class of service value of 2. If the
 packet is larger than 4096 bytes, it will be truncated to carry at most 4096
@@ -3240,7 +3240,7 @@ semantics:
   given `clone_session_id`. Same restrictions as `INSERT` apply here.
 * `DELETE`: Delete the clone session indexed by the given
   `clone_session_id`. Other fields need not be provided for this operation. Any
-  packet with their `clone_session_id` metadata in the dataplane set to the
+  packet with their `clone_session_id` metadata in the data plane set to the
   deleted `session_id` will no longer be cloned.
 
 ## `ValueSetEntry`
@@ -3384,7 +3384,7 @@ A server should buffer digest messages until either:
 * `max_timeout_ns` time has passed since the first digest message was added to
   the empty buffer, or
 * `max_list_size` *distinct* digest messages have been received from the
-  dataplane and added to the buffer
+  data plane and added to the buffer
 
 At which point the server must generate a `DigestList` stream message with the
 buffer contents and send it to the master client. All the messages in a digest
@@ -3531,7 +3531,7 @@ value for the canonical error code based on best practices [@gRPCStatusCodes].
 
 Figure [#fig-error-report] illustrates how these messages fit together.
 
-~ Figure { #fig-error-report; caption: "P4Runtime Error Report Mesage Format" }
+~ Figure { #fig-error-report; caption: "P4Runtime Error Report Message Format" }
 ![error-report]
 ~
 [error-report]: build/error-report.[svg,png] { width: 70%; page-align: here }
@@ -3546,24 +3546,24 @@ Please see sections on individual P4Runtime RPCs for details on how
 # Atomicity of Individual `Write` and `Read` Operations
 
 Each individual entity in a batch is guaranteed to be read or written atomically
-relative to packet forwarding. For example, for every table dataplane `apply`
+relative to packet forwarding. For example, for every table data plane `apply`
 operation, and every single `Write` operation on a table that inserts, deletes,
 or modifies one table entry, the `apply` operation should behave as if that
 `Write` operation has not yet occurred, or as if the `Write` operation is
 complete. The P4 program should never behave as if the `Write` operation is
 partially complete. These guarantees also apply to extern instances: `Read` and
 `Write` operations on extern entities must execute atomically relative to extern
-dataplane methods.
+data plane methods.
 
 The atomicity guarantees provided by P4Runtime for individual `Read` and `Write`
 operations are the same as the guarantees required by PSA and are described in
 details in the PSA specification [@PSAAtomicityOfControlPlaneOps].
 
 The P4~16~ language introduces an `@atomic` annotation [@P4Concurrency], to
-guarantee atomic dataplane execution of entire blocks of P4 code. P4Runtime
+guarantee atomic data plane execution of entire blocks of P4 code. P4Runtime
 implementations are required to honor the `@atomic` annotation for `Write`
 operations, as well as [non-wildcard `Read` operations](#wildcard-reads),
-relative to dataplane execution. Consider the following P4 example written for
+relative to data plane execution. Consider the following P4 example written for
 PSA:
 
 ~ Begin P4Example
@@ -3584,7 +3584,7 @@ control C1 {
 ~ End P4Example
 
 If a P4Runtime server is processing messages which write to Register `r1` at
-index `1`, these writes must not happen between the dataplane `read` and
+index `1`, these writes must not happen between the data plane `read` and
 `write`.
 
 Now let's consider the following example:
@@ -3754,34 +3754,34 @@ enum. A P4Runtime server is required to support only the modes marked as
 
 * *Required*: `CONTINUE_ON_ERROR`: This is the default behavior and the default
   enum value. Each operation within the batch must be attempted even if one or
-  more encounter errors. Every dataplane packet is guaranteed to be processed
+  more encounter errors. Every data plane packet is guaranteed to be processed
   according to table contents as they are between two individual operations of
   the batch, but there could be several packets processed that *see* each of
   these intermediate stages.
 
 * *Optional*: `ROLLBACK_ON_ERROR`: Operations within the batch are attempted in
-  an arbitrary order (each committed to dataplane) until the target detects an
+  an arbitrary order (each committed to data plane) until the target detects an
   error. At this point, the target must roll back the operations such that both
-  software and dataplane state is consistent with the state before the batch was
-  attempted. The resulting behavior is *all-or-none*, except the batch is not
-  atomic from a data plane point of view. Every dataplane packet is guaranteed
-  to be processed according to table contents as they are between two individual
-  operations of the batch, but there could be several packets processed that
-  *see* each of these intermediate stages. The details and design of the
-  rollback mechanism are outside the scope of this specification. One
+  software and data plane state is consistent with the state before the batch
+  was attempted. The resulting behavior is *all-or-none*, except the batch is
+  not atomic from a data plane point of view. Every data plane packet is
+  guaranteed to be processed according to table contents as they are between two
+  individual operations of the batch, but there could be several packets
+  processed that see* each of these intermediate stages. The details and design
+  of the rollback mechanism are outside the scope of this specification. One
   possibility is to create a shadow copy of both the software and hardware state
   at the start, and restore it upon failure.
 
   If this option is not supported, an `UNIMPLEMENTED` error is returned.
 
 * *Optional*: `DATAPLANE_ATOMIC`: This is the strictest requirement where the
-  entire batch must be atomic from a dataplane point of view. Every dataplane
+  entire batch must be atomic from a data plane point of view. Every data plane
   packet is guaranteed to be processed according to table contents before the
   batch began, or after the batch completes. The batch is therefore treated as a
-  *transaction*. The details and design of how to achieve dataplane-atomicity is
+  transaction*. The details and design of how to achieve data plane-atomicity is
   outside the scope of this specification. One possibility is to limit the
-  target to half of the dataplane's table capacity at all times. At the start of
-  the batch processing, the remaining half of the table capacity can be
+  target to half of the data plane's table capacity at all times. At the start
+  of the batch processing, the remaining half of the table capacity can be
   initialized with the current table state and used as a working area to commit
   all operations within the batch. At the end (if there were no errors), a
   simple pointer-swap like approach can be used to switch to this half of the
@@ -3790,7 +3790,7 @@ enum. A P4Runtime server is required to support only the modes marked as
   If a P4Runtime server does not support this option at all, an `UNIMPLEMENTED`
   error is returned at all times. If a P4Runtime supports some batches in an
   atomic way but not others, an `UNIMPLEMENTED` error is returned when the batch
-  cannot be executed in a dataplane-atomic way.
+  cannot be executed in a data plane-atomic way.
 
 There is no expectation that a given batch must always use the same `Atomicity`
 enum value. At any given time, the client is free to compose batches and assign
@@ -3972,7 +3972,7 @@ multi-reader lock (also known as multiple-readers/single-writer lock).
 Conversely (&eg; in a single-threaded architecture), it may choose to serialize
 `Read` RPC processing.
 
-# `SetForwadingPipelineConfig` RPC
+# `SetForwardingPipelineConfig` RPC
 
 A P4Runtime client may configure the P4Runtime target with a new P4 pipeline by
 invoking the `SetForwardingPipelineConfig RPC`. The request is defined as:
@@ -4099,19 +4099,19 @@ message GetForwardingPipelineConfigResponse {
 
 If a P4Runtime server is in a state where the forwarding-pipeline config is not
 known, the top-level `config` field will be unset in the response. Examples are
-(i) a server that only allows configuration via `SetFowardingPipelineConfig` but
-this RPC hasn't been invoked yet, (ii) a server that is configured using a
-different mechanism but this configuration hasn't yet occured.
+(i) a server that only allows configuration via `SetForwardingPipelineConfig`
+but this RPC hasn't been invoked yet, (ii) a server that is configured using a
+different mechanism but this configuration hasn't yet occurred.
 
 Once a forwarding-pipeline config is installed on the device (either via
-`SetFowardingPipelineConfig` or a different mechanism), some P4Runtime servers
+`SetForwardingPipelineConfig` or a different mechanism), some P4Runtime servers
 may not support retrieval of the target-dependent config, in which case
 `config.p4_device_config` will be empty / unset in the response, even if
 `response_type` in the request was set to `ALL`. However, all P4Runtime servers
 are required to return the P4Info in this scenario. Similarly, if a cookie was
 present in the `SetForwardingPipelineConfig` RPC, the same should be returned
 when reading the config. If the config is installed with a mechanism other than
-`SetFowardingPipelineConfig`, the value of `config.cookie` will be unset.
+`SetForwardingPipelineConfig`, the value of `config.cookie` will be unset.
 
 If a P4Runtime server supports both `SetForwardingPipelineConfig` as well as
 returning the `p4_device_config`, there should be read-write symmetry between
@@ -4310,7 +4310,7 @@ Architectures](#sec-extending-p4runtime) for more information.
 ## PSA Metadata Translation { #sec-psa-metadata-translation}
 
 The *Portable Switch Architecture* (PSA) defines standard metadata, whose
-dataplane types are different on different PSA targets. In order to enable
+data plane types are different on different PSA targets. In order to enable
 uniform programming of multiple PSA targets, a centralized remote controller may
 define its own types and numbering of such PSA standard metadata
 [@PSATranslation]. For such metadata, a translation between the controller's
@@ -4320,7 +4320,7 @@ metadata, although the same translation principles apply to other standard PSA
 metadata such as class of service.
 
 ~ Figure { #fig-psa-metadata-translation; \
-caption: "P4Runtime Metadata Translation for the Portable Switch Architeccture" }
+caption: "P4Runtime Metadata Translation for the Portable Switch Architecture" }
 ![psa-metadata-translation]
 ~
 [psa-metadata-translation]: build/psa-metadata-translation.[svg,png] \
@@ -4346,7 +4346,7 @@ action parameter or header field) as being a PSA port metadata type. For this
 purpose, PSA defines the port metadata field type using special [user-defined P4
 types](#sec-user-defined-types), namely `PortId_t` and `PortIdInHeader_t`,
 instead of standard P4 bitstrings. The P4Info for all P4 entities of the special
-PSA port types use a controller-defined 32-bit type instead of the dataplane
+PSA port types use a controller-defined 32-bit type instead of the data plane
 bitwidth defined in the P4 program. The following PSA port metadata types are
 defined in *psa.p4* for the PSA device in Switch 1.
 
@@ -4360,7 +4360,7 @@ type PortIdInHeader_t bit<32>;
 The first argument to the `@p4runtime_translation` annotation is a URI that
 indicates to the P4Runtime server which numerical mapping - provided by the
 out-of-band switch configuration mechanism - to use to translate between the SDN
-value and the dataplane value. The second argument is the bitwidth of the SDN
+value and the data plane value. The second argument is the bitwidth of the SDN
 representation of the translated entity (32-bit in the case of ports).
 
 An SDN port number of 0 is invalid (while 0 may be a valid device port number
@@ -4421,7 +4421,7 @@ port value into the device-specific port value from the mapping provided in the
 out-of-band switch configuration (the mapping can be identified using the
 translation URI - first argument to the `@p4runtime_translation`
 annotation). Any subsequent reference to the `egress_port` field in the
-dataplane will use the translated value. `PortIdInHeader_t` is used in the
+data plane will use the translated value. `PortIdInHeader_t` is used in the
 header definition instead of `PortId_t` to guarantee byte-aligned headers in
 case this is required by the target.
 
@@ -4454,11 +4454,11 @@ table t {
 Table `t` has an exact match on PSA standard metadata ingress port
 (`istd.ingress_port`). Since the field is of type `PortId_t`, the P4Info
 representation of the match field will present a 32-bit bitwidth to the
-controller, regardless of the dataplane port type. A P4Runtime write request
+controller, regardless of the data plane port type. A P4Runtime write request
 for a table entry in `t` from the controller will have the values of the match
 field set to the controller-specific port value. The P4Runtime server should
 intercept the write request and use the switch configuration data to translate
-the SDN port value to respective device-specific value. In the dataplane, the
+the SDN port value to respective device-specific value. In the data plane, the
 packet metadata will carry the device-specific value and, hence, match the right
 table entry. Similarly, when a read response for table `t` is returned to the
 controller, the P4Runtime server should translate the device-specific port
@@ -4508,14 +4508,14 @@ require intervention from the controller. Conversely, if the port comes back up,
 the P4Runtime server can re-enable the member in the group. The watch field is
 of type `uint32` to carry the 32-bit SDN representation of the port being
 watched. The P4Runtime server will translate the given watch port number into
-the device-specific dataplane port number for implementing the fast-failover
+the device-specific data plane port number for implementing the fast-failover
 functionality on the target device.
 
 The Packet Replication Engine (PRE) API in P4Runtime supports cloning and
 multicasting to a set of ports. The egress port fields defined in the PRE
 multicast entry and clone session entry are of type `uint32` to carry the 32-bit
 SDN port number(s). The P4Runtime server will translate these SDN port numbers
-to device-specific port numbers for multicasting and cloning in the dataplane.
+to device-specific port numbers for multicasting and cloning in the data plane.
 
 # P4Runtime Versioning
 
@@ -4632,7 +4632,7 @@ message MyNewPacketCounter {
 Just like *p4info-ext*, *p4runtime-ext* should include a Protobuf message
 definition for every extern type that can be controlled at runtime. This message
 should include the extern-specific parameters defining the read or write
-operation to be peformed by the P4Runtime server on the corresponding extern
+operation to be performed by the P4Runtime server on the corresponding extern
 instance. Instances of this architecture-specific message are meant to be
 embedded in an [`ExternEntry`](#sec-extern-entry) message generated by the
 P4Runtime client.

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -41,7 +41,8 @@ message P4Info {
 message Documentation {
   // A brief description of something, e.g. one sentence
   string brief = 1;
-  // A more verbose description of something. Multiline is accepted. Markup format (if any) is TBD.
+  // A more verbose description of something. Multiline is accepted. Markup
+  // format (if any) is TBD.
   string description = 2;
 }
 
@@ -162,7 +163,7 @@ message MatchField {
   }
   oneof match {
     MatchType match_type = 5;
-    // used for achitecture-specific match types which are not part of the core
+    // used for architecture-specific match types which are not part of the core
     // P4 language or of the PSA architecture.
     string other_match_type = 7;
   }

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -33,11 +33,11 @@ service P4Runtime {
   rpc Read(ReadRequest) returns (stream ReadResponse) {
   }
 
-  // Sets the P4 fowarding-pipeline config.
+  // Sets the P4 forwarding-pipeline config.
   rpc SetForwardingPipelineConfig(SetForwardingPipelineConfigRequest)
       returns (SetForwardingPipelineConfigResponse) {
   }
-  // Gets the current P4 fowarding-pipeline config.
+  // Gets the current P4 forwarding-pipeline config.
   rpc GetForwardingPipelineConfig(GetForwardingPipelineConfigRequest)
       returns (GetForwardingPipelineConfigResponse) {
   }
@@ -68,24 +68,24 @@ message WriteRequest {
   repeated Update updates = 4;
   enum Atomicity {
     // Required. This is the default behavior. The batch is processed in a
-    // non-atomic manner from a dataplane point of view. Each operation within
+    // non-atomic manner from a data plane point of view. Each operation within
     // the batch must be attempted even if one or more encounter errors.
-    // Every dataplane packet is guaranteed to be processed according to
+    // Every data plane packet is guaranteed to be processed according to
     // table contents as they are between two individual operations of the
     // batch, but there could be several packets processed that see each of
     // these intermediate stages.
     CONTINUE_ON_ERROR = 0;
-    // Optional. Operations within the batch are committed to dataplane until
+    // Optional. Operations within the batch are committed to data plane until
     // an error is encountered. At this point, the operations must be rolled
-    // back such that both software and dataplane state is consistent with the
+    // back such that both software and data plane state is consistent with the
     // state before the batch was attempted. The resulting behavior is
     // all-or-none, except the batch is not atomic from a data plane point of
-    // view. Every dataplane packet is guaranteed to be processed according to
+    // view. Every data plane packet is guaranteed to be processed according to
     // table contents as they are between two individual operations of the
     // batch, but there could be several packets processed that see each of
     // these intermediate stages.
     ROLLBACK_ON_ERROR = 1;
-    // Optional. Every dataplane packet is guaranteed to be processed according
+    // Optional. Every data plane packet is guaranteed to be processed according
     // to table contents before the batch began, or after the batch completed
     // and the operations were programmed to the hardware.
     // The batch is therefore treated as a transaction. 
@@ -156,7 +156,7 @@ message TableEntry {
   // the match fields is Ternary or Range.
   // A higher number indicates higher priority.
   // Only the highest priority entry that matches the packet must be selected.
-  // Given an existing entry with prority k, if the controller tries to insert
+  // Given an existing entry with priority k, if the controller tries to insert
   // or modify another entry with priority k such that a packet may match both
   // entries, an error is returned. This will be the case if the overlap is
   // strict (entries are identical) or not.
@@ -201,10 +201,10 @@ message TableEntry {
   int64 idle_timeout_ns = 9;
   message IdleTimeout {
     // Time elapsed - in nanoseconds - since the table entry was last "hit" as
-    // part of a dataplane table lookup.
+    // part of a data plane table lookup.
     int64 elapsed_ns = 1;
   }
-  // Table wite: this field should be left unset.
+  // Table write: this field should be left unset.
   // Table read: if the table supports idle timeout and time_since_last_hit is
   // set in the request, this field will be set in the response.
   IdleTimeout time_since_last_hit = 10;
@@ -645,7 +645,7 @@ message ForwardingPipelineConfig {
   // to uniquely identify this config. There are no restrictions on how such
   // value is computed, or where this is stored on the target, as long as it is
   // returned with a GetForwardingPipelineConfig RPC. When reading the cookie,
-  // we need to distibuish those cases where a cookie is NOT present (e.g. not
+  // we need to distinguish those cases where a cookie is NOT present (e.g. not
   // set in the SetForwardingPipelineConfigRequest, therefore we wrap the actual
   // uint64 value in a protobuf message.
   message Cookie {


### PR DESCRIPTION
Includes also minor editorial changes:
- Consistently use "control plane" and "data plane"
- 80 chars column wrap