### PR TITLE
Remove reference to xform from bibliography

### DIFF
--- a/docs/v1/references.bib
+++ b/docs/v1/references.bib
@@ -29,12 +29,6 @@
     url = "https://stratumproject.org/"
 }
 
-@ONLINE { xform,
-    title = "P4Info transfom utility",
-    subtitle = "Add meta information to P4Info",
-    url = "https://github.com/p4lang/PI/tree/master/proto/p4info/xform"
-}
-
 @ONLINE { P4ComplexTypes,
     title = "Complex types in $P4_{16}$",
     url = "https://p4.org/p4-spec/docs/P4-16-v1.1.0-spec.html#sec-p4-type"


### PR DESCRIPTION
References to xform where removed from the spec after support for
"documentation" annotations was added to the standard p4c compiler. It
seems that we forgot to remove the "xform" entry from the bibliography
at the time.