### PR TITLE
Discard existing Bazel cache for Github build

### DIFF
--- a/.github/workflows/ci-build-proto.yml
+++ b/.github/workflows/ci-build-proto.yml
@@ -25,9 +25,9 @@ jobs:
         path: "~/.cache/bazel"
         # Create a new cache entry whenever Bazel files change.
         # See https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
-        key: ${{ runner.os }}-build-${{ hashFiles('**/*.bzl', '**/*.bazel') }}
+        key: bazel-${{ runner.os }}-build-${{ hashFiles('**/*.bzl', '**/*.bazel') }}
         restore-keys: |
-          ${{ runner.os }}-build-
+          bazel-${{ runner.os }}-build-
 
     - name: Install bazelisk
       run: |


### PR DESCRIPTION
There seems to be a Bazel issue which can be resolved by expunging the
cache: https://github.com/bazelbuild/bazel/issues/9213