### PR TITLE
Update one of the known limitations bullet items

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -4855,8 +4855,9 @@ properties, but we may include on in future versions of the API.
 
 # Known-limitations of P4Runtime v1.0.0
 
-* `FieldMatch` and action `Param` only supports bitstrings (not the more general
-  `P4Data`).
+* `FieldMatch`, action `Param`, and controller packet metadata fields only
+  support unsigned bitstrings, i.e. values of type `bit<W>` (not the more
+  general `P4Data`).
 
 * Support for PSA Random & Timestamp externs is postponed to a future minor
   version update.


### PR DESCRIPTION
+ To FieldMatch and action Param, add controller packet metadata,
  which has the same restriction as the other two.
+ Tighten the restriction to only unsigned bitstrings, i.e. values of
  type bit<W>.  The P4Info file has only a bitwidth value to describe
  the types of these values, with no way to distinguish int<W> from
  bit<W>.