### PR TITLE
Allow for SDN ports that are not usable as watch ports.

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -3607,8 +3607,10 @@ An `ActionProfileGroup` entity update message has the following fields:
       a group are excluded for this reason. If `watch_port` is empty, then the
       member is always included in the selection, regardless of the status of
       any port of the device.  The value must be empty or the SDN port of an
-      existing, usable port on the device, otherwise the server must return
-      `INVALID_ARGUMENT`.
+      existing port on the device, otherwise the server must return
+      `INVALID_ARGUMENT`. If the target does not support using the SDN port as a
+      watch port (&eg; on some targets LAGs cannot be used for this purpose),
+      the server must return `UNIMPLEMENTED`.
 
 * `max_size` is the maximum sum of all member weights for the group. This field
   is defined when the group is inserted, and must not be changed in a

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -3607,7 +3607,7 @@ An `ActionProfileGroup` entity update message has the following fields:
       a group are excluded for this reason. If `watch_port` is empty, then the
       member is always included in the selection, regardless of the status of
       any port of the device.  The value must be empty or the SDN port of an
-      existing port on the device, otherwise the server must return
+      existing, usable port on the device, otherwise the server must return
       `INVALID_ARGUMENT`.
 
 * `max_size` is the maximum sum of all member weights for the group. This field


### PR DESCRIPTION
@rhalstea and I were hoping that we could amend the specification to have some allowance for SDN ports that are not usable as watch ports. I don't know precisely what the concerns would be with this, so I figured I'd create a quick PR to get the discussion started.

Probably, we would, at least, want to add some information about what constitutes 'usable' in this context. I'm imagining that there would be some outside-of-P4RT notion of informing the controller which ports are valid for watch ports vs not (as I think is already the case for SDN ports in general?).

Should we discuss this in a meeting? Are there particular concerns related to having these two different types of SDN ports basically?