### PR TITLE
Match the p4c implementation for duplicate keys in PkgInfo

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -953,16 +953,17 @@ description")
 Above we see several different types of annotations:
 
 * `@pkginfo` - This is used to populate a specific field within the `PkgInfo`
-message. Multiple `@pkginfo` annotations are allowed. For compactness, multiple
-key-value pairs can appear in a single `@pkginfo` annotation, separated by
-commas. Each key should only appear once, but if it appears multiple times, then
-the last value shall be used. The `key`s must be from among the message fields
-inside `PkgInfo`, for example, `name`, `version`, etc. Each key-value pair
-assigns a value to the corresponding field inside the single `PkgInfo` message
-for the program's P4Info. One exception is that the `Documentation` field of
-`PkgInfo` must be expressed as individual `@description` and `@brief`
-annotations, see next bullets. The key `arch` will be ignored (with a warning)
-by the compiler. The value for this should come from the compiler itself.
+  message. Multiple `@pkginfo` annotations are allowed. For compactness,
+  multiple key-value pairs can appear in a single `@pkginfo` annotation,
+  separated by commas. Each key must only appear once and the compiler must
+  reject the program if one appears multiple times. The `key`s must be from
+  among the message fields inside `PkgInfo`, for example, `name`, `version`,
+  etc. Each key-value pair assigns a value to the corresponding field inside the
+  single `PkgInfo` message for the program's P4Info. One exception is that the
+  `Documentation` field of `PkgInfo` must be expressed as individual
+  `@description` and `@brief` annotations, see next bullets. The key `arch` will
+  be ignored (with a warning) by the compiler. The value for this should come
+  from the compiler itself.
 
 * `@brief` - This will populate the `PkgInfo.doc.brief` message field.
 


### PR DESCRIPTION
In this case, I think both solutions (use the last occurrence or reject
the program) are valid. However, the current p4c complier rejects the P4
program in case of duplicate keys. Since it is "hard" to change the
implementation (the error happens when instantiating the IR, not when
generating the P4Info), I suggest we just match the current
implementation...