### PR TITLE
Small fixes for structured annotations

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1070,7 +1070,7 @@ message StructuredAnnotation {
   string name = 1;
   oneof body {
     ExpressionList expression_list = 2;
-    KeyValuePairList kvpair_list = 3;
+    KeyValuePairList kv_pair_list = 3;
   }
 }
 ~ End Proto
@@ -1164,7 +1164,7 @@ The generated P4Info will contain:
 ~ Begin Proto
 structured_annotations {
   name: "MixedKV"
-  kvpair_list {
+  kv_pair_list {
     kv_pairs {
       key: "label"
       value {

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -222,6 +222,7 @@ message ActionRef {
   }
   Scope scope = 3;
   repeated string annotations = 2;
+  repeated StructuredAnnotation structured_annotations = 4;
 }
 
 message Action {

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -179,7 +179,7 @@ message StructuredAnnotation {
   string name = 1;
   oneof body {
     ExpressionList expression_list = 2;
-    KeyValuePairList kvpair_list = 3;
+    KeyValuePairList kv_pair_list = 3;
   }
 }
   


### PR DESCRIPTION
While working on the p4c implementation, I realized that:
 * the ActionRef message was missing a structured_annotations field
 * we use kvpair and kv_pair inconsistently