### PR TITLE
Define canonical representation for P4Data compound types

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1960,10 +1960,9 @@ Just like its P4Info counterpart - `P4DataTypeSpec` -, `P4Data` uses a Protobuf
 We define a canonical representation for `P4Data` messages - therefore
 guaranteeing read-write symmetry - by introducing the following requirements:
 
- * The order of `members` in `P4StructLike`, the order of `bitstrings` in
-   `P4Header`, and the order of `entries` in `P4HeaderStack` and
-   `P4HeaderUnionStack` must match the order in the corresponding p4info.proto
-   type specification and hence the order in the corresponding P4~16~ type
+ * The order of `members` in `P4StructLike` and the order of `bitstrings` in
+   `P4Header` must match the order in the corresponding p4info.proto type
+   specification and hence the order in the corresponding P4~16~ type
    declaration.
 
  * An invalid header is represented by a `P4Header` message where the `is_valid`
@@ -1973,11 +1972,12 @@ guaranteeing read-write symmetry - by introducing the following requirements:
    represented by a `P4HeaderUnion` message where the `valid_header_name` is the
    empty string (default value for the field) and the `valid_header` is unset.
 
- * The length of the `entries` field in `P4HeaderStack` and `P4HeaderUnionStack`
-   messages must always be equal to the compile-time size of the corresponding
-   P4 stack declaration. This size is included in the P4Info, in the
-   corresponding `P4HeaderStackTypeSpec` or `P4HeaderUnionStackTypeSpec`
-   message.
+ * The order of `entries` in `P4HeaderStack` and `P4HeaderUnionStack` is from
+   element at index 0 of the stack to last element of the stack, in ascending
+   order of index. The length of the `entries` field must always be equal to the
+   compile-time size of the corresponding P4 stack declaration. This size is
+   included in the P4Info, in the corresponding `P4HeaderStackTypeSpec` or
+   `P4HeaderUnionStackTypeSpec` message.
 
 ### Example
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1957,10 +1957,27 @@ case (P4~16~ `bit<W>` type).
 Just like its P4Info counterpart - `P4DataTypeSpec` -, `P4Data` uses a Protobuf
 `oneof` to represent all possible values.
 
-The order of `members` in `P4StructLike`, the order of `bitstrings` in
-`P4Header`, and the order of `entries` in `P4HeaderStack` and
-`P4HeaderUnionStack` must match the order in the corresponding p4info.proto type
-specification and hence the order in the corresponding P4~16~ type declaration.
+We define a canonical representation for `P4Data` messages - therefore
+guaranteeing read-write symmetry - by introducing the following requirements:
+
+ * The order of `members` in `P4StructLike`, the order of `bitstrings` in
+   `P4Header`, and the order of `entries` in `P4HeaderStack` and
+   `P4HeaderUnionStack` must match the order in the corresponding p4info.proto
+   type specification and hence the order in the corresponding P4~16~ type
+   declaration.
+
+ * An invalid header is represented by a `P4Header` message where the `is_valid`
+   field is false and the `bitstrings` repeated field is empty.
+
+ * An invalid header union (&ie; all headers in the union are invalid) is
+   represented by a `P4HeaderUnion` message where the `valid_header_name` is the
+   empty string (default value for the field) and the `valid_header` is unset.
+
+ * The length of the `entries` field in `P4HeaderStack` and `P4HeaderUnionStack`
+   messages must always be equal to the compile-time size of the corresponding
+   P4 stack declaration. This size is included in the P4Info, in the
+   corresponding `P4HeaderStackTypeSpec` or `P4HeaderUnionStackTypeSpec`
+   message.
 
 ### Example
 

--- a/proto/p4/v1/p4data.proto
+++ b/proto/p4/v1/p4data.proto
@@ -43,6 +43,8 @@ message P4StructLike {
 }
 
 message P4Header {
+  // If the header is invalid (is_valid is "false"), then the repeated
+  // bitstrings must be empty.
   bool is_valid = 1;
   repeated bytes bitstrings = 2;
 }
@@ -55,9 +57,13 @@ message P4HeaderUnion {
 }
 
 message P4HeaderStack {
+  // The length of this repeated field must always be equal to the compile-time
+  // size of the header stack, which is specified in P4Info.
   repeated P4Header entries = 1;
 }
 
 message P4HeaderUnionStack {
+  // The length of this repeated field must always be equal to the compile-time
+  // size of the header union stack, which is specified in P4Info.
   repeated P4HeaderUnion entries = 1;
 }


### PR DESCRIPTION
By introducing additional constraints, thus ensuring read-write
symmetry.

Fixes #141