### PR TITLE
Generate mocks for the C++ grpc library.

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -5,7 +5,7 @@ package(
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
-load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_proto_library", "py_grpc_library")
+load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_grpc_library", "py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
@@ -41,10 +41,10 @@ proto_library(
     name = "p4runtime_proto",
     srcs = ["p4/v1/p4runtime.proto"],
     deps = [
-        ":p4info_proto",
         ":p4data_proto",
+        ":p4info_proto",
+        "@com_google_googleapis//google/rpc:status_proto",
         "@com_google_protobuf//:any_proto",
-        "@com_google_googleapis//google/rpc:status_proto"
     ],
     # TODO(github.com/grpc/grpc/issues/20675): strip_import_prefix brakes
     # cc_grpc_library. Make proto folder the Bazel root folder as a workaround.
@@ -104,8 +104,8 @@ go_proto_library(
     name = "p4runtime_go_proto",
     importpath = "github.com/p4lang/p4runtime/go/p4/v1",
     protos = [
-        ":p4runtime_proto",
         ":p4data_proto",
+        ":p4runtime_proto",
     ],
     deps = [
         ":p4info_go_proto",
@@ -113,11 +113,11 @@ go_proto_library(
     ],
 )
 
-
 cc_grpc_library(
     name = "p4runtime_cc_grpc",
-    grpc_only = True,
     srcs = [":p4runtime_proto"],
+    generate_mocks = True,
+    grpc_only = True,
     deps = [":p4runtime_cc_proto"],
 )
 


### PR DESCRIPTION
This change will cause Bazel to automatically generate mocks for testing various interactions with gRPC calls.

The only semantic difference is the `generate_mocks = true`, the rest is automatic reordering by my auto-formatter :'(. 

We add and use this internally in Google, meaning that we can't open source some of our tests. I recently read that this should now be supported by Bazel.