### PR TITLE
Update versions of dependencies for Bazel build

### DIFF
--- a/proto/p4runtime_deps.bzl
+++ b/proto/p4runtime_deps.bzl
@@ -41,7 +41,7 @@ def p4runtime_deps():
     if not native.existing_rule("com_github_grpc_grpc"):
         http_archive(
             name = "com_github_grpc_grpc",
-            url = "https://github.com/grpc/grpc/archive/v1.43.0.tar.gz",
-            strip_prefix = "grpc-1.43.0",
-            sha256 = "9647220c699cea4dafa92ec0917c25c7812be51a18143af047e20f3fb05adddc",
+            url = "https://github.com/grpc/grpc/archive/v1.44.0-pre1.tar.gz",
+            strip_prefix = "grpc-1.44.0-pre1",
+            sha256 = "477f9760fcef65660319831251adac02d20b1220f3af0aff19b5400707de445f",
         )

--- a/proto/p4runtime_deps.bzl
+++ b/proto/p4runtime_deps.bzl
@@ -8,40 +8,40 @@ def p4runtime_deps():
     if not native.existing_rule("com_google_protobuf"):
         http_archive(
             name = "com_google_protobuf",
-            url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protobuf-all-3.13.0.tar.gz",
-            strip_prefix = "protobuf-3.13.0",
-            sha256 = "465fd9367992a9b9c4fba34a549773735da200903678b81b25f367982e8df376",
+            url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.18.1/protobuf-all-3.18.1.tar.gz",
+            strip_prefix = "protobuf-3.18.1",
+            sha256 = "b8ab9bbdf0c6968cf20060794bc61e231fae82aaf69d6e3577c154181991f576",
         )
     if not native.existing_rule("rules_proto"):
         http_archive(
             name = "rules_proto",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/cfdc2fa31879c0aebe31ce7702b1a9c8a4be02d2.tar.gz",
-                "https://github.com/bazelbuild/rules_proto/archive/cfdc2fa31879c0aebe31ce7702b1a9c8a4be02d2.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/9e4c622ba8c2178b71420ed3d14fb8874beee3a5.tar.gz",
+                "https://github.com/bazelbuild/rules_proto/archive/9e4c622ba8c2178b71420ed3d14fb8874beee3a5.tar.gz",
             ],
-            strip_prefix = "rules_proto-cfdc2fa31879c0aebe31ce7702b1a9c8a4be02d2",
-            sha256 = "d8992e6eeec276d49f1d4e63cfa05bbed6d4a26cfe6ca63c972827a0d141ea3b",
+            strip_prefix = "rules_proto-9e4c622ba8c2178b71420ed3d14fb8874beee3a5",
+            sha256 = "c2182b2d8894b43dc30afbdc2ce44a216e7c6c933ed34e216bfbf86e2f4e1e48",
         )
     if not native.existing_rule("io_bazel_rules_go"):
         http_archive(
             name = "io_bazel_rules_go",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
             ],
-            sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+            sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
         )
     if not native.existing_rule("com_google_googleapis"):
         git_repository(
             name = "com_google_googleapis",
             remote = "https://github.com/googleapis/googleapis",
-            commit = "8fa381b7138f1d72966ff20563efae1b2194d359",
-            shallow_since = "1611281195 -0800",
+            commit = "9fe00a1330817b5ce00919bf2861cd8a9cea1a00",
+            shallow_since = "1642638275 -0800",
         )
     if not native.existing_rule("com_github_grpc_grpc"):
         http_archive(
             name = "com_github_grpc_grpc",
-            url = "https://github.com/grpc/grpc/archive/v1.35.0.tar.gz",
-            strip_prefix = "grpc-1.35.0",
-            sha256 = "27dd2fc5c9809ddcde8eb6fa1fa278a3486566dfc28335fca13eb8df8bd3b958",
+            url = "https://github.com/grpc/grpc/archive/v1.43.0.tar.gz",
+            strip_prefix = "grpc-1.43.0",
+            sha256 = "9647220c699cea4dafa92ec0917c25c7812be51a18143af047e20f3fb05adddc",
         )


### PR DESCRIPTION
Our CI uses the latest available version of Bazel, which is now 5.0.
With this new Bazel release, the build started breaking, which required
upgrading dependencies to the following versions:
 * Protobuf: v3.18.1
 * gRPC: v1.43.0
 * googleapis: top-of-tree
 * rules_proto: top-of-tree
 * rules_go: v0.29.0