### PR TITLE
Add linter for P4Runtime Madoko spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
 # protoc), then we generate the HTML for the spec.
 script:
   - docker run -t p4runtime-ci /p4runtime/CI/compile_protos.sh /tmp/ || travis_terminate 1
-  - docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-madoko:latest make
+  - docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-madoko:latest make || travis_terminate 1
+  - ./tools/madokolint.py docs/v1/P4Runtime-Spec.mdk
 
 after_success:
   - ls docs/v1/build

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -371,14 +371,15 @@ The following are not in scope of this specification document:
     identification of resources.
 
 # Reference Architecture { #sec-reference-architecture}
+
 Figure [#fig-reference-architecture] represents the P4Runtime Reference
 Architecture. The device or target to be controlled is at the bottom, and one or
 more controllers is shown at the top. A multi-master protocol allows more than
 one controller to participate, and a role-based arbitration scheme ensures only
-one controller has write access to each read/write entity, or the pipeline config
-itself. Any controller may perform read access to any entity or the pipeline
-config. Later sections describe this in detail. For the sake of brevity, the
-term controller may refer to one or more controllers.
+one controller has write access to each read/write entity, or the pipeline
+config itself. Any controller may perform read access to any entity or the
+pipeline config. Later sections describe this in detail. For the sake of
+brevity, the term controller may refer to one or more controllers.
 
 The P4Runtime API defines the messages and semantics of the interface between
 the client(s) and the server. The API is specified by the p4runtime.proto
@@ -612,7 +613,8 @@ arbitration scheme supports it.
 caption: "Use-Case: Embedded Plus Two Remote High-Availability Controllers" }
 ![embedded-plus-two-remote-ha-controllers]
 ~
-[embedded-plus-two-remote-ha-controllers]: build/embedded-plus-two-remote-ha-controllers.[svg,png] \
+[embedded-plus-two-remote-ha-controllers]: \
+build/embedded-plus-two-remote-ha-controllers.[svg,png] \
 { height: 7cm; page-align: forcehere }
 
 # Master-Slave Arbitration and Controller Replication {\
@@ -789,7 +791,7 @@ It is the job of the P4Runtime server to remember the `role.config` for every
     3. If `role.config` does not match the "out-of-band" scheme previously
        agreed upon, the server must return an `INVALID_ARGUMENT` error.
 
-    4. If the number of open streams for the given (`device_id`, `role_id`) 
+    4. If the number of open streams for the given (`device_id`, `role_id`)
        exceeds the supported limit, the P4Runtime server shall terminate the
        stream by returning a `RESOURCE_EXHAUSTED` error.
 
@@ -1080,7 +1082,8 @@ Above we see several different types of annotations:
 
 * `@brief` - This will populate the `PkgInfo.doc.brief` message field.
 
-* `@description` - This will populate the `PkgInfo.doc.description` message field
+* `@description` - This will populate the `PkgInfo.doc.description` message
+  field
 
 * `@<anything else>` - This will create a `PkgInfo.annotation` entry
 
@@ -1350,8 +1353,8 @@ The `ActionProfile` message includes the following fields:
   instance of a PSA Action Selector extern.
 
 * `size`, an `int64` representing the maximum number of member entries that the
-  Action Profile can hold, or, in the case of an Action Selector, the maximum sum
-  of all member weights across all selector groups.
+  Action Profile can hold, or, in the case of an Action Selector, the maximum
+  sum of all member weights across all selector groups.
 
 * `max_group_size`, an `int32` representing the maximum sum of all member
   weights within any given selector group, in the case of an Action Selector, or
@@ -2083,11 +2086,11 @@ the encoder of a P4Runtime request or reply uses the shortest strings that
 fit the encoded integer values.
 
 Representation of variable-length integer values (`varbit<W>` P4 type) is
-similar to the representation of fixed-width unsigned integers. We use a binary string,
-whose length is the *dynamic-length* of the expression. When the value is
-provided by the P4Runtime client, the server must verify that the length of the
-binary string is less than the maximum length specified in the P4 program, and
-return an `OUT_OF_RANGE` error code otherwise.
+similar to the representation of fixed-width unsigned integers. We use a binary
+string, whose length is the *dynamic-length* of the expression. When the value
+is provided by the P4Runtime client, the server must verify that the length of
+the binary string is less than the maximum length specified in the P4 program,
+and return an `OUT_OF_RANGE` error code otherwise.
 
 ## Representation of Arbitrary P4 Types { #sec-representation-of-arbitrary-p4-types}
 
@@ -2347,8 +2350,8 @@ underlying type need to have a corresponding name. `P4TypeInfo` includes the
 mapping between entry name and entry value. When providing serializable enum
 values through `P4Data`, one must use the assigned integer value (`enum_value`
 bytestring field). P4Runtime does not provide a way for the client to use the
-name --- even when the enum member has one --- instead of the value, as it makes it
-easier for the server to respect the [read-write
+name --- even when the enum member has one --- instead of the value, as it makes
+it easier for the server to respect the [read-write
 symmetry](#sec-read-write-symmetry) principle.
 
 ### User-defined types { #sec-user-defined-types}
@@ -2741,8 +2744,8 @@ entry, including with regards to [direct resources](#sec-direct-resources).
 
 In this P4Runtime release, we have decided to restrict the default entry for
 indirect tables --- tables with an ActionProfile or ActionSelector
-`implementation` property --- to a constant `NoAction` action entry, with the hope
-that it would simplify the implementation of the P4Runtime service.
+`implementation` property --- to a constant `NoAction` action entry, with the
+hope that it would simplify the implementation of the P4Runtime service.
 
 ### Constant Tables
 
@@ -3104,8 +3107,8 @@ An `ActionProfileMember` entity update message has the following fields:
 * `action_profile_id` is the `uint32` identifier of the PSA ActionProfile or
   ActionSelector extern instance, as defined in P4Info.
 
-* `member_id` is the `uint32` identifier of the action profile member entry being
-  updated.
+* `member_id` is the `uint32` identifier of the action profile member entry
+  being updated.
 
 * `action` is the specification of the P4 action instance bound to the action
   profile member entry.
@@ -4299,7 +4302,8 @@ message WriteRequest {
 
 The `device_id` uniquely identifies the target P4 device. The `role_id` and
 `election_id` define the client role and election-id as described in the
-[Master-Slave Arbitration and Controller Replication](#sec-master-slave-arbitration-and-controller-replication)
+[Master-Slave Arbitration and Controller
+Replication](#sec-master-slave-arbitration-and-controller-replication)
 section. The server is expected to perform the following checks (in this order)
 before processing the `updates` list:
 
@@ -4438,8 +4442,8 @@ enum. A P4Runtime server is required to support only the modes marked as
   entire batch must be atomic from a data plane point of view. Every data plane
   packet is guaranteed to be processed according to table contents before the
   batch began, or after the batch completes. The batch is therefore treated as a
-  *transaction*. The details and design of how to achieve data plane-atomicity is
-  outside the scope of this specification. One possibility is to limit the
+  *transaction*. The details and design of how to achieve data plane-atomicity
+  is outside the scope of this specification. One possibility is to limit the
   target to half of the data plane's table capacity at all times. At the start
   of the batch processing, the remaining half of the table capacity can be
   initialized with the current table state and used as a working area to commit
@@ -4614,8 +4618,8 @@ A P4Runtime server will process the batch as follows:
 ### Example
 
 If a client asked to read `{a,b,c,d}` and `b` and `d` *requests* didn't
-validate, the server will return entities corresponding to `a` and `c`, followed by
-a status `{p4.Error(OK), p4.Error(xxx), p4.Error(yyy), p4.Error(OK)}` in the
+validate, the server will return entities corresponding to `a` and `c`, followed
+by a status `{p4.Error(OK), p4.Error(xxx), p4.Error(yyy), p4.Error(OK)}` in the
 `details` field.
 
 The P4Runtime server is not required to perform any optimization (&eg; merge two

--- a/tools/madokolint.py
+++ b/tools/madokolint.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# DISCLAIMER: This is a work in progress. This linter was written specifically
+# for the P4Runtime specification document and may not be useful for other
+# Madoko documents, as it may be making some assumptions as to how the document
+# was written.
+
+# TODO: handle Madoko includes (we do not use them for the P4Runtime spec)?
+
+
+import argparse
+from collections import namedtuple
+import os.path
+import re
+import sys
+
+
+LINE_WRAP_LENGTH = 80
+
+
+parser = argparse.ArgumentParser(description='Lint tool for Madoko code')
+parser.add_argument('files', metavar='FILE', type=str, nargs='+',
+                    help='Input files')
+
+
+class MadokoFmtError(Exception):
+    def __init__(self, filename, lineno, description):
+        self.filename = filename
+        self.lineno = lineno
+        self.description = description
+
+    def __str__(self):
+        return "Unexpected Madoko code in file {} at line {}: {}".format(
+            self.filename, self.lineno, self.description)
+
+
+class LintState:
+    def __init__(self):
+        self.errors_cnt = 0
+
+    def error(self, filename, lineno, line, description):
+        # TODO: print line later?
+        print("Error in file {} at line {}: {}.".format(filename, lineno, description))
+        self.errors_cnt += 1
+
+
+lint_state = LintState()
+
+
+class Context:
+    """A context is an object that is used to determine whether a specific "checker" (check_*
+    method) should visit a given line."""
+
+    def enter(self, line, filename, lineno):
+        """Called before visiting a line.
+        Returns True iff the checker should visit the given line.
+        """
+        return True
+
+    def exit(self, line, filename, lineno):
+        """Called after visiting a line."""
+        pass
+
+
+class ContextSkipBlocks(Context):
+    """A context used to only visit Madoko code outside of blocks."""
+
+    Block = namedtuple('Block', ['num_tildes', 'name'])
+
+    def __init__(self):
+        self.p_block = re.compile('^ *(?P<tildes>~+) *(?:(?P<cmd>Begin|End)(?: +))?(?P<name>\w+)?')
+        self.blocks_stack = []
+
+    def enter(self, line, filename, lineno):
+        m = self.p_block.match(line)
+        if m:
+            num_tildes = len(m.group("tildes"))
+            has_begin = m.group("cmd") == "Begin"
+            has_end = m.group("cmd") == "End"
+            blockname = m.group("name")
+
+            if has_begin:
+                self.blocks_stack.append(self.Block(num_tildes, blockname))
+                return False
+            if has_end:
+                if not self.blocks_stack:
+                    raise MadokoFmtError(filename, lineno, "Block end line but no block was begun")
+                expected = self.blocks_stack.pop()
+                if num_tildes != expected.num_tildes or blockname != expected.name:
+                    raise MadokoFmtError(
+                        filename, lineno,
+                        "Block end line does not match last visited block begin line")
+                return False
+            if blockname is None:
+                if not self.blocks_stack:
+                    raise MadokoFmtError(filename, lineno, "Block end line but no block was begun")
+                expected = self.blocks_stack.pop()
+                if num_tildes != expected.num_tildes:
+                    raise MadokoFmtError(
+                        filename, lineno,
+                        "Block end line does not match last visited block begin line")
+                return False
+            self.blocks_stack.append(self.Block(num_tildes, blockname))
+            return False
+        if self.blocks_stack:
+            return False
+        return True
+
+
+# TODO: would "skip metadata" be more generic?
+class ContextAfterTitle(Context):
+    """A context used to visit only Madoko code after the [TITLE] block element.
+    """
+
+    def __init__(self, *args):
+        self.title_found = False
+        self.p_title = re.compile('^ *\[TITLE\] *$')
+
+    def enter(self, line, filename, lineno):
+        if self.title_found:
+            return True
+        self.title_found = self.p_title.match(line) is not None
+        return False
+
+
+class ContextSkipHeadings(Context):
+    """A context used to skip headings (lines starting with #)."""
+
+    def __init__(self, *args):
+        self.p_headings = re.compile('^ *#')
+
+    def enter(self, line, filename, lineno):
+        return self.p_headings.match(line) is None
+
+
+class ContextCompose(Context):
+    """A special context used to combine an arbitrary number of contexts."""
+
+    def __init__(self, *args):
+        self.contexts = list(args)
+
+    def enter(self, line, filename, lineno):
+        res = True
+        for c in self.contexts:
+            # we use a short-circuit on purpose, if a context returns False we do not even enter
+            # subsequent contexts. This has some implications on how contexts are used.
+            res = res and c.enter(line, filename, lineno)
+        return res
+
+    def exit(self, line, filename, lineno):
+        for c in self.contexts:
+            c.exit(line, filename, lineno)
+
+
+def foreach_line(path, context, fn):
+    """Iterate over every line in the file. For each line, call fn iff the enter method of the
+    provided context returns True."""
+    lineno = 1
+    with open(path, 'r') as f:
+        for line in f:
+            if context.enter(line, path, lineno):
+                fn(line, lineno)
+            lineno += 1
+            context.exit(line, path, lineno)
+
+
+def check_line_wraps(path):
+    def check(line, lineno):
+        if "http" in line:  # TODO: we can probably do better than this
+            return
+        if len(line) > LINE_WRAP_LENGTH + 1:  # +1 for the newline characted
+            lint_state.error(path, lineno, line,
+                             "is more than {} characters long".format(LINE_WRAP_LENGTH))
+
+    foreach_line(path,
+                 ContextCompose(ContextAfterTitle(), ContextSkipBlocks(), ContextSkipHeadings()),
+                 check)
+
+
+def check_trailing_whitespace(path):
+    def check(line, lineno):
+        if len(line) >= 2 and line[-2].isspace():
+            lint_state.error(path, lineno, line, "trailing whitespace")
+
+    foreach_line(path, Context(), check)
+
+def check_predefined_abbreviations(path):
+    abbreviations = {
+        'e.g.': '&eg;',
+        'i.e.': '&ie;',
+        'et al.': '&etal;',
+    }
+
+    def check(line, lineno):
+        for k, v in abbreviations.items():
+            if k in line:
+                lint_state.error(path, lineno, line,
+                                 "contains '{}', use '{}' instead".format(k, v))
+
+    foreach_line(path, ContextCompose(ContextAfterTitle(), ContextSkipBlocks()), check)
+
+
+def process_one(path):
+    check_line_wraps(path)
+    check_predefined_abbreviations(path)
+    check_trailing_whitespace(path)
+
+
+def main():
+    args = parser.parse_args()
+
+    for f in args.files:
+        if not os.path.isfile(f):
+            print("'{}' is not a valid file path".format(f))
+            sys.exit(1)
+        _, ext = os.path.splitext(f)
+        if ext != ".mdk":
+            print("'{}' does not have an .mdk extension")
+            sys.exit(1)
+
+    for f in args.files:
+        try:
+            process_one(f)
+        except MadokoFmtError as e:
+            print(e)
+
+    errors_cnt = lint_state.errors_cnt
+    print("**********")
+    print("Errors found: {}".format(errors_cnt))
+    rc = 0 if errors_cnt == 0 else 2
+    sys.exit(rc)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
It is quite a primitive tool at the moment but it makes sure that:
 * there is no trailing whitespace
 * lines longer than 80 chars are wrapped
 * `&eg;` and `&ie;` are used