### PR TITLE
Update links to working draft in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Git tags are used to mark minor and patch release versions.
 ## Reading the latest version of the documentation
 
 The latest version of the P4Runtime v1 specification is available:
-* [here](https://p4lang.github.io/p4runtime/spec/main/P4Runtime-Spec.html) in **HTML**
-  format
-* [here](https://p4lang.github.io/p4runtime/spec/main/P4Runtime-Spec.pdf) in **PDF**
-  format
+* [here](https://p4.org/p4-spec/docs/p4runtime-spec-working-draft-html-version.html)
+  in **HTML** format
+* [here](https://p4.org/p4-spec/docs/p4runtime-spec-working-draft-pdf-version.html)
+  in **PDF** format
 
 It is updated every time a new commit is pushed to the main branch.
 


### PR DESCRIPTION
The links in the current README point to versions last generated in 2021.  The ones in this PR were auto-generated on 2022-Oct-28 when I checked while creating this PR.