### PR TITLE
Support nested bit-vector struct inside header or struct for p4runtime API generation

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1883,18 +1883,21 @@ specification.
 | `void`         | error                 | error        | error           |
 | `error`        | error                 | error        | allowed         |
 | `match_kind`   | error                 | error        | error           |
-| `bool`         | error                 | error        | allowed         |
+| `bool`         | allowed               | error        | allowed         |
 | `enum`         | allowed[^enum_header] | error        | allowed         |
 | `header`       | error                 | allowed      | allowed         |
 | header stack   | error                 | error        | allowed         |
 | `header_union` | error                 | error        | allowed         |
-| `struct`       | error                 | error        | allowed         |
+| `struct`       | allowed[*st_header]   | error        | allowed         |
 | `tuple`        | error                 | error        | allowed         |
 |----------------|-----------------------|--------------|-----------------|
 ~
 
 [^enum_header]: an `enum` type used as a field in a `header` must specify a
     underlying type and representation for `enum` elements.
+[*st_header]: a `struct` or nested 'struct' type that has the same properties, 
+              used as a field in a `header` must contain only 
+              `bit<W>`, `int<W>`, a Serializable Enum, or a `bool`.
 
 For example, the following P4~16~ objects involve complex types that need to be
 exposed in P4Runtime in order to support runtime operations on these objects.

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -85,7 +85,8 @@ message P4Ids {
     TABLE = 0x02;
     VALUE_SET = 0x03;
     CONTROLLER_HEADER = 0x04;
-
+    HEADER_OR_STRUCT = 0x05;  // used to test specific struct or header other than
+                              // controller_header for nested struct support.
     // PSA externs
     PSA_EXTERNS_START = 0x10;
     ACTION_PROFILE = 0x11;

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -31,16 +31,20 @@ package p4.config.v1;
  * | void               | error     | error        | error           |
  * | error              | error     | error        | allowed         |
  * | match_kind         | error     | error        | error           |
- * | bool               | error     | error        | allowed         |
+ * | bool               | allowed   | error        | allowed         |
  * | enum               | allowed*  | error        | allowed         |
  * | header             | error     | allowed      | allowed         |
  * | header stack       | error     | error        | allowed         |
  * | header_union       | error     | error        | allowed         |
- * | struct             | error     | error        | allowed         |
+ * | struct             | allowed** | error        | allowed         |
  * | tuple              | error     | error        | allowed         |
  * |--------------------|-----------|--------------|-----------------|
  *
  * *if serializable
+ *
+ * **struct_header: a `struct` or nested 'struct' type that has the same properties, 
+ *   used as a field in a `header` must contain only 
+ *   bit<W>, int<W>, a Serializable Enum, or a bool.
  */
 
 // These P4 types (struct, header_type, header_union and enum) are guaranteed to
@@ -129,7 +133,7 @@ message P4StructTypeSpec {
 message P4HeaderTypeSpec {
   message Member {
     string name = 1;
-    P4BitstringLikeTypeSpec type_spec = 2;
+    P4DataTypeSpec type_spec = 2;
   }
   repeated Member members = 1;
   repeated string annotations = 2;

--- a/proto/p4/v1/p4data.proto
+++ b/proto/p4/v1/p4data.proto
@@ -46,7 +46,7 @@ message P4Header {
   // If the header is invalid (is_valid is "false"), then the repeated
   // bitstrings must be empty.
   bool is_valid = 1;
-  repeated bytes bitstrings = 2;
+  repeated P4Data members = 2;
 }
 
 message P4HeaderUnion {


### PR DESCRIPTION
It was decided to also use ```P4DataTypeSpec``` for ```P4HeaderTypeSpec``` so that a struct can be supported inside a header.  The p4c frontend restricts what kind of fields can exist in a struct if the struct is inside a header.  Thus the protobuf changes to ```P4HeaderTypeSpec``` should be good. 

I think nested struct support in p4runtime should be a new feature and thus I would like to submit these changes to in v1.1.0.

Thanks much to Antonin for holding my hands regarding p4runtime and PI changes!