### PR TITLE
Changes for P4Runtime release 1.2.0-rc.1

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1,5 +1,5 @@
 Title : P4Runtime Specification
-Title Note: version 1.2.0-dev
+Title Note: version 1.2.0-rc.1
 Title Footer: &date;
 Author: The P4.org API Working Group
 Heading depth: 5
@@ -231,7 +231,7 @@ P4Runtime is designed to be implemented in conjunction with the P4~16~ language
 version or later. P4~14~ programs should be translated into P4~16~ to be made
 compatible with P4Runtime. This version of P4Runtime utilizes features which are
 not in P4~16~ 1.0, but were introduced in P4~16~ 1.1.0 [@P4Revisions110]. For
-this version of P4Runtime, we recommend using P4~16~ 1.2.0 [@P4Spec].
+this version of P4Runtime, we recommend using P4~16~ 1.2.1 [@P4Spec].
 
 ## In Scope
 
@@ -6071,18 +6071,25 @@ man-in-the-middle attacks between the server and client.
 
 ## Revision History
 
-### Changes in v1.2.0 (under development)
+### Changes in v1.2.0
 
 * Add new `OPTIONAL` match kind. At the moment, `OPTIONAL` is only supported by
-  the v1model architecture [@v1model], and not by PSA. We hope that it will be
-  included in the core P4 language by the time P4Runtime v1.2.0 is released.
-* Added a new `metadata` field of type `bytes` to `TableEntry`. This is more
+  the v1model architecture [@v1model], and not by PSA. It will eventually be
+  included in the core P4 language.
+* Add support in P4Info for structured annotations, which are used to annotate
+  objects with key-value lists or expression lists.
+* Add a new `metadata` field of type `bytes` to `TableEntry`. This is more
   flexible than the now deprecated `controller_metadata` field.
-* Added the ability to change the ID of table match fields, action parameters,
+* Add the ability to change the ID of table match fields, action parameters,
   Packet IO metadata fields, and Value Set match fields in P4Info by using the
   `@id` annotation.
-* Clarified the behavior of some corner cases involving action profiles and
+* Clarify the behavior of some corner cases involving action profiles and
   selectors, including the watch port feature.
+* Support using `string` as the controller type in the `@p4runtime_translation`
+  annotation. Update syntax when using a fixed-width unsigned bitstring as the
+  controller type.
+* Add optional P4 source locations to both structured and unstructured
+  annotations.
 
 ### Changes in v1.1.0
 

--- a/docs/v1/p4runtime-id-notes.md
+++ b/docs/v1/p4runtime-id-notes.md
@@ -9,19 +9,9 @@ in one place notes on those identifiers, including:
 + When the values are chosen
 + What is their scope in "space" and time in which they must be unique
 
-This document was written while referring to the P4Runtime API
-specification as of this commit of the Github repository
-https://github.com/p4lang/p4runtime
-
-```
-commit c9cd4af17c2d562d6e4ec760237f16fea9558fcb
-Author: Chris Sommers <31145757+chrispsommers@users.noreply.github.com>
-Date:   Fri Mar 27 13:43:31 2020 -0700
-```
-
-This is after version 1.1.0 of the specification was released, and it
-is expected that version 1.2.0 will be released soon after this time,
-with very few (if any) changes from the version above.
+This document was written at the time of the release of P4Runtime
+v1.2.0. If you refer to other P4Runtime specification versions, you may
+find some small inconsistencies with respect to this document.
 
 Here is a complete list of Google Protobuf `.proto` files in this
 version of the p4lang/p4runtime repository:

--- a/docs/v1/references.bib
+++ b/docs/v1/references.bib
@@ -31,7 +31,7 @@
 
 @ONLINE { P4ComplexTypes,
     title = "Complex types in $P4_{16}$",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-p4-type"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-p4-type"
 }
 
 @ONLINE { ProtoDefaults,
@@ -47,27 +47,27 @@
 
 @ONLINE { P4TableProperties,
     title = "Table properties in $P4_{16}$",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-table-props"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-table-props"
 }
 
 @ONLINE { P4ValueSets,
     title = "Value Sets in $P4_{16}$",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-value-set"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-value-set"
 }
 
 @ONLINE { P4SelectExpr,
     title = "Select expressions in $P4_{16}$",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-select"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-select"
 }
 
 @ONLINE { P4Revisions110,
     title = "Summary of changes made in $P4_{16}$ version 1.1.0",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-summary-of-changes-made-in-version-110"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-summary-of-changes-made-in-version-110"
 }
 
 @ONLINE { P4Spec,
-    title = "$P4_{16}$ 1.2.0 specification",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html"
+    title = "$P4_{16}$ 1.2.1 specification",
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html"
 }
 
 @ONLINE { PSA,
@@ -77,7 +77,7 @@
 
 @ONLINE { P4Enums,
     title = "Enums in $P4_{16}$",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-enum-types"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-enum-types"
 }
 
 @ONLINE { ProtoAny,
@@ -113,7 +113,7 @@
 
 @ONLINE { P4NewTypes,
     title = "Introducing new types in $P4_{16}$",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-newtype"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-newtype"
 }
 
 @ONLINE { APIVersioning,
@@ -138,7 +138,7 @@
 
 @ONLINE { P4MatchTypes,
     title = "Match types in P4",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-match-kind-type"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-match-kind-type"
 }
 
 @ONLINE { gRPCStreamC,
@@ -153,7 +153,7 @@
 
 @ONLINE { P4ActionAnnotations,
     title = "P4 standard annotations on table actions",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-table-action-anno"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-table-action-anno"
 }
 
 @ONLINE { PSAActionSelector,
@@ -173,7 +173,7 @@
 
 @ONLINE { P4Concurrency,
     title = "P4 Concurrency Model",
-    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.0.html#sec-concurrency"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-concurrency"
 }
 
 @ONLINE { PSATranslation,
@@ -193,7 +193,7 @@
 
 @ONLINE { P4Annotations,
     title = "P4 Annotations",
-    url = "https://p4.org/p4-spec/docs/P4-16-working-spec.html#sec-annotations"
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-annotations"
 }
 
 @ONLINE { v1model,


### PR DESCRIPTION
Changes for P4Runtime release 1.2.0-rc.1

 * Update version to 1.2.0-rc.1 for release
 * Update references to P4_16 spec from 1.2.0 to 1.2.1
 * Update companion documents
