### PR TITLE
Added Structured Annotations

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1042,7 +1042,7 @@ representations of the original annotation source. This parsing includes
 expression-evaluation, so the resulting `P4Info` may contain a simplified
 replica of the original structured annotations.
 
-The structured annotation messages are defined in `p4types.proto`.
+The structured annotation messages are defined in p4types.proto.
 
 ~ Begin Proto
 message KeyValuePair {

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -2477,7 +2477,7 @@ the `TableEntry` entity, which has the following fields:
   match and with which argument values.
 
 * `priority`, a 32-bit integer used to order entries when the table's match key
-  includes a ternary or range match.
+  includes an optional, ternary or range match.
 
 * `controller_metadata`, a 64-bit cookie value which is opaque to the
   target. There is no requirement of where this is stored, but it must be
@@ -2502,7 +2502,8 @@ the `TableEntry` entity, which has the following fields:
 
 The `priority` field must be set to a non-zero value if the match key includes a
 ternary match (&ie; in the case of PSA if the P4Info entry for the table
-indicates that one or more of its match fields has a `TERNARY` or `RANGE` match
+indicates that one or more of its match fields has an `OPTIONAL`, `TERNARY` or
+`RANGE` match
 type) or to zero otherwise. A higher priority number indicates that the entry
 must be given higher priority when performing a table lookup. Clients must allow
 multiple entries to be added with the same priority value.  If a packet can
@@ -2545,6 +2546,8 @@ to ensure [read-write symmetry](#sec-read-write-symmetry). For PSA match types,
 a "don't care" match for a specific match key field is defined as follows:
 
 * For a `TERNARY` match, it is logically equivalent to a mask of zeros.
+
+* For a `OPTIONAL` match, it is logically equivalent to a wildcard match.
 
 * For an `LPM` match, it is logically equivalent to a prefix_len of zero.
 
@@ -2666,6 +2669,14 @@ assert(low <= high)
 assert(low != min_field_value || high != max_field_value)
 ~ End Pseudo
 
+* `OPTIONAL` match
+    * The binary string encoding of the value must conform to the
+      [Bytestrings](#sec-bytestrings) requirements.
+
+~ Begin Pseudo
+assert(BytestringValid(match.optional().value()))
+~ End Pseudo
+
 ### Action Specification
 
 The `TableEntry` `action` field must be set for every `INSERT` update but may be
@@ -2773,9 +2784,9 @@ static entries. If the table requires a priority value for entries, the server
 must populate the `priority` field appropriately, starting at 1 for the lowest
 priority entry and incrementing the value by 1 for each successive entry. Note
 that P4~16~ does not support assigning explicit priorities to static
-entries. When a priority value is required (&eg; for tables including `RANGE`
-and / or `TERNARY` matches in the case of PSA), it is inferred based on the
-order in which entries appear in the table declaration.
+entries. When a priority value is required (&eg; for tables including `RANGE`,
+`TERNARY` or `OPTIONAL` matches), it is inferred based on the order in which
+entries appear in the table declaration.
 
 ### Wildcard Reads { #sec-table-wildcard-reads}
 
@@ -2899,7 +2910,7 @@ entities {
 }
 ~ End Prototext
 
-This issue also exists for tables with `TERNARY` and / or `RANGE`
+This issue also exists for tables with `TERNARY`, `RANGE`, and `OPTIONAL`
 matches. However, in this case the priority is also taken into account for
 wildcard reads, and because a priority of 0 is not valid, in practice only the
 entries with the same priority as the "don't care" entry will be returned to the
@@ -3952,10 +3963,10 @@ can perform a `MODIFY` update with an empty `members` repeated field.
 
 To facilitate [read-write symmetry](#sec-read-write-symmetry), the server must
 return an `ALREADY_EXISTS` error in case of duplicate members. Unlike for match
-tables, a priority value is not required for ternary and range matches:
-overlapping entries do not need to be ordered and the parse state transition
-is determined by whether or not the packet matches at least one entry in the
-set.
+tables, a priority value is not required for ternary, range and optional
+matches: overlapping entries do not need to be ordered and the parse state
+transition is determined by whether or not the packet matches at least one entry
+in the set.
 
 See Appendix [#sec-value-set-example] for a more complex Value Set example.
 
@@ -5595,8 +5606,9 @@ An architecture may introduce new table match types [@P4MatchTypes]. P4Runtime
 accounts for this by providing the following hooks:
 
 * The `match` field in `p4.config.v1.MatchField` (p4info.proto) is a `oneof`
-  which can be either one of the default match types (`EXACT`, `LPM`, `TERNARY`
-  or `RANGE`) or an architecture-specific match type encoded as a string.
+  which can be either one of the default match types (`EXACT`, `LPM`, `TERNARY`,
+  `RANGE`, or `OPTIONAL`) or an architecture-specific match type encoded as a
+  string.
 
 * The `field_match_type` field in `p4.v1.FieldMatch` (p4runtime.proto) is a
   `oneof` which includes an `Any` Protobuf message [@ProtoAny] field

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1106,15 +1106,11 @@ table t {
 }
 ~ End P4Example
 
-The generated P4Info will contain the following. An empty structured annotation
-body generates an empty `expression_list` to remain consistent with the P4
-Language Spec.
+The generated P4Info will contain the following.
 
 ~ Begin Proto
 structured_annotations {
   name: "Empty"
-  expression_list {
-  }
 }
 ~ End Proto
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1059,7 +1059,6 @@ message Expression {
     string string_value = 1;
     int64 int64_value = 2;
     bool bool_value = 3;
-    ExpressionList expr_list_value = 4;
   }
 }
 
@@ -1079,15 +1078,13 @@ message StructuredAnnotation {
 The `StructuredAnnotation` message can represent either a `KeyValuePairList`
 or an `ExpressionList`.
 
-The type of an expression is intentionally limited to a practical subset:
-string literal, 64-bit signed integer, boolean, or a nested list of
-`Expression`s. This is more restrictive than the P4 language but provides
-reasonable types for known annotation use-cases. The `p4c` compiler frontend
-which generates `P4Info` will evaluate all expressions and simplify them to
-one of the valid types. Any expressions which don't match one of the valid
-types will generate an error. For integers exceeding 64 bits, besides issuing
-an error, the compiler *could* print a suggestion to use a string
-representation, and the `P4Info` consumer could perform any necessary
+The type of an expression is intentionally limited to one of the following
+base types: string literal, 64-bit signed integer, or boolean. The `p4c`
+compiler frontend which generates `P4Info` will evaluate all expressions and
+simplify them to one of the valid types. Any expressions which don't match one
+of the valid types will generate an error. For integers exceeding 64 bits,
+besides issuing an error, the compiler *could* print a suggestion to use a
+string representation, and the `P4Info` consumer could perform any necessary
 conversions.
 
 The following invariants hold:
@@ -1152,105 +1149,16 @@ structured_annotations {
   }
 }
 ~ End Proto
-
-**Nested Expression List**
-
-~ Begin P4Example
-@NestedExprLists[1,TEXT_CONST,true,1==2,{3, 4, {5, 6}}]
-#define TEXT_CONST "hello"
-#define NUM_CONST 6
-@MixedExprList[1,TEXT_CONST,true,1==2,5+NUM_CONST]
-table t {
-    ...
-}
-~ End P4Example
-
-The generated p4Info will contain:
-
-~ Begin Proto
-structured_annotations {
-  name: "NestedExprLists"
-  expression_list {
-    expressions {
-      int64_value: 1
-    }
-    expressions {
-      string_value: "hello"
-    }
-    expressions {
-      bool_value: true
-    }
-    expressions {
-      bool_value: false
-    }
-    expressions {
-      expr_list_value {
-        expressions {
-          int64_value: 3
-        }
-        expressions {
-          int64_value: 4
-        }
-        expressions {
-          expr_list_value {
-            expressions {
-              int64_value: 5
-            }
-            expressions {
-              int64_value: 6
-            }
-          }
-        }
-      }
-    }
-  }
-}
-~ End Proto
-
-**kvList of Strings**
-
-~ Begin P4Example
-@Labels[short="Short Label", hover="My Longer Table Label to appear in hover-help"]
-table t {
-    ...
-}
-~ End P4Example
-
-The generated p4Info will contain:
-
-~ Begin Proto
-structured_annotations {
-  name: "Labels"
-  kvpair_list {
-    kv_pairs {
-      key: "short"
-      value {
-        string_value: "Short Label"
-      }
-    }
-    kv_pairs {
-      key: "hover"
-      value {
-        string_value: "My Longer Table Label to appear in hover-help"
-      }
-    }
-  }
-}
 ~ End Proto
 
 **kvList of Mixed Expressions**
 
-The following example will produce a more  complex `kvList`: one of
-the `kvPair`s has a value which is itself an `{expressionList}`, which is a
-valid form of an expression.
-
 ~ Begin P4Example
-@MixedKV[label="text", my_bool=true, list_key={"a", 5+6, 1==2}, int_val=2*3]
+@MixedKV[label="text", my_bool=true, int_val=2*3]
 table t {
     ...
 }
 ~ End P4Example
-
 
 The generated p4Info will contain:
 
@@ -1268,22 +1176,6 @@ structured_annotations {
       key: "my_bool"
       value {
         bool_value: true
-      }
-    }
-    kv_pairs {
-      key: "list_key"
-      value {
-        expr_list_value {
-          expressions {
-            string_value: "a"
-          }
-          expressions {
-            int64_value: 11
-          }
-          expressions {
-            bool_value: true
-          }
-        }
       }
     }
     kv_pairs {

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -989,6 +989,7 @@ message Preamble {
   repeated string annotations = 4;
   // Documentation of the entity
   Documentation doc = 5;
+  repeated StructuredAnnotation structured_annotations = 6;
 }
 ~ End Proto
 
@@ -1020,6 +1021,257 @@ table my_ipv4_lkup {
 }
 ~ End p4example
 
+### Structured Annotations
+
+P4 supports both unstructured and structured annotations [@P4Annotations].
+Unstructured annotations of the form `MyAnno1` or `MyAnno2(body-content)` can
+either be empty, or contain free-form content; anything between the pair of
+matched parentheses is legal. Conversely, structured annotations of the form
+`MyAnno3[]` or `MyAnno4[kvList|expressionList]` have a more prescribed syntax,
+which allows declaring key-value lists or expression lists. Both unstructured
+and structured annotations may be used simultaneously on a P4 element and
+`P4Info` supports this.
+
+The annotations described up to this point, &eg; `@brief()`, have all been
+unstructured annotations, or simply annotations. These are represented in
+`P4Info` as `repeated string annotations` fields in the various `message`s.
+Similarly, structured annotations are represented in
+`repeated structured_annotations` fields which are siblings to the unstructured
+`annotations`. The `structured_annotations` contain parsed representations of
+the original annotation source. This parsing includes expression-evaluation,
+so the resulting `P4Info` may contain a simplified replica of the original
+structured annotations.
+
+The structured annotation messages are defined in `p4types.proto`.
+
+~ Begin Proto
+// One parsed element within a structured annotation's body.
+message StructuredAnnotationElement {
+// Key is empty if and only if no key was specified
+  string key = 1;
+  StructuredAnnotationValue value = 2;
+}
+
+// A structured annotation value may be scalar or a list
+message StructuredAnnotationValue {
+  oneof value {
+    ExpressionValue expression = 1;
+    ExpressionList expression_list = 2;
+  }
+}
+
+// Various value types
+message ExpressionValue {
+  oneof value {
+    string string_value = 1;
+    int64 int64_value = 2;
+    bool bool_value = 3;
+  }
+}
+
+// A list of expressions
+message ExpressionList {
+  repeated ExpressionValue expressions = 1;
+}
+
+// An ordered list of annotations identified by the name
+message StructuredAnnotation {
+  string name = 1;
+  repeated StructuredAnnotationElement elements = 2;
+}
+~ End Proto
+
+The `StructuredAnnotationElement` can represent a `kvPair` as a `key` and a
+`value`; alternatively, it can represent an `expression` as a keyless value.
+Therefore a `kvList` or `expressionList` can both use the same
+`StructuredAnnotation` message with the annotation `name` and a list of
+`StructuredAnnotationElement`s.
+
+The type of an expression is intentionally limited to a practical subset:
+string literal, 64-bit signed integer, boolean, or a list of any of these.
+This is more restrictive than the P4 language but provides reasonable types
+for known annotation use-cases. The `p4c` compiler frontend which generates
+`P4Info` will evaluate all expressions and simplify them to one of the three
+types. Any expressions which don't match one of the valid types will generate
+an error.
+
+The following invariants hold:
+
+1. For any P4 entity, there are no two `StructuredAnnotation`s that have the
+same name.
+
+2. Within a `StructuredAnnotation`, there are no two
+`StructuredAnnotationElement`s that have the same key, except for the empty
+key, which can appear any number of times to represent `expressionList`s.
+
+### Structured Annotation Examples
+
+**Empty Expression List**
+
+~ Begin P4Example
+@Empty[]
+table t {
+    ...
+}
+~ End P4Example
+
+The generated p4Info will contain:
+
+~ Begin Proto
+structured_annotations {
+  name: "Empty"
+}
+~ End Proto
+
+**Mixed Expression List**
+
+~ Begin P4Example
+#define TEXT_CONST "hello"
+#define NUM_CONST 6
+@MixedExprList[1,TEXT_CONST,true,1==2,5+NUM_CONST]
+table t {
+    ...
+}
+~ End P4Example
+
+The generated p4Info will contain:
+
+~ Begin Proto
+structured_annotations {
+  name: "MixedExprList"
+  elements {
+    value {
+      expression {
+        int64_value: 1
+      }
+    }
+  }
+  elements {
+    value {
+      expression {
+        string_value: "hello"
+      }
+    }
+  }
+  elements {
+    value {
+      expression {
+        bool_value: true
+      }
+    }
+  }
+  elements {
+    value {
+      expression {
+        bool_value: false
+      }
+    }
+  }
+  elements {
+    value {
+      expression {
+        int64_value: 11
+      }
+    }
+  }
+}
+~ End Proto
+
+**kvList of Strings**
+
+~ Begin P4Example
+@Labels[short="Short Label", hover="My Longer Table Label to appear in hover-help"]
+table t {
+    ...
+}
+~ End P4Example
+
+The generated p4Info will contain:
+
+~ Begin Proto
+structured_annotations {
+  name: "Labels"
+  elements {
+    key: "short"
+    value {
+      expression {
+        string_value: "Short Label"
+      }
+    }
+  }
+  elements {
+    key: "hover"
+    value {
+      expression {
+        string_value: "My Longer Table Label to appear in hover-help"
+      }
+    }
+  }
+}
+~ End Proto
+
+**kvList of Mixed Expressions**
+
+The following example will produce a more  complex `kvList`: one of
+the `kvPair`s has a value which is itself an `{expressionList}`, which is a
+valid form of an expression.
+
+~ Begin P4Example
+@MixedKV[label="text", my_bool=true, list_key={"a", 5+6, 1==2}, int_val=2*3]
+table t {
+    ...
+}
+~ End P4Example
+
+
+The generated p4Info will contain:
+
+~ Begin Proto
+structured_annotations {
+  name: "MixedKV"
+  elements {
+    key: "label"
+    value {
+      expression {
+        string_value: "text"
+      }
+    }
+  }
+  elements {
+    key: "my_bool"
+    value {
+      expression {
+        bool_value: true
+      }
+    }
+  }
+  elements {
+    key: "list_key"
+    value {
+      expression_list {
+        expressions {
+          string_value: "a"
+        }
+        expressions {
+          int64_value: 11
+        }
+        expressions {
+          bool_value: true
+        }
+      }
+    }
+  }
+  elements {
+    key: "int_val"
+    value {
+      expression {
+        int64_value: 6
+      }
+    }
+  }
+}
+~ End Proto
+
 ## `PkgInfo` Message
 
 The `PkgInfo` message contains package-level metadata which describes the
@@ -1048,6 +1300,8 @@ message PkgInfo {
   string contact = 7;
   // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
   string url = 8;
+  // Miscellaneous metadata, structured; a way to extend PkgInfo
+  repeated StructuredAnnotation structured_annotations = 9;
 }
 ~ End Proto
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1151,7 +1151,6 @@ structured_annotations {
   }
 }
 ~ End Proto
-~ End Proto
 
 **kvList of Mixed Expressions**
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1030,16 +1030,16 @@ matched parentheses is legal. Conversely, structured annotations of the form
 `MyAnno3[]` or `MyAnno4[kvList|expressionList]` have a more prescribed syntax,
 which allows declaring key-value lists or expression lists. Both unstructured
 and structured annotations may be used simultaneously on a P4 element and
-`P4Info` supports this.
+P4Info supports this.
 
 The annotations described up to this point, &eg; `@brief()`, have all been
 unstructured annotations, or simply annotations. These are represented in
-`P4Info` as `repeated string annotations` fields in the various `message`s.
+P4Info as `repeated string annotations` fields in the various `message`s.
 Similarly, structured annotations are represented in `repeated
 StructuredAnnotation structured_annotations` fields which are siblings to the
 unstructured `annotations`. The `structured_annotations` contain parsed
 representations of the original annotation source. This parsing includes
-expression-evaluation, so the resulting `P4Info` may contain a simplified
+expression-evaluation, so the resulting P4Info may contain a simplified
 replica of the original structured annotations.
 
 The structured annotation messages are defined in p4types.proto.
@@ -1080,11 +1080,11 @@ or an `ExpressionList`.
 
 The type of an expression is intentionally limited to one of the following
 base types: string literal, 64-bit signed integer, or boolean. The `p4c`
-compiler frontend which generates `P4Info` will evaluate all expressions and
+compiler frontend which generates P4Info will evaluate all expressions and
 simplify them to one of the valid types. Any expressions which don't match one
 of the valid types will generate an error. For integers exceeding 64 bits,
-besides issuing an error, the compiler *could* print a suggestion to use a
-string representation, and the `P4Info` consumer could perform any necessary
+besides issuing an error, the compiler *may* print a suggestion to use a
+string representation, and the P4Info consumer may perform any necessary
 conversions.
 
 The following invariants hold:
@@ -1106,7 +1106,7 @@ table t {
 }
 ~ End P4Example
 
-The generated p4Info will contain the following. An empty structured annotation
+The generated P4Info will contain the following. An empty structured annotation
 body generates an empty `expression_list` to remain consistent with the P4
 Language Spec.
 
@@ -1129,7 +1129,7 @@ table t {
 }
 ~ End P4Example
 
-The generated p4Info will contain:
+The generated P4Info will contain:
 
 ~ Begin Proto
 structured_annotations {
@@ -1163,7 +1163,7 @@ table t {
 }
 ~ End P4Example
 
-The generated p4Info will contain:
+The generated P4Info will contain:
 
 ~ Begin Proto
 structured_annotations {

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1106,9 +1106,9 @@ table t {
 }
 ~ End P4Example
 
-The generated p4Info will contain the following. An empty annotation body
-generates an empty `expression_list` to remain consistent with the P4 Language
-Spec.
+The generated p4Info will contain the following. An empty structured annotation
+body generates an empty `expression_list` to remain consistent with the P4
+Language Spec.
 
 ~ Begin Proto
 structured_annotations {

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1111,6 +1111,8 @@ The generated p4Info will contain:
 ~ Begin Proto
 structured_annotations {
   name: "Empty"
+  expression_list {
+  }
 }
 ~ End Proto
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1035,74 +1035,68 @@ and structured annotations may be used simultaneously on a P4 element and
 The annotations described up to this point, &eg; `@brief()`, have all been
 unstructured annotations, or simply annotations. These are represented in
 `P4Info` as `repeated string annotations` fields in the various `message`s.
-Similarly, structured annotations are represented in
-`repeated structured_annotations` fields which are siblings to the unstructured
-`annotations`. The `structured_annotations` contain parsed representations of
-the original annotation source. This parsing includes expression-evaluation,
-so the resulting `P4Info` may contain a simplified replica of the original
-structured annotations.
+Similarly, structured annotations are represented in `repeated
+StructuredAnnotation structured_annotations` fields which are siblings to the
+unstructured `annotations`. The `structured_annotations` contain parsed
+representations of the original annotation source. This parsing includes
+expression-evaluation, so the resulting `P4Info` may contain a simplified
+replica of the original structured annotations.
 
 The structured annotation messages are defined in `p4types.proto`.
 
 ~ Begin Proto
-// One parsed element within a structured annotation's body.
-message StructuredAnnotationElement {
-// Key is empty if and only if no key was specified
+message KeyValuePair {
   string key = 1;
-  StructuredAnnotationValue value = 2;
+  Expression value = 2;
 }
 
-// A structured annotation value may be scalar or a list
-message StructuredAnnotationValue {
-  oneof value {
-    ExpressionValue expression = 1;
-    ExpressionList expression_list = 2;
-  }
+message KeyValuePairList {
+  repeated KeyValuePair kv_pairs = 1;
 }
 
-// Various value types
-message ExpressionValue {
+message Expression {
   oneof value {
     string string_value = 1;
     int64 int64_value = 2;
     bool bool_value = 3;
+    ExpressionList expr_list_value = 4;
   }
 }
 
-// A list of expressions
 message ExpressionList {
-  repeated ExpressionValue expressions = 1;
+  repeated Expression expressions = 1;
 }
 
-// An ordered list of annotations identified by the name
 message StructuredAnnotation {
   string name = 1;
-  repeated StructuredAnnotationElement elements = 2;
+  oneof body {
+    ExpressionList expression_list = 2;
+    KeyValuePairList kvpair_list = 3;
+  }
 }
 ~ End Proto
 
-The `StructuredAnnotationElement` can represent a `kvPair` as a `key` and a
-`value`; alternatively, it can represent an `expression` as a keyless value.
-Therefore a `kvList` or `expressionList` can both use the same
-`StructuredAnnotation` message with the annotation `name` and a list of
-`StructuredAnnotationElement`s.
+The `StructuredAnnotation` message can represent either a `KeyValuePairList`
+or an `ExpressionList`.
 
 The type of an expression is intentionally limited to a practical subset:
-string literal, 64-bit signed integer, boolean, or a list of any of these.
-This is more restrictive than the P4 language but provides reasonable types
-for known annotation use-cases. The `p4c` compiler frontend which generates
-`P4Info` will evaluate all expressions and simplify them to one of the three
-types. Any expressions which don't match one of the valid types will generate
-an error.
+string literal, 64-bit signed integer, boolean, or a nested list of
+`Expression`s. This is more restrictive than the P4 language but provides
+reasonable types for known annotation use-cases. The `p4c` compiler frontend
+which generates `P4Info` will evaluate all expressions and simplify them to
+one of the valid types. Any expressions which don't match one of the valid
+types will generate an error. For integers exceeding 64 bits, besides issuing
+an error, the compiler *could* print a suggestion to use a string
+representation, and the `P4Info` consumer could perform any necessary
+conversions.
 
 The following invariants hold:
 
 1. For any P4 entity, there are no two `StructuredAnnotation`s that have the
 same name.
 
-2. Within a `StructuredAnnotation`, there are no two
-`StructuredAnnotationElement`s that have the same key, except for the empty
-key, which can appear any number of times to represent `expressionList`s.
+2. Within a `KeyValuePairList`, there are no two `KeyValuePair`s that have the
+same `key.`
 
 ### Structured Annotation Examples
 
@@ -1139,38 +1133,74 @@ The generated p4Info will contain:
 ~ Begin Proto
 structured_annotations {
   name: "MixedExprList"
-  elements {
-    value {
-      expression {
-        int64_value: 1
-      }
+  expression_list {
+    expressions {
+      int64_value: 1
+    }
+    expressions {
+      string_value: "hello"
+    }
+    expressions {
+      bool_value: true
+    }
+    expressions {
+      bool_value: false
+    }
+    expressions {
+      int64_value: 11
     }
   }
-  elements {
-    value {
-      expression {
-        string_value: "hello"
-      }
+}
+~ End Proto
+
+**Nested Expression List**
+
+~ Begin P4Example
+@NestedExprLists[1,TEXT_CONST,true,1==2,{3, 4, {5, 6}}]
+#define TEXT_CONST "hello"
+#define NUM_CONST 6
+@MixedExprList[1,TEXT_CONST,true,1==2,5+NUM_CONST]
+table t {
+    ...
+}
+~ End P4Example
+
+The generated p4Info will contain:
+
+~ Begin Proto
+structured_annotations {
+  name: "NestedExprLists"
+  expression_list {
+    expressions {
+      int64_value: 1
     }
-  }
-  elements {
-    value {
-      expression {
-        bool_value: true
-      }
+    expressions {
+      string_value: "hello"
     }
-  }
-  elements {
-    value {
-      expression {
-        bool_value: false
-      }
+    expressions {
+      bool_value: true
     }
-  }
-  elements {
-    value {
-      expression {
-        int64_value: 11
+    expressions {
+      bool_value: false
+    }
+    expressions {
+      expr_list_value {
+        expressions {
+          int64_value: 3
+        }
+        expressions {
+          int64_value: 4
+        }
+        expressions {
+          expr_list_value {
+            expressions {
+              int64_value: 5
+            }
+            expressions {
+              int64_value: 6
+            }
+          }
+        }
       }
     }
   }
@@ -1191,18 +1221,16 @@ The generated p4Info will contain:
 ~ Begin Proto
 structured_annotations {
   name: "Labels"
-  elements {
-    key: "short"
-    value {
-      expression {
+  kvpair_list {
+    kv_pairs {
+      key: "short"
+      value {
         string_value: "Short Label"
       }
     }
-  }
-  elements {
-    key: "hover"
-    value {
-      expression {
+    kv_pairs {
+      key: "hover"
+      value {
         string_value: "My Longer Table Label to appear in hover-help"
       }
     }
@@ -1229,42 +1257,38 @@ The generated p4Info will contain:
 ~ Begin Proto
 structured_annotations {
   name: "MixedKV"
-  elements {
-    key: "label"
-    value {
-      expression {
+  kvpair_list {
+    kv_pairs {
+      key: "label"
+      value {
         string_value: "text"
       }
     }
-  }
-  elements {
-    key: "my_bool"
-    value {
-      expression {
+    kv_pairs {
+      key: "my_bool"
+      value {
         bool_value: true
       }
     }
-  }
-  elements {
-    key: "list_key"
-    value {
-      expression_list {
-        expressions {
-          string_value: "a"
-        }
-        expressions {
-          int64_value: 11
-        }
-        expressions {
-          bool_value: true
+    kv_pairs {
+      key: "list_key"
+      value {
+        expr_list_value {
+          expressions {
+            string_value: "a"
+          }
+          expressions {
+            int64_value: 11
+          }
+          expressions {
+            bool_value: true
+          }
         }
       }
     }
-  }
-  elements {
-    key: "int_val"
-    value {
-      expression {
+    kv_pairs {
+      key: "int_val"
+      value {
         int64_value: 6
       }
     }

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1095,7 +1095,7 @@ same name.
 2. Within a `KeyValuePairList`, there are no two `KeyValuePair`s that have the
 same `key.`
 
-### Structured Annotation Examples
+#### Structured Annotation Examples
 
 **Empty Expression List**
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1106,7 +1106,9 @@ table t {
 }
 ~ End P4Example
 
-The generated p4Info will contain:
+The generated p4Info will contain the following. An empty annotation body
+generates an empty `expression_list` to remain consistent with the P4 Language
+Spec.
 
 ~ Begin Proto
 structured_annotations {

--- a/docs/v1/references.bib
+++ b/docs/v1/references.bib
@@ -190,3 +190,8 @@
     title = "Protobuf OneOf backwards-compatibility issues",
     url = "https://developers.google.com/protocol-buffers/docs/proto3#backwards-compatibility-issues"
 }
+
+@ONLINE { P4Annotations,
+    title = "P4 Annotations",
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-annotations"
+}

--- a/docs/v1/references.bib
+++ b/docs/v1/references.bib
@@ -193,7 +193,7 @@
 
 @ONLINE { P4Annotations,
     title = "P4 Annotations",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-annotations"
+    url = "https://p4.org/p4-spec/docs/P4-16-working-spec.html#sec-annotations"
 }
 
 @ONLINE { v1model,

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -159,6 +159,7 @@ message MatchField {
     LPM = 3;
     TERNARY = 4;
     RANGE = 5;
+    OPTIONAL = 6;
   }
   oneof match {
     MatchType match_type = 5;

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -65,6 +65,8 @@ message PkgInfo {
   string contact = 7;
   // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
   string url = 8;
+  // Miscellaneous metadata, structured; a way to extend PkgInfo
+  repeated StructuredAnnotation structured_annotations = 9;
 }
 
 // wrapping the enum in a message to avoid name collisions in C++, where "enum
@@ -130,6 +132,7 @@ message Preamble {
   repeated string annotations = 4;
   // Documentation of the entity
   Documentation doc = 5;
+  repeated StructuredAnnotation structured_annotations = 6;
 }
 
 // used to group all extern instances of the same type in one message
@@ -171,6 +174,7 @@ message MatchField {
   Documentation doc = 6;
   // unset if not user-defined type
   P4NamedType type_name = 8;
+  repeated StructuredAnnotation structured_annotations = 9;
 }
 
 message Table {
@@ -231,6 +235,7 @@ message Action {
     Documentation doc = 5;
     // unset if not user-defined type
     P4NamedType type_name = 6;
+    repeated StructuredAnnotation structured_annotations = 7;
   }
   repeated Param params = 2;
 }
@@ -322,6 +327,7 @@ message ControllerPacketMetadata {
     int32 bitwidth = 4;
     // unset if not user-defined type
     P4NamedType type_name = 5;
+    repeated StructuredAnnotation structured_annotations = 6;
   }
   // Ordered based on header layout.
   // This is a constraint on the generator of this P4Info.

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -154,15 +154,52 @@ message P4HeaderUnionStackTypeSpec {
   int32 size = 2;
 }
 
+// One parsed element within a structured annotation's body.
+message StructuredAnnotationElement {
+  // Key is empty if and only if no key was specified
+    string key = 1;
+    StructuredAnnotationValue value = 2;
+  }
+  
+// A structured annotation value may be scalar or a list
+message StructuredAnnotationValue {
+  oneof value {
+    ExpressionValue expression = 1;
+    ExpressionList expression_list = 2;
+  }
+}
+
+// Various value types
+message ExpressionValue {
+  oneof value {
+    string string_value = 1;
+    int64 int64_value = 2;
+    bool bool_value = 3;
+  }
+}
+
+// A list of expressions
+message ExpressionList {
+  repeated ExpressionValue expressions = 1;
+}
+
+// An ordered list of annotations identified by the name
+message StructuredAnnotation {
+  string name = 1;
+  repeated StructuredAnnotationElement elements = 2;
+}
+  
 // For "safe" enums with no underlying representation and no member integer
 // values.
 message P4EnumTypeSpec {
   message Member {
     string name = 1;
     repeated string annotations = 2;
+    repeated StructuredAnnotation structured_annotations = 3;
   }
   repeated Member members = 1;
   repeated string annotations = 2;
+  repeated StructuredAnnotation structured_annotations = 3;
 }
 
 // For serializable (or "unsafe") enums, which have an underlying type. Note
@@ -173,10 +210,12 @@ message P4SerializableEnumTypeSpec {
     string name = 1;
     bytes value = 2;
     repeated string annotations = 3;
+    repeated StructuredAnnotation structured_annotations = 4;
   }
   P4BitTypeSpec underlying_type = 1;
   repeated Member members = 2;
   repeated string annotations = 3;
+  repeated StructuredAnnotation structured_annotations = 4;
 }
 
 // Similar to an enum, but there is always one and only one instance per P4
@@ -204,6 +243,7 @@ message P4NewTypeSpec {
   }
   // for other annotations (not @p4runtime_translation)
   repeated string annotations = 3;
+  repeated StructuredAnnotation structured_annotations = 4;
 }
 
 // End of P4 type specs --------------------------------------------------------

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -154,39 +154,34 @@ message P4HeaderUnionStackTypeSpec {
   int32 size = 2;
 }
 
-// One parsed element within a structured annotation's body.
-message StructuredAnnotationElement {
-  // Key is empty if and only if no key was specified
-    string key = 1;
-    StructuredAnnotationValue value = 2;
-  }
-  
-// A structured annotation value may be scalar or a list
-message StructuredAnnotationValue {
-  oneof value {
-    ExpressionValue expression = 1;
-    ExpressionList expression_list = 2;
-  }
+message KeyValuePair {
+  string key = 1;
+  Expression value = 2;
 }
 
-// Various value types
-message ExpressionValue {
+message KeyValuePairList {
+  repeated KeyValuePair kv_pairs = 1;
+}
+
+message Expression {
   oneof value {
     string string_value = 1;
     int64 int64_value = 2;
     bool bool_value = 3;
+    ExpressionList expr_list_value = 4;
   }
 }
 
-// A list of expressions
 message ExpressionList {
-  repeated ExpressionValue expressions = 1;
+  repeated Expression expressions = 1;
 }
 
-// An ordered list of annotations identified by the name
 message StructuredAnnotation {
   string name = 1;
-  repeated StructuredAnnotationElement elements = 2;
+  oneof body {
+    ExpressionList expression_list = 2;
+    KeyValuePairList kvpair_list = 3;
+  }
 }
   
 // For "safe" enums with no underlying representation and no member integer

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -168,7 +168,6 @@ message Expression {
     string string_value = 1;
     int64 int64_value = 2;
     bool bool_value = 3;
-    ExpressionList expr_list_value = 4;
   }
 }
 

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -148,11 +148,11 @@ message TableEntry {
   repeated FieldMatch match = 2;
   TableAction action = 3;
   // Should only be set if the match implies a TCAM lookup, i.e. at least one of
-  // the match fields is Ternary or Range.  A higher number indicates higher
-  // priority.  Only a highest priority entry that matches the packet must be
-  // selected.  Multiple entries in the same table with the same priority value
-  // are permitted.  See Section "TableEntry" in the specification for details
-  // of the behavior.
+  // the match fields is Optional, Ternary or Range.  A higher number indicates
+  // higher priority.  Only a highest priority entry that matches the packet
+  // must be selected.  Multiple entries in the same table with the same
+  // priority value are permitted.  See Section "TableEntry" in the
+  // specification for details of the behavior.
   int32 priority = 4;
   // Metadata (cookie) opaque to the target. There is no requirement of where
   // this is stored, as long as it is returned with the rest of the entry in
@@ -199,7 +199,7 @@ message TableEntry {
   IdleTimeout time_since_last_hit = 10;
 }
 
-// field_match_type ::= exact | ternary | lpm | range
+// field_match_type ::= exact | ternary | lpm | range | optional
 message FieldMatch {
   uint32 field_id = 1;
 
@@ -222,12 +222,18 @@ message FieldMatch {
     bytes low = 1;
     bytes high = 2;
   }
+  // If the Optional match should be a wildcard, the FieldMatch must be omitted.
+  // Otherwise, this behaves like an exact match.
+  message Optional {
+    bytes value = 1;
+  }
 
   oneof field_match_type {
     Exact exact = 2;
     Ternary ternary = 3;
     LPM lpm = 4;
     Range range = 6;
+    Optional optional = 7;
     // Architecture-specific match value; it corresponds to the other_match_type
     // in the P4Info MatchField message.
     .google.protobuf.Any other = 100;


### PR DESCRIPTION
This PR updates p4info.proto and p4types.proto as well as the P4Runtime specification to add structured annotations as described in https://github.com/p4lang/p4runtime/issues/264 and https://github.com/p4lang/p4-spec/pull/796. The P4_16 lang spec PR is not yet ratified, it is awaiting a practical implementation in `p4c` so one goal of this PR is to inform an implementation. Step one is to parse the syntax, step two is to generate the new `P4info`.