### PR TITLE
Improve CI build times through smarter caching

### DIFF
--- a/.github/workflows/ci-build-proto.yml
+++ b/.github/workflows/ci-build-proto.yml
@@ -21,8 +21,13 @@ jobs:
     - name: Mount bazel cache
       uses: actions/cache@v2
       with:
-        path: "~/.cache/bazel"  # See https://docs.bazel.build/versions/master/output_directories.html
-        key: bazel
+        # See https://docs.bazel.build/versions/master/output_directories.html
+        path: "~/.cache/bazel"
+        # Create a new cache entry whenever Bazel files change.
+        # See https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
+        key: ${{ runner.os }}-build-${{ hashFiles('**/*.bzl', '**/*.bazel') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
 
     - name: Install bazelisk
       run: |


### PR DESCRIPTION
GitHub's caching mechanism never overwrites cache entries for existing keys. Since we were using a static key, this caused our cache to never be refreshed. With this PR, a new cache entry is generated whenever any Bazel files (including dependencies) change.