### PR TITLE
Add max_num_members to Action Profiles.

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -6167,7 +6167,7 @@ the purpose of adding features for the P4Runtime API.
 | `@description`           | See section [#sec-annotating-p4-entities-with-documentation] |
 | `@id`                    | See section [#sec-id-allocation] |
 | `@max_group_size`        | See sections [#sec-p4info-action-profile], [#sec-action-profile-group-programming] |
-| `@max_num_members`       | See sections [#sec-p4info-action-profile], [#sec-action-profile-group-programming] |
+| `@max_num_members`       | See section [#sec-p4info-action-profile] |
 | `@pkginfo`               | See section [#sec-annotating-p4-code-with-pkginfo] |
 | `@p4runtime_translation` | See sections [#sec-user-defined-types], [#sec-translation-of-port-numbers] |
 +--------------------------+---------------------------------------+

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -1595,6 +1595,12 @@ The `ActionProfile` message includes the following fields:
   Action Profile can hold, or, in the case of an Action Selector, the maximum
   sum of all member weights across all selector groups.
 
+* `max_num_members`, an `int64` representing the maximum number of member
+  entries that an Action Profile or Action Selector can hold. For Action
+  Profiles, this should always be equal to the size. PSA programs can use the
+  `@max_num_members` annotation to provide this value. If the annotation is
+  omitted, the P4Info field will default to the same value as `size`.
+
 * `max_group_size`, an `int32` which is 0 for an Action Profile, or, for an
   Action Selector, represents the maximum sum of all member weights within any
   given selector group. The `max_group_size` must be no larger than `size`. PSA
@@ -6161,6 +6167,7 @@ the purpose of adding features for the P4Runtime API.
 | `@description`           | See section [#sec-annotating-p4-entities-with-documentation] |
 | `@id`                    | See section [#sec-id-allocation] |
 | `@max_group_size`        | See sections [#sec-p4info-action-profile], [#sec-action-profile-group-programming] |
+| `@max_num_members`       | See sections [#sec-p4info-action-profile], [#sec-action-profile-group-programming] |
 | `@pkginfo`               | See section [#sec-annotating-p4-code-with-pkginfo] |
 | `@p4runtime_translation` | See sections [#sec-user-defined-types], [#sec-translation-of-port-numbers] |
 +--------------------------+---------------------------------------+

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -60,7 +60,7 @@ message PkgInfo {
   // Miscellaneous metadata, free-form; a way to extend PkgInfo
   repeated string annotations = 4;
   // Optional. If present, the location of `annotations[i]` is given by
- // `annotation_locations[i]`.
+  // `annotation_locations[i]`.
   repeated SourceLocation annotation_locations = 10;
   // the target architecture, e.g. "psa"
   string arch = 5;
@@ -68,7 +68,8 @@ message PkgInfo {
   string organization = 6;
   // contact info for support,e.g. "tech-support@acme.org"
   string contact = 7;
-  // url for more information, e.g. "http://support.p4.org/ref/p4/switch.p4_v1.0"
+  // url for more information, e.g.
+  // "http://support.p4.org/ref/p4/switch.p4_v1.0"
   string url = 8;
   // Miscellaneous metadata, structured; a way to extend PkgInfo
   repeated StructuredAnnotation structured_annotations = 9;
@@ -136,7 +137,7 @@ message Preamble {
   string alias = 3;
   repeated string annotations = 4;
   // Optional. If present, the location of `annotations[i]` is given by
- // `annotation_locations[i]`.
+  // `annotation_locations[i]`.
   repeated SourceLocation annotation_locations = 7;
   // Documentation of the entity
   Documentation doc = 5;
@@ -234,7 +235,7 @@ message ActionRef {
   Scope scope = 3;
   repeated string annotations = 2;
   // Optional. If present, the location of `annotations[i]` is given by
- // `annotation_locations[i]`.
+  // `annotation_locations[i]`.
   repeated SourceLocation annotation_locations = 5;
   repeated StructuredAnnotation structured_annotations = 4;
 }
@@ -264,12 +265,15 @@ message ActionProfile {
   repeated uint32 table_ids = 2;
   // true iff the action profile used dynamic selection
   bool with_selector = 3;
-  // max number of weighted member entries in action profile (across all
-  // selector groups, if the action profile has a selector)
+  // max total weight of all member entries across all groups, or max number of
+  // member entries across all groups if the action profile does not have a
+  // selector
   int64 size = 4;
   // max number of weighted member entries in any given selector group, or 0 if
   // the action profile does not have a selector
   int32 max_group_size = 5;
+  // max number of member entries across all groups
+  int64 max_num_members = 6;
 }
 
 message CounterSpec {


### PR DESCRIPTION
See issue #364 for more information.

It is a bit unnatural for a proto field to default to the same value as another field, but it seems like the right thing to do if we want the semantics to be the same for `standard` Action Profiles. WDYT @antoninbas and @smolkaj?