### PR TITLE
Add Go proto build rule for p4runtime

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -105,11 +105,14 @@ go_proto_library(
     importpath = "github.com/p4lang/p4runtime/go/p4/v1",
     protos = [
         ":p4runtime_proto",
-        ":p4info_proto",
         ":p4data_proto",
-        "@com_google_googleapis//google/rpc:status_proto",
+    ],
+    deps = [
+        ":p4info_go_proto",
+        "@com_google_googleapis//google/rpc:status_go_proto",
     ],
 )
+
 
 cc_grpc_library(
     name = "p4runtime_cc_grpc",

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -61,15 +61,6 @@ cc_proto_library(
     deps = [":p4info_proto"],
 )
 
-go_proto_library(
-    name = "p4info_go_proto",
-    importpath = "github.com/p4lang/p4runtime/go/p4/config/v1",
-    protos = [
-        ":p4info_proto",
-        ":p4types_proto",
-    ],
-)
-
 cc_proto_library(
     name = "p4data_cc_proto",
     deps = [":p4data_proto"],
@@ -98,6 +89,26 @@ py_proto_library(
 py_proto_library(
     name = "p4runtime_py_proto",
     deps = [":p4runtime_proto"],
+)
+
+go_proto_library(
+    name = "p4info_go_proto",
+    importpath = "github.com/p4lang/p4runtime/go/p4/config/v1",
+    protos = [
+        ":p4info_proto",
+        ":p4types_proto",
+    ],
+)
+
+go_proto_library(
+    name = "p4runtime_go_proto",
+    importpath = "github.com/p4lang/p4runtime/go/p4/v1",
+    protos = [
+        ":p4runtime_proto",
+        ":p4info_proto",
+        ":p4data_proto",
+        "@com_google_googleapis//google/rpc:status_proto",
+    ],
 )
 
 cc_grpc_library(

--- a/proto/WORKSPACE.bazel
+++ b/proto/WORKSPACE.bazel
@@ -22,6 +22,7 @@ switched_rules_by_language(
     grpc = True,
     cc = True,
     python = True,
+    go = True,
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")


### PR DESCRIPTION
This PR adds go_proto_library rule for p4runtime.proto in BUILD file.