### PR TITLE
Support wildcard reads for multicast groups and clone sessions

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -3715,6 +3715,22 @@ semantics.
   operation. Any packets with their `multicast_group` metadata in the data plane
   set to the deleted `multicast_group_id` will be dropped.
 
+When reading a multicast group, only `multicast_group_id` is considered. All
+other fields in `MulticastGroupEntry`` are ignored. To perform a *wildcard* read
+on all configured multicast group entries, the client must set the
+`multicast_group_id` field to `MULTICAST_GROUP_ID_WILDCARD`, which is defined in
+p4runtime.proto as an enum member with the value `0xffffffff`:
+
+~ Begin Proto
+enum MulticastGroupIdReserved {
+  // 0xffffffff
+  MULTICAST_GROUP_ID_WILDCARD = -1;
+}
+~ End Proto
+
+This reserved value can never appear in a `Write` RPC. If it does, the server
+must return an `INVALID_ARGUMENT` error.
+
 ### `CloneSessionEntry`
 
 PSA supports cloning of packets in both the ingress and egress pipeline. Ingress
@@ -3808,6 +3824,22 @@ semantics:
   `clone_session_id`. Other fields need not be provided for this operation. Any
   packet with their `clone_session_id` metadata in the data plane set to the
   deleted `session_id` will no longer be cloned.
+
+When reading a clone session, only `session_id` is considered. All other fields
+in `CloneSessionEntry` are ignored. To perform a *wildcard* read on all
+configured clone session entries, the client must set the `session_id` field to
+`CLONE_SESSION_ID_WILDCARD`, which is defined in p4runtime.proto as an enum
+member with the value `0xffffffff`:
+
+~ Begin Proto
+enum CloneSessionIdReserved {
+  // 0xffffffff
+  CLONE_SESSION_ID_WILDCARD = -1;
+}
+~ End Proto
+
+This reserved value can never appear in a `Write` RPC. If it does, the server
+must return an `INVALID_ARGUMENT` error.
 
 ## `ValueSetEntry`
 

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -394,8 +394,17 @@ message Replica {
 // each replica's egress input metadata will be set to the respective values
 // programmed in the multicast group entry.
 message MulticastGroupEntry {
+  // Set multicast_group_id to MULTICAST_GROUP_ID_WILDCARD for wildcard reads
   uint32 multicast_group_id = 1;
   repeated Replica replicas = 2;
+
+  // We define a special reserved value for the multicast_group_id field. This
+  // value can be used to do a wildcard Read on all configured multicast
+  // groups. This value cannot be used in Write RPCs.
+  enum MulticastGroupIdReserved {
+    // 0xffffffff
+    MULTICAST_GROUP_ID_WILDCARD = -1;
+  }
 }
 
 // A packet may be cloned by setting the clone_session_id field of PSA
@@ -412,10 +421,19 @@ message MulticastGroupEntry {
 // packet_length_bytes field is 0, no truncation on the clone(s) will be
 // performed.
 message CloneSessionEntry {
+  // Set session_id to CLONE_SESSION_ID_WILDCARD for wildcard reads
   uint32 session_id = 1;
   repeated Replica replicas = 2;
   uint32 class_of_service = 3;
   int32 packet_length_bytes = 4;
+
+  // We define a special reserved value for the session_id field. This value can
+  // be used to do a wildcard read on all configured clone sessions. This value
+  // cannot be used in Write RPCs.
+  enum CloneSessionIdReserved {
+    // 0xffffffff
+    CLONE_SESSION_ID_WILDCARD = -1;
+  }
 }
 
 // A member in a P4 value set. Each member defines a list of matches, which can
@@ -444,12 +462,14 @@ message ValueSetEntry {
   repeated ValueSetMember members = 2;
 }
 
+//------------------------------------------------------------------------------
 message RegisterEntry {
   uint32 register_id = 1;
   Index index = 2;
   P4Data data = 3;
 }
 
+//------------------------------------------------------------------------------
 // Used to configure the digest extern only, not to stream digests or acks
 message DigestEntry {
   uint32 digest_id = 1;


### PR DESCRIPTION
By reserving a special id value (0xffffffff) which is assigned to a enum
member in p4runtime.proto.