### PR TITLE
[breaking change] use common data structure for all annotations

### DIFF
--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -57,6 +57,8 @@ message PkgInfo {
   Documentation doc = 3;
   // Miscellaneous metadata, free-form; a way to extend PkgInfo
   repeated string annotations = 4;
+  // The location of `annotations[i]` is given by `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 10;
   // the target architecture, e.g. "psa"
   string arch = 5;
   // organization which produced the configuration, e.g. "p4.org"
@@ -130,6 +132,8 @@ message Preamble {
   // object (TBD).
   string alias = 3;
   repeated string annotations = 4;
+  // The location of `annotations[i]` is given by `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 7;
   // Documentation of the entity
   Documentation doc = 5;
   repeated StructuredAnnotation structured_annotations = 6;
@@ -155,6 +159,8 @@ message MatchField {
   uint32 id = 1;
   string name = 2;
   repeated string annotations = 3;
+  // The location of `annotations[i]` is given by `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 10;
   int32 bitwidth = 4;
   enum MatchType {
     UNSPECIFIED = 0;
@@ -222,6 +228,8 @@ message ActionRef {
   }
   Scope scope = 3;
   repeated string annotations = 2;
+  // The location of `annotations[i]` is given by `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 5;
   repeated StructuredAnnotation structured_annotations = 4;
 }
 
@@ -231,6 +239,8 @@ message Action {
     uint32 id = 1;
     string name = 2;
     repeated string annotations = 3;
+    // The location of `annotations[i]` is given by `annotation_locations[i]`.
+    repeated SourceLocation annotation_locations = 8;
     int32 bitwidth = 4;
     // Documentation of the Param
     Documentation doc = 5;
@@ -325,6 +335,8 @@ message ControllerPacketMetadata {
     // to e.g. Action.Param.name.
     string name = 2;
     repeated string annotations = 3;
+    // The location of `annotations[i]` is given by `annotation_locations[i]`.
+    repeated SourceLocation annotation_locations = 7;
     int32 bitwidth = 4;
     // unset if not user-defined type
     P4NamedType type_name = 5;

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -55,10 +55,8 @@ message PkgInfo {
   string version = 2;
   // brief and detailed descriptions
   Documentation doc = 3;
-  // Miscellaneous metadata, free-form; a way to extend PkgInfo
-  repeated string annotations = 4;
-  // The location of `annotations[i]` is given by `annotation_locations[i]`.
-  repeated SourceLocation annotation_locations = 10;
+  // Miscellaneous metadata; a way to extend PkgInfo.
+  repeated Annotation annotations = 4;
   // the target architecture, e.g. "psa"
   string arch = 5;
   // organization which produced the configuration, e.g. "p4.org"
@@ -67,8 +65,6 @@ message PkgInfo {
   string contact = 7;
   // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
   string url = 8;
-  // Miscellaneous metadata, structured; a way to extend PkgInfo
-  repeated StructuredAnnotation structured_annotations = 9;
 }
 
 // wrapping the enum in a message to avoid name collisions in C++, where "enum
@@ -131,12 +127,9 @@ message Preamble {
   // P4 programmer may also be able to override the default alias for any P4
   // object (TBD).
   string alias = 3;
-  repeated string annotations = 4;
-  // The location of `annotations[i]` is given by `annotation_locations[i]`.
-  repeated SourceLocation annotation_locations = 7;
+  repeated Annotation annotations = 4;
   // Documentation of the entity
   Documentation doc = 5;
-  repeated StructuredAnnotation structured_annotations = 6;
 }
 
 // used to group all extern instances of the same type in one message
@@ -158,9 +151,7 @@ message ExternInstance {
 message MatchField {
   uint32 id = 1;
   string name = 2;
-  repeated string annotations = 3;
-  // The location of `annotations[i]` is given by `annotation_locations[i]`.
-  repeated SourceLocation annotation_locations = 10;
+  repeated Annotation annotations = 3;
   int32 bitwidth = 4;
   enum MatchType {
     UNSPECIFIED = 0;
@@ -180,7 +171,6 @@ message MatchField {
   Documentation doc = 6;
   // unset if not user-defined type
   P4NamedType type_name = 8;
-  repeated StructuredAnnotation structured_annotations = 9;
 }
 
 message Table {
@@ -227,10 +217,7 @@ message ActionRef {
     DEFAULT_ONLY = 2;
   }
   Scope scope = 3;
-  repeated string annotations = 2;
-  // The location of `annotations[i]` is given by `annotation_locations[i]`.
-  repeated SourceLocation annotation_locations = 5;
-  repeated StructuredAnnotation structured_annotations = 4;
+  repeated Annotation annotations = 2;
 }
 
 message Action {
@@ -238,15 +225,12 @@ message Action {
   message Param {
     uint32 id = 1;
     string name = 2;
-    repeated string annotations = 3;
-    // The location of `annotations[i]` is given by `annotation_locations[i]`.
-    repeated SourceLocation annotation_locations = 8;
+    repeated Annotation annotations = 3;
     int32 bitwidth = 4;
     // Documentation of the Param
     Documentation doc = 5;
     // unset if not user-defined type
     P4NamedType type_name = 6;
-    repeated StructuredAnnotation structured_annotations = 7;
   }
   repeated Param params = 2;
 }
@@ -334,13 +318,10 @@ message ControllerPacketMetadata {
     // This is the name of the header field (not fully-qualified), similar
     // to e.g. Action.Param.name.
     string name = 2;
-    repeated string annotations = 3;
-    // The location of `annotations[i]` is given by `annotation_locations[i]`.
-    repeated SourceLocation annotation_locations = 7;
+    repeated Annotation annotations = 3;
     int32 bitwidth = 4;
     // unset if not user-defined type
     P4NamedType type_name = 5;
-    repeated StructuredAnnotation structured_annotations = 6;
   }
   // Ordered based on header layout.
   // This is a constraint on the generator of this P4Info.

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -181,6 +181,17 @@ message StructuredAnnotation {
     ExpressionList expression_list = 2;
     KeyValuePairList kv_pair_list = 3;
   }
+  // Location of the '@' symbol of this annotation in the source code.
+  SourceLocation source_location = 4;
+}
+
+// Location of code relative to a given source file.
+message SourceLocation {
+  // Path to the source file (total or relative to the working directory).
+  string file = 1;
+  // Line and column numbers within the source file, 1-based.
+  int32 line = 2;
+  int32 column = 3;
 }
   
 // For "safe" enums with no underlying representation and no member integer

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -175,14 +175,15 @@ message ExpressionList {
   repeated Expression expressions = 1;
 }
 
-message StructuredAnnotation {
-  string name = 1;
-  oneof body {
-    ExpressionList expression_list = 2;
-    KeyValuePairList kv_pair_list = 3;
+message Annotation {
+  string name = 1;  // required
+  oneof body {      // optional
+    string raw_string = 2;
+    ExpressionList expression_list = 3;
+    KeyValuePairList kv_pair_list = 4;
   }
   // Location of the '@' symbol of this annotation in the source code.
-  SourceLocation source_location = 4;
+  SourceLocation source_location = 5;
 }
 
 // Location of code relative to a given source file.
@@ -200,11 +201,11 @@ message P4EnumTypeSpec {
   message Member {
     string name = 1;
     repeated string annotations = 2;
-    repeated StructuredAnnotation structured_annotations = 3;
+    repeated Annotation structured_annotations = 3;
   }
   repeated Member members = 1;
   repeated string annotations = 2;
-  repeated StructuredAnnotation structured_annotations = 3;
+  repeated Annotation structured_annotations = 3;
 }
 
 // For serializable (or "unsafe") enums, which have an underlying type. Note
@@ -215,12 +216,12 @@ message P4SerializableEnumTypeSpec {
     string name = 1;
     bytes value = 2;
     repeated string annotations = 3;
-    repeated StructuredAnnotation structured_annotations = 4;
+    repeated Annotation structured_annotations = 4;
   }
   P4BitTypeSpec underlying_type = 1;
   repeated Member members = 2;
   repeated string annotations = 3;
-  repeated StructuredAnnotation structured_annotations = 4;
+  repeated Annotation structured_annotations = 4;
 }
 
 // Similar to an enum, but there is always one and only one instance per P4
@@ -256,7 +257,7 @@ message P4NewTypeSpec {
   }
   // for other annotations (not @p4runtime_translation)
   repeated string annotations = 3;
-  repeated StructuredAnnotation structured_annotations = 4;
+  repeated Annotation structured_annotations = 4;
 }
 
 // End of P4 type specs --------------------------------------------------------

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -96,7 +96,7 @@ message P4BitstringLikeTypeSpec {
   }
   // Useful to identify well-known types, such as IP address or Ethernet MAC
   // address.
-  repeated string annotations = 4;
+  repeated Annotation annotations = 4;
 }
 
 message P4BitTypeSpec {
@@ -123,7 +123,7 @@ message P4StructTypeSpec {
     P4DataTypeSpec type_spec = 2;
   }
   repeated Member members = 1;
-  repeated string annotations = 2;
+  repeated Annotation annotations = 2;
 }
 
 message P4HeaderTypeSpec {
@@ -132,7 +132,7 @@ message P4HeaderTypeSpec {
     P4BitstringLikeTypeSpec type_spec = 2;
   }
   repeated Member members = 1;
-  repeated string annotations = 2;
+  repeated Annotation annotations = 2;
 }
 
 message P4HeaderUnionTypeSpec {
@@ -141,7 +141,7 @@ message P4HeaderUnionTypeSpec {
     P4NamedType header = 2;
   }
   repeated Member members = 1;
-  repeated string annotations = 2;
+  repeated Annotation annotations = 2;
 }
 
 message P4HeaderStackTypeSpec {
@@ -200,12 +200,10 @@ message SourceLocation {
 message P4EnumTypeSpec {
   message Member {
     string name = 1;
-    repeated string annotations = 2;
-    repeated Annotation structured_annotations = 3;
+    repeated Annotation annotations = 2;
   }
   repeated Member members = 1;
-  repeated string annotations = 2;
-  repeated Annotation structured_annotations = 3;
+  repeated Annotation annotations = 2;
 }
 
 // For serializable (or "unsafe") enums, which have an underlying type. Note
@@ -215,13 +213,11 @@ message P4SerializableEnumTypeSpec {
   message Member {
     string name = 1;
     bytes value = 2;
-    repeated string annotations = 3;
-    repeated Annotation structured_annotations = 4;
+    repeated Annotation annotations = 3;
   }
   P4BitTypeSpec underlying_type = 1;
   repeated Member members = 2;
-  repeated string annotations = 3;
-  repeated Annotation structured_annotations = 4;
+  repeated Annotation annotations = 3;
 }
 
 // Similar to an enum, but there is always one and only one instance per P4
@@ -256,8 +252,7 @@ message P4NewTypeSpec {
     P4NewTypeTranslation translated_type = 2;
   }
   // for other annotations (not @p4runtime_translation)
-  repeated string annotations = 3;
-  repeated Annotation structured_annotations = 4;
+  repeated Annotation annotations = 3;
 }
 
 // End of P4 type specs --------------------------------------------------------


### PR DESCRIPTION
This is non-backward-compatible solution to issue #285. To be included in 2.0.