### PR TITLE
Fix Bazel example

### DIFF
--- a/bazel/example/WORKSPACE.bazel
+++ b/bazel/example/WORKSPACE.bazel
@@ -1,11 +1,13 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+P4RUNTIME_COMMIT="263b08c59991d31def22b0467a2fb2ae3bf61fe7"
+
 http_archive(
     name = "com_github_p4lang_p4runtime",
     # TODO(smolkaj): Set url to v1.2 release once it is available.
-    urls = ["https://github.com/p4lang/p4runtime/archive/bazel.zip"],
-    strip_prefix = "p4runtime-bazel/proto",
+    urls = ["https://github.com/p4lang/p4runtime/archive/%s.zip" % P4RUNTIME_COMMIT],
+    strip_prefix = "p4runtime-%s/proto" % P4RUNTIME_COMMIT,
     # TODO(smolkaj): Include once URL points to stable release.
     # sha256 = "...",
 )
@@ -16,7 +18,7 @@ http_archive(
 #   remote = "https://github.com/p4lang/p4runtime.git",
 #   # strip_prefix = "proto",  # https://github.com/bazelbuild/bazel/issues/10062
 #   patch_cmds = ["mv proto/* ."],  # Workaround since strip_prefix is broken.
-#   branch = "bazel",  # Replace with tag = "v1.2" once released.
+#   commit = P4RUNTIME_COMMIT,  # Replace with tag = "v1.2" once released.
 # )
 
 load("@com_github_p4lang_p4runtime//:p4runtime_deps.bzl", "p4runtime_deps")


### PR DESCRIPTION
The "bazel" branch no longer exists after merging #297. This is
temporary until tag v1.2.0 is available.