### PR TITLE
Require idle_timeout_ns to be set in IdleTimeoutNotification

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -4489,8 +4489,8 @@ The `IdleTimeoutNotification` Protobuf message has the following fields:
 * `table_entry`: a repeated field of entries which have expired. Each individual
   entry is identified by a single `TableEntry` message. For each `TableEntry`,
   the *key* fields (`table_id`, `match` and `priority`) must be set, along with
-  the `controller_metadata` field. Other fields may be set by the server but
-  should be ignored by the client.
+  the `controller_metadata` field and the `idle_timeout_ns` field. Other fields
+  may be set by the server but should be ignored by the client.
 
 Because we use a repeated Protobuf field, the P4Runtime server may elect to
 coalesce several idle timeout notifications in the same

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -567,8 +567,9 @@ message Role {
 }
 
 message IdleTimeoutNotification {
-  // Only "key" fields are required to be set in each TableEntry: table_id,
-  // match and priority.
+  // The only fields that are required to be set in each TableEntry are the
+  // "key" fields (table_id, match and priority) along with controller_metadata
+  // and idle_timeout_ns.
   repeated TableEntry table_entry = 1;
   // Timestamp at which the server generated the message (in nanoseconds since
   // Epoch)


### PR DESCRIPTION
I think it makes sense to include that information for the P4Runtime
client.