### PR TITLE
Simplify semantics for "no-op" master arbitration updates

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -859,7 +859,7 @@ current primary if there is one).
 
 1. If `election_id` is greater than or equal to `election_id_past`, then the
    controller becomes primary. The server updates the role configuration to
-   `role.config` for the given `role.id`. Furthermore:
+   `role.config` for the given `role`. Furthermore:
 
     1. If there was no primary for this `device_id` and `role` before and
        there are no `Write` requests still processing from a previous primary,
@@ -908,7 +908,7 @@ primary downgrades its status to a backup, a primary disconnects, or the
 (`device_id`, `role`) are informed of this by sending a
 `StreamMessageResponse`. The `MasterArbitrationUpdate` is populated as follows:
 
-* `device_id` and `role.id` as given.
+* `device_id` and `role` as given.
 
 * `role.config` is set to the role configuration the server received most
   recently in a `MasterArbitrationUpdate` from a primary.

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -845,30 +845,14 @@ It is the job of the P4Runtime server to remember the `role.config` for every
        (`device_id`, `role`), the P4Runtime server shall terminate the stream
        by returning an `INVALID_ARGUMENT` error.
 
-    5. If the `election_id` matches the one assigned to this stream:
-
-        1. If the controller for this channel is the primary, then the server
-          updates the `role.config` to the one specified in the
-          `MasterArbitrationUpdate`. An advisory client arbitration message is
-          sent to all controllers for this `device_id` and `role` informing
-          them of the new `role.config`.  Since the format of `role.config` is
-          out of scope for the P4Runtime specification, the server will send
-          the advisory message for every update, even if the primary sets the
-          same `role.config` as it has before. See the [following
-          section](#sec-arbitration-notification) for the format of the
-          advisory message.
-
-        2. If the controller is a backup, this is a no-op and the `role.config`
-           is ignored. No response is sent to any controller.
-
-    6. Otherwise, the server updates the `election_id` it has stored for this
+    5. Otherwise, the server updates the `election_id` it has stored for this
        controller. This change might cause a change in the primary client (this
        controller might become primary, or the controller might have downgraded
        itself to a backup, see below), as well as notifications being sent to
        one or more controllers.
 
 If the `MasterArbitrationUpdate` is accepted by either of the two steps above
-(cases 1.5. and 2.6. above), then the server determines if there are changes in
+(cases 1.5. and 2.5. above), then the server determines if there are changes in
 the primary client. Let `election_id_past` be the highest election ID the server
 has ever seen for the given `device_id` and `role` (including the one of the
 current primary if there is one).

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1610,12 +1610,12 @@ The `ActionProfile` message includes the following fields:
   Action Profile can hold, or, in the case of an Action Selector, the maximum
   sum of all member weights across all selector groups.
 
-* `max_group_size`, an `int32` which is 0 for an Action Profile and represents
-  the maximum sum of all member weights within any given selector group for an
-  Action Selector. `max_group_size` must be no larger than `size`.
-  PSA programs can use the `@max_group_size` annotation to provide this value
-  for Action Selectors. If the annotation is omitted, the P4Info field will
-  default to 0.
+* `max_group_size`, an `int32` which is 0 for an Action Profile, or, for an
+  Action Selector, represents the maximum sum of all member weights within any
+  given selector group. The `max_group_size` must be no larger than `size`. PSA
+  programs can use the `@max_group_size` annotation to provide this value for
+  Action Selectors. If the annotation is omitted, the P4Info field will default
+  to 0.
 
 ### `Counter` & `DirectCounter`
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -858,8 +858,8 @@ has ever seen for the given `device_id` and `role` (including the one of the
 current primary if there is one).
 
 1. If `election_id` is greater than or equal to `election_id_past`, then the
-   controller becomes primary. The server updates the role configuration to
-   `role.config` for the given `role`. Furthermore:
+   controller becomes, or stays, primary. The server updates the role
+   configuration to `role.config` for the given `role`. Furthermore:
 
     1. If there was no primary for this `device_id` and `role` before and
        there are no `Write` requests still processing from a previous primary,
@@ -868,8 +868,9 @@ current primary if there is one).
        [following section](#sec-arbitration-notification) for the format of the
        advisory message.
 
-    2. If there was a previous primary or `Write` requests in flight, then the
-       server carries out the following steps (in this order):
+    2. If there was a previous primary, including this controller, or `Write`
+       requests in flight, then the server carries out the following steps
+       (in this order):
 
         1. The server stops accepting `Write` requests from the previous primary
            (if there is one). At this point, the server will reject all `Write`

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1610,9 +1610,9 @@ The `ActionProfile` message includes the following fields:
   Action Profile can hold, or, in the case of an Action Selector, the maximum
   sum of all member weights across all selector groups.
 
-* `max_group_size`, an `int32` representing the maximum sum of all member
-  weights within any given selector group, in the case of an Action Selector, or
-  0 for an Action Profile. `max_group_size` is never larger than `size`.
+* `max_group_size`, an `int32` which is 0 for an Action Profile and represents
+  the maximum sum of all member weights within any given selector group for an
+  Action Selector. `max_group_size` must be no larger than `size`.
   PSA programs can use the `@max_group_size` annotation to provide this value
   for Action Selectors. If the annotation is omitted, the P4Info field will
   default to 0.

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1612,9 +1612,10 @@ The `ActionProfile` message includes the following fields:
 
 * `max_group_size`, an `int32` representing the maximum sum of all member
   weights within any given selector group, in the case of an Action Selector, or
-  0 for an Action Profile. PSA programs can use the `@max_group_size` annotation
-  to provide this value for Action Selectors. If the annotation is omitted, the
-  P4Info field will default to 0.
+  0 for an Action Profile. `max_group_size` is never larger than `size`.
+  PSA programs can use the `@max_group_size` annotation to provide this value
+  for Action Selectors. If the annotation is omitted, the P4Info field will
+  default to 0.
 
 ### `Counter` & `DirectCounter`
 


### PR DESCRIPTION
See issue #361.

This text seems to have originally come from a large commit from two years ago fixing master arbitration updates: https://github.com/p4lang/p4runtime/commit/c3f6bdc3499910f4ba85c24215e7ba6fe579e414