### PR TITLE
Chris/add anno property maps

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1016,6 +1016,104 @@ table my_ipv4_lkup {
   ...
 }
 ~ End p4example
+### Custom Annotations in P4Info
+P4 allows flexible annotations[@P4Annotations]. Users may add their own annotations as long as they obey the language syntax. To facilitate consumption of user-defined annotations, P4Info has an `annotation_map` for any element which can accept such annotations, &ie; the `PkgInfo`, `Preamble`, `MatchField`, `ActionRef`, `Action` and `ControllerPacketMetadata` messages. The `annotation_map` contains a suitable parsed representation for the different types of annotation bodies, namely: `expression_list` and `kv_map`. Empty annotation bodies are signified by an empty `value` field  in the `annotation_map` entry. 
+
+Note that `AnnotationBody` allows for simultaneous `expression_list` and `kv_map` entries even though the P6-16 specification grammar does not at this writing.
+
+~ Begin Proto
+// A parsed representation of the annotation body.
+// Ex. empty annotation:           @my_anno1()
+// Ex. expression list annotation: @my_anno2(1+1, "Hello", 1 << 3)
+// Ex. KV-pair annotation:         @my_anno3(a=b,c=d)
+// Ex. Cumulative kv-pair          @my_anno3(e=f)  // adds to my_anno3's properties
+message AnnotationBody {
+  repeated string expressions = 1;
+  map <string,string> properties = 2;
+}
+~ End Proto
+
+Given the following P4 source fragment:
+~ Begin P4Example
+@my_anno1()
+@my_anno2("Some random content: for i in range(10)")
+@my_anno3(1+1, "Hello", 1 << 3)
+@my_anno4(a=b,c=d)
+@my_anno4(e=f)
+@my_anno5(w=x, "expression one", y=z, expression two)
+table test1 {
+    key = { hdrs.data.f1 : ternary; }
+    actions = {
+        setb1;
+        noop;
+    }
+    default_action = noop;
+}
+~ End P4Example
+The corresponding P4Info `Preamble` fragment would be as follows. Note the appearance of the raw `annotations` fields which are deprecated in favor of the `annotation_map` fields.
+~ Begin Prototext
+  preamble {
+    id: 33619894
+    name: "ingress.test1"
+    alias: "test1"
+    annotations: "@my_anno1"
+    annotations: "@my_anno2(\"Some random content: for i in range(10)\")"
+    annotations: "@my_anno3(1 + 1 , \"Hello\" , 1 << 3)"
+    annotations: "@my_anno4(a = b , c = d)"
+    annotations: "@my_anno4(e = f)"
+    annotations: "@my_anno5(w = x , \"expression one\" , y = z , expression two)"
+    annotation_map {
+      key: "my_anno1"
+      value {
+      }
+    }
+    annotation_map {
+      key: "my_anno2"
+      value {
+        expressions: "\"Some random content: for i in range"
+      }
+    }
+    annotation_map {
+      key: "my_anno3"
+      value {
+        expressions: "\"Hello\""
+        expressions: "1 << 3"
+        expressions: "1 + 1"
+      }
+    }
+    annotation_map {
+      key: "my_anno4"
+      value {
+        properties {
+          key: "a"
+          value: "b"
+        }
+        properties {
+          key: "c"
+          value: "d"
+        }
+        properties {
+          key: "e"
+          value: "f"
+        }
+      }
+    }
+    annotation_map {
+      key: "my_anno5"
+      value {
+        expressions: "\"expression one\""
+        expressions: "expression two"
+        properties {
+          key: "w"
+          value: "x"
+        }
+        properties {
+          key: "y"
+          value: "z"
+        }
+      }
+    }
+~ End Prototext
 
 ## `PkgInfo` Message
 
@@ -1107,7 +1205,6 @@ Built for data-center profile.")
 PSA_Switch(IgPipeline, PacketReplicationEngine(), EgPipeline,
            BufferingQueueingEngine()) main;
 ~ End p4example
-
 ## ID Allocation for P4Info Objects { #sec-id-allocation}
 
 P4Info objects receive a unique ID, which is used to identify the object in
@@ -5472,79 +5569,6 @@ the purpose of adding features for the P4Runtime API.
 | `@p4runtime_translation` | See sections [#sec-user-defined-types], [#sec-translation-of-port-numbers] |
 +--------------------------+---------------------------------------+
 ~
-### Custom Annotations in P4Info
-P4 allows flexible annotations. Users may add their own annotations as long as they obey the language syntax.
-To facilitate consumption of user-defined annotations, P4Info has an `anno_map` for any element which can accept
-such annotations, e.g. the `PkgInfo`, `Preamble`, `MatchField`, `ActionRef`, `Action` and
-`ControllerPacketMetadata` messages. The `anno_map` contains a suitable parsed representation for the different
-types of annotation bodies, namely: empty, free-form string, and a key-value-map.
-
-Given the following P4 source fragment:
-
-~ Begin P4Example
-    @my_anno1()
-    @my_anno2("Some random content: for i in range(10)")
-    @my_anno3(a=b,c=d)
-    @my_anno3(e=f)
-    table test1 {
-        key = { hdrs.data.f1 : ternary; }
-        actions = {
-            setb1;
-            noop;
-        }
-        default_action = noop;
-    }
-~ End P4Example
-
-The corresponding P4Info `Preamble` fragment would be as follows.
-Note the lingering presence of the raw `annotations` fields, which are deprecated in favor of the newer
-`anno_map` fields and slated to be removed in some future release.
-~ Begin Prototext
-  preamble {
-    id: 33619894
-    name: "ingress.test1"
-    alias: "test1"
-    annotations: "@my_anno1"
-    annotations: "@my_anno2(\"Some random content: for i in range(10)\")"
-    annotations: "@my_anno3(a = b , c = d)"
-    annotations: "@my_anno3(e = f)"
-    anno_map {
-      key: "my_anno1"
-      value {
-        empty {
-        }
-      }
-    }
-    anno_map {
-      key: "my_anno2"
-      value {
-        string {
-          value: "\"Some random content: for i in range"
-        }
-      }
-    }
-    anno_map {
-      key: "my_anno3"
-      value {
-        kv_map {
-          property {
-            key: "a"
-            value: "b"
-          }
-          property {
-            key: "c"
-            value: "d"
-          }
-          property {
-            key: "e"
-            value: "f"
-          }
-        }
-      }
-    }
-  }
-~ End Prototext
-
 ## A More Complex Value Set Example { #sec-value-set-example}
 
 This section includes a more complex Value Set example, with multiple matches of

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -5472,6 +5472,78 @@ the purpose of adding features for the P4Runtime API.
 | `@p4runtime_translation` | See sections [#sec-user-defined-types], [#sec-translation-of-port-numbers] |
 +--------------------------+---------------------------------------+
 ~
+### Custom Annotations in P4Info
+P4 allows flexible annotations. Users may add their own annotations as long as they obey the language syntax.
+To facilitate consumption of user-defined annotations, P4Info has an `anno_map` for any element which can accept
+such annotations, e.g. the `PkgInfo`, `Preamble`, `MatchField`, `ActionRef`, `Action` and
+`ControllerPacketMetadata` messages. The `anno_map` contains a suitable parsed representation for the different
+types of annotation bodies, namely: empty, free-form string, and a key-value-map.
+
+Given the following P4 source fragment:
+
+~ Begin P4Example
+    @my_anno1()
+    @my_anno2("Some random content: for i in range(10)")
+    @my_anno3(a=b,c=d)
+    @my_anno3(e=f)
+    table test1 {
+        key = { hdrs.data.f1 : ternary; }
+        actions = {
+            setb1;
+            noop;
+        }
+        default_action = noop;
+    }
+~ End P4Example
+
+The corresponding P4Info `Preamble` fragment would be as follows.
+Note the lingering presence of the raw `annotations` fields, which are deprecated in favor of the newer
+`anno_map` fields and slated to be removed in some future release.
+~ Begin Prototext
+  preamble {
+    id: 33619894
+    name: "ingress.test1"
+    alias: "test1"
+    annotations: "@my_anno1"
+    annotations: "@my_anno2(\"Some random content: for i in range(10)\")"
+    annotations: "@my_anno3(a = b , c = d)"
+    annotations: "@my_anno3(e = f)"
+    anno_map {
+      key: "my_anno1"
+      value {
+        empty {
+        }
+      }
+    }
+    anno_map {
+      key: "my_anno2"
+      value {
+        string {
+          value: "\"Some random content: for i in range"
+        }
+      }
+    }
+    anno_map {
+      key: "my_anno3"
+      value {
+        kv_map {
+          property {
+            key: "a"
+            value: "b"
+          }
+          property {
+            key: "c"
+            value: "d"
+          }
+          property {
+            key: "e"
+            value: "f"
+          }
+        }
+      }
+    }
+  }
+~ End Prototext
 
 ## A More Complex Value Set Example { #sec-value-set-example}
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1033,7 +1033,8 @@ comma-separated expressions and/or key-value ("property") pairs. Empty
 annotation bodies are signified by zero `AnnotationElement`s in the `elements`
 field of `ParsedAnnotation`.
 
-The `AnnotationElement` and `ParsedAnnotation` messages are defined in `p4types.proto`
+The `AnnotationElement` and `ParsedAnnotation` messages are defined in
+`p4types.proto`
 
 ~ Begin Proto
 // One parsed element within an annotation's body.
@@ -1052,8 +1053,11 @@ message ParsedAnnotation {
 
 The following invariants hold:
 
-1. For any P4 entity with annotations, there are no two parsed_annotations that have the same name.
-2. Within a `ParsedAnnotation`, there are no two `AnnotationElement`s that have the same key, except for the empty key, which can appear any number of times.
+1. For any P4 entity with annotations, there are no two parsed_annotations that
+have the same name.
+
+2. Within a `ParsedAnnotation`, there are no two `AnnotationElement`s that have
+the same key, except for the empty key, which can appear any number of times.
 
 
 Given the following P4 source fragment:

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1020,47 +1020,60 @@ table my_ipv4_lkup {
 ~ End p4example
 
 ### Custom Annotations in P4Info
+
 P4 allows flexible annotations[@P4Annotations]. Users may add their own
 annotations as long as they obey the language syntax. To facilitate consumption
-of user-defined annotations, P4Info has an `AnnotationMap` for any element which
-can accept such annotations, &ie; the `PkgInfo`, `Preamble`, `MatchField`,
-`ActionRef`, `Action` and `ControllerPacketMetadata` messages, as well as the
-type specification messages in `p4types.proto`. The `AnnotationMap` contains a
-suitable parsed representation for the different types of annotation bodies,
-namely: `expressions` and `properties`. Empty annotation bodies are signified by
-an empty `value` field  in the `AnnotationMap` entry. 
+of user-defined annotations, P4Info has a `repeated ParsedAnnotation` for any
+element which can accept such annotations, &ie; the `PkgInfo`, `Preamble`,
+`MatchField`, `ActionRef`, `Action` and `ControllerPacketMetadata` messages, as
+well as the type specification messages in `p4types.proto`. The
+`ParsedAnnotation` contains a parsed representation which accomodates both
+unstructured annotation content, as well as common structured use-cases:
+comma-separated expressions and/or key-value ("property") pairs. Empty
+annotation bodies are signified by zero `AnnotationElement`s in the `elements`
+field of `ParsedAnnotation`.
 
-Note that `AnnotationBody` allows for simultaneous `expressions` and
-`properties` entries even though the P6-16 specification grammar does not at this
-writing.
-
-The `AnnotationBody` and `AnnotationMap` messages are defined in `p4types.proto`:
+The `AnnotationElement` and `ParsedAnnotation` messages are defined in `p4types.proto`
 
 ~ Begin Proto
-// A parsed representation of the annotation body.
-// Ex. empty annotation:           @my_anno1()
-// Ex. expression list annotation: @my_anno2(1+1, "Hello", 1 << 3)
-// Ex. KV-pair annotation:         @my_anno3(a=b,c=d)
-// Ex. Cumulative kv-pair          @my_anno3(e=f)  // adds to my_anno3's properties
-message AnnotationBody {
-  repeated string expressions = 1;
-  map <string, string> properties = 2;
+// One parsed element within an annotation's body.
+message AnnotationElement {
+// Key is empty if and only if no key was specified
+  string key = 1;
+  string value = 2;
 }
 
-// A map of annotations keyed by the annotation tag following the @-sign
-message AnnotationMap {
-  map <string, AnnotationBody> annotations = 1;
+// An ordered list of annotations identified by the name
+message ParsedAnnotation {
+  string name = 1;
+  repeated AnnotationElement elements = 2;
 }
 ~ End Proto
 
+The following invariants hold:
+
+1. For any P4 entity with annotations, there are no two parsed_annotations that have the same name.
+2. Within a `ParsedAnnotation`, there are no two `AnnotationElement`s that have the same key, except for the empty key, which can appear any number of times.
+
+
 Given the following P4 source fragment:
 ~ Begin P4Example
-@my_anno1()
-@my_anno2("Some random content: for i in range(10)")
-@my_anno3(1+1, "Hello", 1 << 3)
-@my_anno4(a=b,c=d)
-@my_anno4(e=f)
-@my_anno5(w=x, "expression one", y=z, expression two)
+@MyAnno1()
+@MyAnno2("Some random content: for i in range(10)")
+@MyAnno3(1+1, "Hello", 1 << 3)
+@MyAnno4(a=b,c=d)
+@MyAnno4(e=f)
+@MyAnno5(a=1,a=2)
+@MyAnno6(e=f)
+@MyAnno6(1)
+@MyAnno7(
+- What do you get if you multiply six by nine?
+- Six by nine. Forty two.
+- That's it. That's all there is.
+- I always thought there was something fundamentally wrong with the
+  universe.
+0xdeadbeef
+)
 table test1 {
     key = { hdrs.data.f1 : ternary; }
     actions = {
@@ -1070,72 +1083,92 @@ table test1 {
     default_action = noop;
 }
 ~ End P4Example
+
 The corresponding P4Info `Preamble` fragment would be as follows. Note the
 appearance of the raw `annotations` fields which are deprecated in favor of the
-`annotation_map` fields.
+`annotation_map` fields. (Note the final `annotations` entry has artificial line
+breaks inserted for print layout purposes.)
+
 ~ Begin Prototext
 tables {
   preamble {
     id: 33619894
     name: "ingress.test1"
     alias: "test1"
-    annotations: "@my_anno1"
-    annotations: "@my_anno2(\"Some random content: for i in range(10)\")"
-    annotations: "@my_anno3(1 + 1 , \"Hello\" , 1 << 3)"
-    annotations: "@my_anno4(a = b , c = d)"
-    annotations: "@my_anno4(e = f)"
-    annotations: "@my_anno5(w = x , \"expression one\" , y = z , expression two)"
-    annotation_map {
-      annotations {
-        key: "my_anno1"
-        value {
-        }
+    annotations: "@MyAnno1"
+    annotations: "@MyAnno2(\"Some random content: for i in range(10)\")"
+    annotations: "@MyAnno3(1 + 1 , \"Hello\" , 1 << 3)"
+    annotations: "@MyAnno4(a = b , c = d)"
+    annotations: "@MyAnno4(e = f)"
+    annotations: "@MyAnno5(a = 1 , a = 2)"
+    annotations: "@MyAnno6(e = f)"
+    annotations: "@MyAnno6(1)"
+    annotations: "@MyAnno7(- What do you get if you multiply six by nine ?
+     - Six by nine. Forty two. - That \' s it. That \' s all there is.
+     - I always thought there was something fundamentally wrong with the universe.
+     0xdeadbeef)"
+    parsed_annotations {
+      name: "@MyAnno1"
+      elements {
       }
-      annotations {
-        key: "my_anno2"
-        value {
-          expressions: "\"Some random content: for i in range"
-        }
+    }
+    parsed_annotations {
+      name: "@MyAnno2"
+      elements {
+        value: "\"Some random content: for i in range(10)\""
       }
-      annotations {
-        key: "my_anno3"
-        value {
-          expressions: "\"Hello\""
-          expressions: "1 << 3"
-          expressions: "1 + 1"
-        }
+    }
+    parsed_annotations {
+      name: "@MyAnno3"
+      elements {
+        value: "\"Hello\""
       }
-      annotations {
-        key: "my_anno4"
-        value {
-          properties {
-            key: "a"
-            value: "b"
-          }
-          properties {
-            key: "c"
-            value: "d"
-          }
-          properties {
-            key: "e"
-            value: "f"
-          }
-        }
+      elements {
+        value: "1 << 3"
       }
-      annotations {
-        key: "my_anno5"
-        value {
-          expressions: "\"expression one\""
-          expressions: "expression two"
-          properties {
-            key: "w"
-            value: "x"
-          }
-          properties {
-            key: "y"
-            value: "z"
-          }
-        }
+      elements {
+        value: "1 + 1"
+      }
+    }
+    parsed_annotations {
+      name: "@MyAnno4"
+      elements {
+        key: "a"
+        value: "b"
+      }
+      elements {
+        key: "c"
+        value: "d"
+      }
+      elements {
+        key: "e"
+        value: "f"
+      }
+    }
+    parsed_annotations {
+      name: "@MyAnno5"
+      elements {
+        key: "a"
+        value: "2"
+      }
+    }
+    parsed_annotations {
+      name: "@MyAnno6"
+      elements {
+        key: "e"
+        value: "f"
+      }
+      elements {
+        value: "1"
+      }
+    }
+    parsed_annotations {
+      name: "@MyAnno7"
+      elements {
+        value: "- What do you get if you multiply six by nine ?
+        - Six by nine. Forty two  - That \' s it. That \' s all there is.
+        - I always thought there was something fundamentally wrong with the universe.
+        0xdeadbeef"
       }
     }
   }

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -983,9 +983,11 @@ message Preamble {
   // P4 programmer may also be able to override the default alias for any P4
   // object (TBD).
   string alias = 3;
-  repeated string annotations = 4;
+  repeated string annotations = 4 [deprecated=true];
   // Documentation of the entity
   Documentation doc = 5;
+  // Annotation map derived from raw annotations, keyed by annotation tag
+  AnnotationMap annotation_map = 6;
 }
 ~ End Proto
 
@@ -1016,10 +1018,23 @@ table my_ipv4_lkup {
   ...
 }
 ~ End p4example
-### Custom Annotations in P4Info
-P4 allows flexible annotations[@P4Annotations]. Users may add their own annotations as long as they obey the language syntax. To facilitate consumption of user-defined annotations, P4Info has an `annotation_map` for any element which can accept such annotations, &ie; the `PkgInfo`, `Preamble`, `MatchField`, `ActionRef`, `Action` and `ControllerPacketMetadata` messages. The `annotation_map` contains a suitable parsed representation for the different types of annotation bodies, namely: `expression_list` and `kv_map`. Empty annotation bodies are signified by an empty `value` field  in the `annotation_map` entry. 
 
-Note that `AnnotationBody` allows for simultaneous `expression_list` and `kv_map` entries even though the P6-16 specification grammar does not at this writing.
+### Custom Annotations in P4Info
+P4 allows flexible annotations[@P4Annotations]. Users may add their own
+annotations as long as they obey the language syntax. To facilitate consumption
+of user-defined annotations, P4Info has an `AnnotationMap` for any element which
+can accept such annotations, &ie; the `PkgInfo`, `Preamble`, `MatchField`,
+`ActionRef`, `Action` and `ControllerPacketMetadata` messages, as well as the
+type specification messages in `p4types.proto`. The `AnnotationMap` contains a
+suitable parsed representation for the different types of annotation bodies,
+namely: `expressions` and `properties`. Empty annotation bodies are signified by
+an empty `value` field  in the `AnnotationMap` entry. 
+
+Note that `AnnotationBody` allows for simultaneous `expressions` and
+`properties` entries even though the P6-16 specification grammar does not at this
+writing.
+
+The `AnnotationBody` and `AnnotationMap` messages are defined in `p4types.proto`:
 
 ~ Begin Proto
 // A parsed representation of the annotation body.
@@ -1029,7 +1044,12 @@ Note that `AnnotationBody` allows for simultaneous `expression_list` and `kv_map
 // Ex. Cumulative kv-pair          @my_anno3(e=f)  // adds to my_anno3's properties
 message AnnotationBody {
   repeated string expressions = 1;
-  map <string,string> properties = 2;
+  map <string, string> properties = 2;
+}
+
+// A map of annotations keyed by the annotation tag following the @-sign
+message AnnotationMap {
+  map <string, AnnotationBody> annotations = 1;
 }
 ~ End Proto
 
@@ -1050,8 +1070,11 @@ table test1 {
     default_action = noop;
 }
 ~ End P4Example
-The corresponding P4Info `Preamble` fragment would be as follows. Note the appearance of the raw `annotations` fields which are deprecated in favor of the `annotation_map` fields.
+The corresponding P4Info `Preamble` fragment would be as follows. Note the
+appearance of the raw `annotations` fields which are deprecated in favor of the
+`annotation_map` fields.
 ~ Begin Prototext
+tables {
   preamble {
     id: 33619894
     name: "ingress.test1"
@@ -1063,56 +1086,60 @@ The corresponding P4Info `Preamble` fragment would be as follows. Note the appea
     annotations: "@my_anno4(e = f)"
     annotations: "@my_anno5(w = x , \"expression one\" , y = z , expression two)"
     annotation_map {
-      key: "my_anno1"
-      value {
-      }
-    }
-    annotation_map {
-      key: "my_anno2"
-      value {
-        expressions: "\"Some random content: for i in range"
-      }
-    }
-    annotation_map {
-      key: "my_anno3"
-      value {
-        expressions: "\"Hello\""
-        expressions: "1 << 3"
-        expressions: "1 + 1"
-      }
-    }
-    annotation_map {
-      key: "my_anno4"
-      value {
-        properties {
-          key: "a"
-          value: "b"
-        }
-        properties {
-          key: "c"
-          value: "d"
-        }
-        properties {
-          key: "e"
-          value: "f"
+      annotations {
+        key: "my_anno1"
+        value {
         }
       }
-    }
-    annotation_map {
-      key: "my_anno5"
-      value {
-        expressions: "\"expression one\""
-        expressions: "expression two"
-        properties {
-          key: "w"
-          value: "x"
+      annotations {
+        key: "my_anno2"
+        value {
+          expressions: "\"Some random content: for i in range"
         }
-        properties {
-          key: "y"
-          value: "z"
+      }
+      annotations {
+        key: "my_anno3"
+        value {
+          expressions: "\"Hello\""
+          expressions: "1 << 3"
+          expressions: "1 + 1"
+        }
+      }
+      annotations {
+        key: "my_anno4"
+        value {
+          properties {
+            key: "a"
+            value: "b"
+          }
+          properties {
+            key: "c"
+            value: "d"
+          }
+          properties {
+            key: "e"
+            value: "f"
+          }
+        }
+      }
+      annotations {
+        key: "my_anno5"
+        value {
+          expressions: "\"expression one\""
+          expressions: "expression two"
+          properties {
+            key: "w"
+            value: "x"
+          }
+          properties {
+            key: "y"
+            value: "z"
+          }
         }
       }
     }
+  }
+  ...
 ~ End Prototext
 
 ## `PkgInfo` Message
@@ -1134,7 +1161,7 @@ message PkgInfo {
   // brief and detailed descriptions
   Documentation doc = 3;
   // Miscellaneous metadata, free-form; a way to extend PkgInfo
-  repeated string annotations = 4;
+  repeated string annotations = 4 [deprecated=true];
   // the target architecture, e.g. "psa"
   string arch = 5;
   // organization which produced the configuration, e.g. "p4.org"
@@ -1205,6 +1232,7 @@ Built for data-center profile.")
 PSA_Switch(IgPipeline, PacketReplicationEngine(), EgPipeline,
            BufferingQueueingEngine()) main;
 ~ End p4example
+
 ## ID Allocation for P4Info Objects { #sec-id-allocation}
 
 P4Info objects receive a unique ID, which is used to identify the object in
@@ -5569,6 +5597,7 @@ the purpose of adding features for the P4Runtime API.
 | `@p4runtime_translation` | See sections [#sec-user-defined-types], [#sec-translation-of-port-numbers] |
 +--------------------------+---------------------------------------+
 ~
+
 ## A More Complex Value Set Example { #sec-value-set-example}
 
 This section includes a more complex Value Set example, with multiple matches of

--- a/docs/v1/references.bib
+++ b/docs/v1/references.bib
@@ -186,3 +186,8 @@
     title = "The Protobuf MessageDifferencer in the C++ API",
     url = "https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.util.message_differencer"
 }
+
+@ONLINE { P4Annotations,
+    title = "P4 Annotations",
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.1.0-spec.html#sec-annotations"
+}

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -57,18 +57,13 @@ message KVmap {
 // Ex. string annotation:  @my_anno2("Any text at all", for (i = 1 to 10) {print i} )
 // Ex. KV-pair annotation: @my_anno3(a=b,c=d)
 // NOTE: multiple KV annotations with the same tag are cumulative, so @my_anno3(a=b,c=d) in conjunction with
-//       @my_anno3(e=f) would add to my_anno3's map
+//       @my_anno3(e=f) would result in 3 kv-pairs for my_anno3.
 message AnnotationBody {
   oneof anno {
     google.protobuf.Empty empty = 1;          // The annotation body is empty
     google.protobuf.StringValue string = 2;   // The annotation body contains free-form string or expression 
-    KVMap property_map = 3;                   // The annotation body contains one or more KV-pairs
+    KVmap kv_map = 3;                         // The annotation body contains one or more KV-pairs
   }
-}
-
-// A map of annotation tags to the annotation body.
-message AnnotationMap {
-  map <string,AnnotationBody> propertyMap = 1;   // key-map pairs
 }
   
 // Top-level package documentation describing the forwarding pipeline config
@@ -92,7 +87,7 @@ message PkgInfo {
   // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
   string url = 8;
   // Annotation map derived from raw annotations
-  AnnotationMap anno_map = 9;
+  map <string,AnnotationBody> anno_map = 9;
 }
 
 // wrapping the enum in a message to avoid name collisions in C++, where "enum
@@ -160,7 +155,7 @@ message Preamble {
   // Documentation of the entity
   Documentation doc = 5;
   // Annotation map derived from raw annotations
-  AnnotationMap anno_map = 6;
+  map <string,AnnotationBody> anno_map = 6;
 }
 
 // used to group all extern instances of the same type in one message
@@ -203,7 +198,7 @@ message MatchField {
   // unset if not user-defined type
   P4NamedType type_name = 8;
   // Annotation map derived from raw annotations
-  AnnotationMap anno_map = 9;
+  map <string,AnnotationBody> anno_map = 9;
 }
 
 message Table {
@@ -254,7 +249,7 @@ message ActionRef {
   // raw annotations - deprecated, use anno_map
   repeated string annotations = 2;
   // Annotation map derived from raw annotations
-  AnnotationMap anno_map = 3;
+  map <string,AnnotationBody> anno_map = 6;
 }
 
 message Action {
@@ -270,7 +265,7 @@ message Action {
     // unset if not user-defined type
     P4NamedType type_name = 6;
     // Annotation map derived from raw annotations
-    AnnotationMap anno_map = 7;
+    map <string,AnnotationBody> anno_map = 7;
   }
   repeated Param params = 2;
 }
@@ -364,7 +359,7 @@ message ControllerPacketMetadata {
     // unset if not user-defined type
     P4NamedType type_name = 5;
     // Annotation map derived from raw annotations
-    AnnotationMap anno_map = 6;
+    map <string,AnnotationBody> anno_map = 6;
   }
   // Ordered based on header layout.
   // This is a constraint on the generator of this P4Info.

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -48,9 +48,9 @@ message Documentation {
 
 // A parsed representation of the annotation body.
 // Ex. empty annotation:           @my_anno1()
-// Ex. ExpressionList annotation:  @my_anno2(1+1, "Hello", 1 << 3)
+// Ex. expression list annotation: @my_anno2(1+1, "Hello", 1 << 3)
 // Ex. KV-pair annotation:         @my_anno3(a=b,c=d)
-// Ex. Cumulative kv-pair          @my_anno3(e=f)  // adds to my_anno3's properties
+// Ex. Cumulative KV-pair          @my_anno3(e=f)  // adds to my_anno3's properties
 message AnnotationBody {
   repeated string expressions = 1;
   map <string,string> properties = 2;

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -67,7 +67,7 @@ message PkgInfo {
   // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
   string url = 8;
   // Annotation map derived from raw annotations, keyed by annotation tag
-  AnnotationMap annotation_map = 9;
+  repeated ParsedAnnotation parsed_annotations = 9;
 }
 
 // wrapping the enum in a message to avoid name collisions in C++, where "enum
@@ -135,7 +135,7 @@ message Preamble {
   // Documentation of the entity
   Documentation doc = 5;
   // Annotation map derived from raw annotations, keyed by annotation tag
-  AnnotationMap annotation_map = 6;
+  repeated ParsedAnnotation parsed_annotations = 6;
 }
 
 // used to group all extern instances of the same type in one message
@@ -178,7 +178,7 @@ message MatchField {
   // unset if not user-defined type
   P4NamedType type_name = 8;
   // Annotation map derived from raw annotations, keyed by annotation tag
-  AnnotationMap annotation_map = 9;
+  repeated ParsedAnnotation parsed_annotations = 9;
 }
 
 message Table {
@@ -229,7 +229,7 @@ message ActionRef {
   // raw annotations - deprecated, use annotation_map
   repeated string annotations = 2 [deprecated=true];
   // Annotation map derived from raw annotations, keyed by annotation tag
-  AnnotationMap annotation_map = 6;
+  repeated ParsedAnnotation parsed_annotations = 6;
 }
 
 message Action {
@@ -245,7 +245,7 @@ message Action {
     // unset if not user-defined type
     P4NamedType type_name = 6;
     // Annotation map derived from raw annotations, keyed by annotation tag
-    AnnotationMap annotation_map = 7;
+    repeated ParsedAnnotation parsed_annotations = 7;
   }
   repeated Param params = 2;
 }
@@ -339,7 +339,7 @@ message ControllerPacketMetadata {
     // unset if not user-defined type
     P4NamedType type_name = 5;
     // Annotation map derived from raw annotations, keyed by annotation tag
-    AnnotationMap annotation_map = 6;
+    repeated ParsedAnnotation parsed_annotations = 6;
   }
   // Ordered based on header layout.
   // This is a constraint on the generator of this P4Info.

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -46,16 +46,6 @@ message Documentation {
   string description = 2;
 }
 
-// A parsed representation of the annotation body.
-// Ex. empty annotation:           @my_anno1()
-// Ex. expression list annotation: @my_anno2(1+1, "Hello", 1 << 3)
-// Ex. KV-pair annotation:         @my_anno3(a=b,c=d)
-// Ex. Cumulative KV-pair          @my_anno3(e=f)  // adds to my_anno3's properties
-message AnnotationBody {
-  repeated string expressions = 1;
-  map <string,string> properties = 2;
-}
- 
 // Top-level package documentation describing the forwarding pipeline config
 // Can be used to manage multiple P4 packages.
 message PkgInfo {
@@ -67,7 +57,7 @@ message PkgInfo {
   Documentation doc = 3;
   // Miscellaneous metadata, free-form; a way to extend PkgInfo
   // raw annotations - deprecated, use annotation_map
-  repeated string annotations = 4;
+  repeated string annotations = 4 [deprecated=true];
   // the target architecture, e.g. "psa"
   string arch = 5;
   // organization which produced the configuration, e.g. "p4.org"
@@ -77,7 +67,7 @@ message PkgInfo {
   // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
   string url = 8;
   // Annotation map derived from raw annotations, keyed by annotation tag
-  map <string,AnnotationBody> annotation_map = 9;
+  AnnotationMap annotation_map = 9;
 }
 
 // wrapping the enum in a message to avoid name collisions in C++, where "enum
@@ -141,11 +131,11 @@ message Preamble {
   // object (TBD).
   string alias = 3;
   // raw annotations - deprecated, use annotation_map
-  repeated string annotations = 4;
+  repeated string annotations = 4 [deprecated=true];
   // Documentation of the entity
   Documentation doc = 5;
   // Annotation map derived from raw annotations, keyed by annotation tag
-  map <string,AnnotationBody> annotation_map = 6;
+  AnnotationMap annotation_map = 6;
 }
 
 // used to group all extern instances of the same type in one message
@@ -168,7 +158,7 @@ message MatchField {
   uint32 id = 1;
   string name = 2;
   // raw annotations - deprecated, use annotation_map
-  repeated string annotations = 3;
+  repeated string annotations = 3 [deprecated=true];
   int32 bitwidth = 4;
   enum MatchType {
     UNSPECIFIED = 0;
@@ -188,7 +178,7 @@ message MatchField {
   // unset if not user-defined type
   P4NamedType type_name = 8;
   // Annotation map derived from raw annotations, keyed by annotation tag
-  map <string,AnnotationBody> annotation_map = 9;
+  AnnotationMap annotation_map = 9;
 }
 
 message Table {
@@ -237,9 +227,9 @@ message ActionRef {
   Scope scope = 3;
   
   // raw annotations - deprecated, use annotation_map
-  repeated string annotations = 2;
+  repeated string annotations = 2 [deprecated=true];
   // Annotation map derived from raw annotations, keyed by annotation tag
-  map <string,AnnotationBody> annotation_map = 6;
+  AnnotationMap annotation_map = 6;
 }
 
 message Action {
@@ -248,14 +238,14 @@ message Action {
     uint32 id = 1;
     string name = 2;
     // raw annotations - deprecated, use annotation_map
-    repeated string annotations = 3;
+    repeated string annotations = 3 [deprecated=true];
     int32 bitwidth = 4;
     // Documentation of the Param
     Documentation doc = 5;
     // unset if not user-defined type
     P4NamedType type_name = 6;
     // Annotation map derived from raw annotations, keyed by annotation tag
-    map <string,AnnotationBody> annotation_map = 7;
+    AnnotationMap annotation_map = 7;
   }
   repeated Param params = 2;
 }
@@ -344,12 +334,12 @@ message ControllerPacketMetadata {
     // to e.g. Action.Param.name.
     string name = 2;
     // raw annotations - deprecated, use annotation_map
-    repeated string annotations = 3;
+    repeated string annotations = 3 [deprecated=true];
     int32 bitwidth = 4;
     // unset if not user-defined type
     P4NamedType type_name = 5;
     // Annotation map derived from raw annotations, keyed by annotation tag
-    map <string,AnnotationBody> annotation_map = 6;
+    AnnotationMap annotation_map = 6;
   }
   // Ordered based on header layout.
   // This is a constraint on the generator of this P4Info.

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -15,6 +15,8 @@
 syntax = "proto3";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
 import "p4/config/v1/p4types.proto";
 
 // This package and its contents are a work-in-progress.
@@ -46,6 +48,29 @@ message Documentation {
   string description = 2;
 }
 
+message KVmap {
+  map <string,string> property = 1;   // a map of key-value pairs
+}
+
+// A parsed representation of the annotation body.
+// Ex. empty annotation:   @my_anno1()
+// Ex. string annotation:  @my_anno2("Any text at all", for (i = 1 to 10) {print i} )
+// Ex. KV-pair annotation: @my_anno3(a=b,c=d)
+// NOTE: multiple KV annotations with the same tag are cumulative, so @my_anno3(a=b,c=d) in conjunction with
+//       @my_anno3(e=f) would add to my_anno3's map
+message AnnotationBody {
+  oneof anno {
+    google.protobuf.Empty empty = 1;          // The annotation body is empty
+    google.protobuf.StringValue string = 2;   // The annotation body contains free-form string or expression 
+    KVMap property_map = 3;                   // The annotation body contains one or more KV-pairs
+  }
+}
+
+// A map of annotation tags to the annotation body.
+message AnnotationMap {
+  map <string,AnnotationBody> propertyMap = 1;   // key-map pairs
+}
+  
 // Top-level package documentation describing the forwarding pipeline config
 // Can be used to manage multiple P4 packages.
 message PkgInfo {
@@ -56,6 +81,7 @@ message PkgInfo {
   // brief and detailed descriptions
   Documentation doc = 3;
   // Miscellaneous metadata, free-form; a way to extend PkgInfo
+  // raw annotations - deprecated, use anno_map
   repeated string annotations = 4;
   // the target architecture, e.g. "psa"
   string arch = 5;
@@ -65,6 +91,8 @@ message PkgInfo {
   string contact = 7;
   // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
   string url = 8;
+  // Annotation map derived from raw annotations
+  AnnotationMap anno_map = 9;
 }
 
 // wrapping the enum in a message to avoid name collisions in C++, where "enum
@@ -127,9 +155,12 @@ message Preamble {
   // P4 programmer may also be able to override the default alias for any P4
   // object (TBD).
   string alias = 3;
+  // raw annotations - deprecated, use anno_map
   repeated string annotations = 4;
   // Documentation of the entity
   Documentation doc = 5;
+  // Annotation map derived from raw annotations
+  AnnotationMap anno_map = 6;
 }
 
 // used to group all extern instances of the same type in one message
@@ -151,6 +182,7 @@ message ExternInstance {
 message MatchField {
   uint32 id = 1;
   string name = 2;
+  // raw annotations - deprecated, use anno_map
   repeated string annotations = 3;
   int32 bitwidth = 4;
   enum MatchType {
@@ -170,6 +202,8 @@ message MatchField {
   Documentation doc = 6;
   // unset if not user-defined type
   P4NamedType type_name = 8;
+  // Annotation map derived from raw annotations
+  AnnotationMap anno_map = 9;
 }
 
 message Table {
@@ -216,7 +250,11 @@ message ActionRef {
     DEFAULT_ONLY = 2;
   }
   Scope scope = 3;
+  
+  // raw annotations - deprecated, use anno_map
   repeated string annotations = 2;
+  // Annotation map derived from raw annotations
+  AnnotationMap anno_map = 3;
 }
 
 message Action {
@@ -224,12 +262,15 @@ message Action {
   message Param {
     uint32 id = 1;
     string name = 2;
+    // raw annotations - deprecated, use anno_map
     repeated string annotations = 3;
     int32 bitwidth = 4;
     // Documentation of the Param
     Documentation doc = 5;
     // unset if not user-defined type
     P4NamedType type_name = 6;
+    // Annotation map derived from raw annotations
+    AnnotationMap anno_map = 7;
   }
   repeated Param params = 2;
 }
@@ -317,10 +358,13 @@ message ControllerPacketMetadata {
     // This is the name of the header field (not fully-qualified), similar
     // to e.g. Action.Param.name.
     string name = 2;
+    // raw annotations - deprecated, use anno_map
     repeated string annotations = 3;
     int32 bitwidth = 4;
     // unset if not user-defined type
     P4NamedType type_name = 5;
+    // Annotation map derived from raw annotations
+    AnnotationMap anno_map = 6;
   }
   // Ordered based on header layout.
   // This is a constraint on the generator of this P4Info.

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -15,8 +15,6 @@
 syntax = "proto3";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/empty.proto";
-import "google/protobuf/wrappers.proto";
 import "p4/config/v1/p4types.proto";
 
 // This package and its contents are a work-in-progress.
@@ -48,24 +46,16 @@ message Documentation {
   string description = 2;
 }
 
-message KVmap {
-  map <string,string> property = 1;   // a map of key-value pairs
-}
-
 // A parsed representation of the annotation body.
-// Ex. empty annotation:   @my_anno1()
-// Ex. string annotation:  @my_anno2("Any text at all", for (i = 1 to 10) {print i} )
-// Ex. KV-pair annotation: @my_anno3(a=b,c=d)
-// NOTE: multiple KV annotations with the same tag are cumulative, so @my_anno3(a=b,c=d) in conjunction with
-//       @my_anno3(e=f) would result in 3 kv-pairs for my_anno3.
+// Ex. empty annotation:           @my_anno1()
+// Ex. ExpressionList annotation:  @my_anno2(1+1, "Hello", 1 << 3)
+// Ex. KV-pair annotation:         @my_anno3(a=b,c=d)
+// Ex. Cumulative kv-pair          @my_anno3(e=f)  // adds to my_anno3's properties
 message AnnotationBody {
-  oneof anno {
-    google.protobuf.Empty empty = 1;          // The annotation body is empty
-    google.protobuf.StringValue string = 2;   // The annotation body contains free-form string or expression 
-    KVmap kv_map = 3;                         // The annotation body contains one or more KV-pairs
-  }
+  repeated string expressions = 1;
+  map <string,string> properties = 2;
 }
-  
+ 
 // Top-level package documentation describing the forwarding pipeline config
 // Can be used to manage multiple P4 packages.
 message PkgInfo {
@@ -76,7 +66,7 @@ message PkgInfo {
   // brief and detailed descriptions
   Documentation doc = 3;
   // Miscellaneous metadata, free-form; a way to extend PkgInfo
-  // raw annotations - deprecated, use anno_map
+  // raw annotations - deprecated, use annotation_map
   repeated string annotations = 4;
   // the target architecture, e.g. "psa"
   string arch = 5;
@@ -86,8 +76,8 @@ message PkgInfo {
   string contact = 7;
   // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
   string url = 8;
-  // Annotation map derived from raw annotations
-  map <string,AnnotationBody> anno_map = 9;
+  // Annotation map derived from raw annotations, keyed by annotation tag
+  map <string,AnnotationBody> annotation_map = 9;
 }
 
 // wrapping the enum in a message to avoid name collisions in C++, where "enum
@@ -150,12 +140,12 @@ message Preamble {
   // P4 programmer may also be able to override the default alias for any P4
   // object (TBD).
   string alias = 3;
-  // raw annotations - deprecated, use anno_map
+  // raw annotations - deprecated, use annotation_map
   repeated string annotations = 4;
   // Documentation of the entity
   Documentation doc = 5;
-  // Annotation map derived from raw annotations
-  map <string,AnnotationBody> anno_map = 6;
+  // Annotation map derived from raw annotations, keyed by annotation tag
+  map <string,AnnotationBody> annotation_map = 6;
 }
 
 // used to group all extern instances of the same type in one message
@@ -177,7 +167,7 @@ message ExternInstance {
 message MatchField {
   uint32 id = 1;
   string name = 2;
-  // raw annotations - deprecated, use anno_map
+  // raw annotations - deprecated, use annotation_map
   repeated string annotations = 3;
   int32 bitwidth = 4;
   enum MatchType {
@@ -197,8 +187,8 @@ message MatchField {
   Documentation doc = 6;
   // unset if not user-defined type
   P4NamedType type_name = 8;
-  // Annotation map derived from raw annotations
-  map <string,AnnotationBody> anno_map = 9;
+  // Annotation map derived from raw annotations, keyed by annotation tag
+  map <string,AnnotationBody> annotation_map = 9;
 }
 
 message Table {
@@ -246,10 +236,10 @@ message ActionRef {
   }
   Scope scope = 3;
   
-  // raw annotations - deprecated, use anno_map
+  // raw annotations - deprecated, use annotation_map
   repeated string annotations = 2;
-  // Annotation map derived from raw annotations
-  map <string,AnnotationBody> anno_map = 6;
+  // Annotation map derived from raw annotations, keyed by annotation tag
+  map <string,AnnotationBody> annotation_map = 6;
 }
 
 message Action {
@@ -257,15 +247,15 @@ message Action {
   message Param {
     uint32 id = 1;
     string name = 2;
-    // raw annotations - deprecated, use anno_map
+    // raw annotations - deprecated, use annotation_map
     repeated string annotations = 3;
     int32 bitwidth = 4;
     // Documentation of the Param
     Documentation doc = 5;
     // unset if not user-defined type
     P4NamedType type_name = 6;
-    // Annotation map derived from raw annotations
-    map <string,AnnotationBody> anno_map = 7;
+    // Annotation map derived from raw annotations, keyed by annotation tag
+    map <string,AnnotationBody> annotation_map = 7;
   }
   repeated Param params = 2;
 }
@@ -353,13 +343,13 @@ message ControllerPacketMetadata {
     // This is the name of the header field (not fully-qualified), similar
     // to e.g. Action.Param.name.
     string name = 2;
-    // raw annotations - deprecated, use anno_map
+    // raw annotations - deprecated, use annotation_map
     repeated string annotations = 3;
     int32 bitwidth = 4;
     // unset if not user-defined type
     P4NamedType type_name = 5;
-    // Annotation map derived from raw annotations
-    map <string,AnnotationBody> anno_map = 6;
+    // Annotation map derived from raw annotations, keyed by annotation tag
+    map <string,AnnotationBody> annotation_map = 6;
   }
   // Ordered based on header layout.
   // This is a constraint on the generator of this P4Info.

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -43,19 +43,17 @@ package p4.config.v1;
  * *if serializable
  */
 
-// A parsed representation of the annotation body.
-// Ex. empty annotation:           @my_anno1()
-// Ex. expression list annotation: @my_anno2(1+1, "Hello", 1 << 3)
-// Ex. KV-pair annotation:         @my_anno3(a=b,c=d)
-// Ex. Cumulative kv-pair          @my_anno3(e=f)  // adds to my_anno3's properties
-message AnnotationBody {
-  repeated string expressions = 1;
-  map <string, string> properties = 2;
+// One parsed element within an annotation's body.
+message AnnotationElement {
+// Key is empty if and only if no key was specified
+  string key = 1;
+  string value = 2;
 }
 
-// A map of annotations keyed by the annotation tag following the @-sign
-message AnnotationMap {
-  map <string, AnnotationBody> annotations = 1;
+// An ordered list of annotations identified by the name
+message ParsedAnnotation {
+  string name = 1;
+  repeated AnnotationElement elements = 2;
 }
 
 // These P4 types (struct, header_type, header_union and enum) are guaranteed to
@@ -112,7 +110,7 @@ message P4BitstringLikeTypeSpec {
   // Useful to identify well-known types, such as IP address or Ethernet MAC
   // address.
   repeated string annotations = 4 [deprecated=true];
-  AnnotationMap annotation_map = 5;
+  repeated ParsedAnnotation parsed_annotations = 5;
 }
 
 message P4BitTypeSpec {
@@ -140,7 +138,7 @@ message P4StructTypeSpec {
   }
   repeated Member members = 1;
   repeated string annotations = 2 [deprecated=true];
-  AnnotationMap annotation_map = 3;
+  repeated ParsedAnnotation parsed_annotations = 3;
 }
 
 message P4HeaderTypeSpec {
@@ -150,7 +148,7 @@ message P4HeaderTypeSpec {
   }
   repeated Member members = 1;
   repeated string annotations = 2 [deprecated=true];
-  AnnotationMap annotation_map = 3;
+  repeated ParsedAnnotation parsed_annotations = 3;
 }
 
 message P4HeaderUnionTypeSpec {
@@ -160,7 +158,7 @@ message P4HeaderUnionTypeSpec {
   }
   repeated Member members = 1;
   repeated string annotations = 2 [deprecated=true];
-  AnnotationMap annotation_map = 3;
+  repeated ParsedAnnotation parsed_annotations = 3;
 }
 
 message P4HeaderStackTypeSpec {
@@ -179,11 +177,11 @@ message P4EnumTypeSpec {
   message Member {
     string name = 1;
     repeated string annotations = 2 [deprecated=true];
-    AnnotationMap annotation_map = 3;
+    repeated ParsedAnnotation parsed_annotations = 3;
   }
   repeated Member members = 1;
   repeated string annotations = 2 [deprecated=true];
-  AnnotationMap annotation_map = 3;
+  repeated ParsedAnnotation parsed_annotations = 3;
 }
 
 // For serializable (or "unsafe") enums, which have an underlying type. Note
@@ -194,13 +192,13 @@ message P4SerializableEnumTypeSpec {
     string name = 1;
     bytes value = 2;
     repeated string annotations = 3 [deprecated=true];
-    AnnotationMap annotation_map = 4;
+    repeated ParsedAnnotation parsed_annotations = 4;
   }
 
   P4BitTypeSpec underlying_type = 1;
   repeated Member members = 2;
   repeated string annotations = 3 [deprecated=true];
-  AnnotationMap annotation_map = 4;
+  repeated ParsedAnnotation parsed_annotations = 4;
 }
 
 // Similar to an enum, but there is always one and only one instance per P4
@@ -228,7 +226,7 @@ message P4NewTypeSpec {
   }
   // for other annotations (not @p4runtime_translation)
   repeated string annotations = 3 [deprecated=true];
-  AnnotationMap annotation_map = 4;
+  repeated ParsedAnnotation parsed_annotations = 4;
 }
 
 // End of P4 type specs --------------------------------------------------------

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -43,6 +43,21 @@ package p4.config.v1;
  * *if serializable
  */
 
+// A parsed representation of the annotation body.
+// Ex. empty annotation:           @my_anno1()
+// Ex. expression list annotation: @my_anno2(1+1, "Hello", 1 << 3)
+// Ex. KV-pair annotation:         @my_anno3(a=b,c=d)
+// Ex. Cumulative kv-pair          @my_anno3(e=f)  // adds to my_anno3's properties
+message AnnotationBody {
+  repeated string expressions = 1;
+  map <string, string> properties = 2;
+}
+
+// A map of annotations keyed by the annotation tag following the @-sign
+message AnnotationMap {
+  map <string, AnnotationBody> annotations = 1;
+}
+
 // These P4 types (struct, header_type, header_union and enum) are guaranteed to
 // have a fully-qualified name (e.g. you cannot use an anonymous struct to
 // declare a variable like in C). Instead of duplicating the type spec for these
@@ -96,7 +111,8 @@ message P4BitstringLikeTypeSpec {
   }
   // Useful to identify well-known types, such as IP address or Ethernet MAC
   // address.
-  repeated string annotations = 4;
+  repeated string annotations = 4 [deprecated=true];
+  AnnotationMap annotation_map = 5;
 }
 
 message P4BitTypeSpec {
@@ -123,7 +139,8 @@ message P4StructTypeSpec {
     P4DataTypeSpec type_spec = 2;
   }
   repeated Member members = 1;
-  repeated string annotations = 2;
+  repeated string annotations = 2 [deprecated=true];
+  AnnotationMap annotation_map = 3;
 }
 
 message P4HeaderTypeSpec {
@@ -132,7 +149,8 @@ message P4HeaderTypeSpec {
     P4BitstringLikeTypeSpec type_spec = 2;
   }
   repeated Member members = 1;
-  repeated string annotations = 2;
+  repeated string annotations = 2 [deprecated=true];
+  AnnotationMap annotation_map = 3;
 }
 
 message P4HeaderUnionTypeSpec {
@@ -141,7 +159,8 @@ message P4HeaderUnionTypeSpec {
     P4NamedType header = 2;
   }
   repeated Member members = 1;
-  repeated string annotations = 2;
+  repeated string annotations = 2 [deprecated=true];
+  AnnotationMap annotation_map = 3;
 }
 
 message P4HeaderStackTypeSpec {
@@ -159,10 +178,12 @@ message P4HeaderUnionStackTypeSpec {
 message P4EnumTypeSpec {
   message Member {
     string name = 1;
-    repeated string annotations = 2;
+    repeated string annotations = 2 [deprecated=true];
+    AnnotationMap annotation_map = 3;
   }
   repeated Member members = 1;
-  repeated string annotations = 2;
+  repeated string annotations = 2 [deprecated=true];
+  AnnotationMap annotation_map = 3;
 }
 
 // For serializable (or "unsafe") enums, which have an underlying type. Note
@@ -172,11 +193,14 @@ message P4SerializableEnumTypeSpec {
   message Member {
     string name = 1;
     bytes value = 2;
-    repeated string annotations = 3;
+    repeated string annotations = 3 [deprecated=true];
+    AnnotationMap annotation_map = 4;
   }
+
   P4BitTypeSpec underlying_type = 1;
   repeated Member members = 2;
-  repeated string annotations = 3;
+  repeated string annotations = 3 [deprecated=true];
+  AnnotationMap annotation_map = 4;
 }
 
 // Similar to an enum, but there is always one and only one instance per P4
@@ -203,7 +227,8 @@ message P4NewTypeSpec {
     P4NewTypeTranslation translated_type = 2;
   }
   // for other annotations (not @p4runtime_translation)
-  repeated string annotations = 3;
+  repeated string annotations = 3 [deprecated=true];
+  AnnotationMap annotation_map = 4;
 }
 
 // End of P4 type specs --------------------------------------------------------


### PR DESCRIPTION
#234 - Add annotation maps. I added to `p4info.proto` and updated the P4Runtime spec with an example. I generated the example P4Info by using the proposed enhanced `p4info.proto`, reading in actual `xxx.p4info.txt` from current `p4c`, parsing the P4info using python, adding parsed annotations to the P4info "DOM" (with generated `p4info_pb2.py` libs from the new `p4info.proto`) then emitting it.

If acceptable, hopefully `p4c` can be enhanced to do the *adding parsed annotations to the P4info "DOM"* task