### PR TITLE
Restrict max_group_size to be less than size in Action Selectors.

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1610,12 +1610,12 @@ The `ActionProfile` message includes the following fields:
   Action Profile can hold, or, in the case of an Action Selector, the maximum
   sum of all member weights across all selector groups.
 
-* `max_group_size`, an `int32` which is 0 for an Action Profile and represents
-  the maximum sum of all member weights within any given selector group for an
-  Action Selector. `max_group_size` must be no larger than `size`.
-  PSA programs can use the `@max_group_size` annotation to provide this value
-  for Action Selectors. If the annotation is omitted, the P4Info field will
-  default to 0.
+* `max_group_size`, an `int32` which is 0 for an Action Profile, or, for an
+  Action Selector, represents the maximum sum of all member weights within any
+  given selector group. The `max_group_size` must be no larger than `size`. PSA
+  programs can use the `@max_group_size` annotation to provide this value for
+  Action Selectors. If the annotation is omitted, the P4Info field will default
+  to 0.
 
 ### `Counter` & `DirectCounter`
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1610,9 +1610,9 @@ The `ActionProfile` message includes the following fields:
   Action Profile can hold, or, in the case of an Action Selector, the maximum
   sum of all member weights across all selector groups.
 
-* `max_group_size`, an `int32` representing the maximum sum of all member
-  weights within any given selector group, in the case of an Action Selector, or
-  0 for an Action Profile. `max_group_size` is never larger than `size`.
+* `max_group_size`, an `int32` which is 0 for an Action Profile and represents
+  the maximum sum of all member weights within any given selector group for an
+  Action Selector. `max_group_size` must be no larger than `size`.
   PSA programs can use the `@max_group_size` annotation to provide this value
   for Action Selectors. If the annotation is omitted, the P4Info field will
   default to 0.

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1612,9 +1612,10 @@ The `ActionProfile` message includes the following fields:
 
 * `max_group_size`, an `int32` representing the maximum sum of all member
   weights within any given selector group, in the case of an Action Selector, or
-  0 for an Action Profile. PSA programs can use the `@max_group_size` annotation
-  to provide this value for Action Selectors. If the annotation is omitted, the
-  P4Info field will default to 0.
+  0 for an Action Profile. `max_group_size` is never larger than `size`.
+  PSA programs can use the `@max_group_size` annotation to provide this value
+  for Action Selectors. If the annotation is omitted, the P4Info field will
+  default to 0.
 
 ### `Counter` & `DirectCounter`
 


### PR DESCRIPTION
See issue: #355 