### PR TITLE
Add type_name field to P4Info Metadata message

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1398,7 +1398,10 @@ message contains the following fields:
       example below).
     * `annotations`, a repeated field of strings, each one representing a P4
       annotation associated to this metadata.
-    * `bitwidth`, an `int32` representing the size in bit of this metadata.
+    * `bitwidth`, an `int32` representing the size in bits of this metadata.
+    * `type_name`, which indicates whether the metadata field has a
+      [user-defined type](#sec-user-defined-types); this is useful for
+      [translation](#sec-psa-metadata-translation).
 
 As an example, consider the following snippet of a P4 program where controller
 headers are specified and we show the corresponding `ControllerPacketMetadata`
@@ -1542,6 +1545,9 @@ value_sets {
    field, except for the `@match` annotation, if present (see the `match` field
    below).
  * `bitwidth`: set to the value of `W` for the corresponding struct field.
+ * `type_name`, which indicates whether the struct field has a [user-defined
+   type](#sec-user-defined-types); this is useful for
+   [translation](#sec-psa-metadata-translation).
  * `match`: by default `match_type` is set to `EXACT`; the P4 programmer can
    specify a different match type by using the `@match` annotation
    [@P4SelectExpr].

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -319,6 +319,8 @@ message ControllerPacketMetadata {
     string name = 2;
     repeated string annotations = 3;
     int32 bitwidth = 4;
+    // unset if not user-defined type
+    P4NamedType type_name = 5;
   }
   // Ordered based on header layout.
   // This is a constraint on the generator of this P4Info.


### PR DESCRIPTION
Add a description of this field to the text of the section describing
the contents of ControllerPacketMetadata messages.

Also add a description of the type_name field in the ValueSet section.
It was already re-using the MatchField messages used by table search
key fields, and already had this type_name field in it, but it seems
best to explicitly mention that it can be included in MatchField
messages for ValueSet objects, too.