### PR TITLE
Fix codegen/update_go.sh for Mac

### DIFF
--- a/codegen/update_go.sh
+++ b/codegen/update_go.sh
@@ -8,7 +8,7 @@ pushd "$THIS_DIR/.." >/dev/null
 
 docker build -t p4runtime-ci -f codegen/Dockerfile .
 
-tmpdir="$(mktemp -d -p /tmp)"
+tmpdir="$(mktemp -d /tmp/p4rt.XXXXXX)"
 
 docker run --rm \
        -v "$tmpdir:/tmp/gen" \


### PR DESCRIPTION
-p isn't supported on Mac, but a template can be provided be provided on Linux and Mac