### PR TITLE
Update commit author date when deploying spec

### DIFF
--- a/CI/deploy.sh
+++ b/CI/deploy.sh
@@ -29,5 +29,5 @@ cp -r docs/v1/build spec/$TARGET_DIR
 
 # Amend previous commit and force-push to gh-pages
 git add spec
-git commit --amend -m "Publish spec from Travis"
+git commit --amend --date=now -m "Publish spec from Travis"
 git push -f $REMOTE_NAME $TARGET_BRANCH


### PR DESCRIPTION
This makes it clear when the spec was last updated when looking at gh-pages.