### PR TITLE
Support for adding GenericTable

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -2007,6 +2007,15 @@ The `Digest` message defines the following fields:
   notification using a `P4DataTypeSpec` message (see section on [Representation
   of Arbitrary P4 Types](#sec-representation-of-arbitrary-p4-types)).
 
+### `GenericTable` { #sec-p4info-generic-table}
+`GenericTable` messages are used to map non-PSA P4 externs or non-P4 target-
+specific features to their implementation in a generic way. The same can be achieved
+via Extern, but GenericTable provides a structured way in which every feature is
+represented as a set of match-fields and data-fields. The data consists of unions
+wihch are similar to actions. The best use of GenericTable in a server backend is
+with TDI (Table Driven Interface), but targets can use Generic table to map to their
+own specific feature implementations as well.
+
 ### `Extern` { #sec-p4info-extern}
 
 `Extern` messages are used to specify all extern instances across all extern
@@ -2041,6 +2050,9 @@ the following fields:
 
 If the P4 program does not include any instance of a given extern type, the
 `Extern` message instance for that type should be omitted from the P4Info.
+
+
+
 
 ## Support for Arbitrary P4 Types with P4TypeInfo
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -2008,47 +2008,7 @@ The `Digest` message defines the following fields:
   of Arbitrary P4 Types](#sec-representation-of-arbitrary-p4-types)).
 
 ### `GenericTable` { #sec-p4info-generic-table}
-`GenericTable` messages are used to map non-PSA P4-externs or non-P4 target-
-specific "fixed" features to their implementation in a generic way. The same can be achieved
-via `Extern`, but GenericTable provides a structured way in which every feature is
-represented as a set of match-fields and data-fields. The data consists of unions
-wihch are similar to actions. One use of GenericTable in a server backend is
-with TDI [Table Driven Interface](https://github.com/p4lang/tdi), but targets
-can use Generic table to map to their own specific feature implementations as
-well.
-It defines the following fields
-
-* `preamble`, a `Preamble` message with the ID, name, and alias of this 
-  GenericTable.
-
-* `match_fields`, a repeated field of type `MatchField` representing the data to
-  be used to construct the lookup key matched in this table. For information check
-  the match_fields info in the [Table section](#sec-table)
-
-* `union_refs`, a repeated `UnionRef` field representing the set of possible
-  unions for this table. Functionally, it behaves same as that of ActionRefs.
-  Hence it has been kept as ActionRefs itself.
-  Please check the action_refs info in the [Table section](#sec-table)
-
-* `const_default_union_id`, if this table has a constant default union, this
-  field will carry the `uint32` identifier of that action, otherwise its value
-  will be 0. A default union is the data when the key is null. It is similar to
-  a default action for Match Tables.
-  Being constant means that the control plane cannot
-  set a different default union at runtime or change the default union's
-  arguments.
-
-* `size`, an `int64` describing the desired number of table entries that the
-  target should support for the table.  See the "Size" subsection within the
-  "Table Properties" section of the P4~16~ language specification for details
-  [@P4TableProperties].
-
-* `is_const_table`, a boolean flag indicating that the table cannot be modified
-  by the control plane at runtime.
-
-* `other_properties`, an `Any` Protobuf message [@ProtoAny] to embed
-  architecture-specific or target-specific table properties [@P4TableProperties]
-  that the target wants to convey.
+See section [GenericTable p4info](#sec-p4info-generic-table) for more info
 
 ### `Extern` { #sec-p4info-extern}
 
@@ -2977,24 +2937,8 @@ tables {
 ~ End Prototext
 
 ### GenericData
-
-`GenericData` is an addition to p4data.proto- which aims at adding support for
-data types which aren't covered by P4Data. This incorporates all the data types
-used as primitive data types like bytes, float, strings.
-
-  * bitstring : Bytes type used for simple unsigned integers or bytes
-  * float : Floating type values
-  * bool : Boolean type values
-  * generic_struct : Used to define a structure that can contain
-    one or more of the other members. So one structure can contain
-    different members of different types in GenericData
-  * generic_list : Used to define a list of same types. Even though the def
-    is same as that of generic_struct, this only allows for a variable list
-    of the same type. It can also be a list of generic_structs
-  * string : Used to define control plane strings. The max string length is
-    defined by the size
-  * enum : String representation with which safe enums are realized
-  * enum_val : bytes value with which unsafe/serializable enums are defined
+See section [GenericData p4types](#sec-p4data-generic-data) for more info on the info type.
+See section [GenericData p4data](#sec-p4types-generic-data) for more info on the runtime type.
 
 # P4 Entity Messages { #sec-p4-entity-msgs}
 
@@ -4850,78 +4794,8 @@ message should be defined in a separate architecture-specific Protobuf file. See
 section on [Extending P4Runtime for non-PSA
 Architectures](#sec-extending-p4runtime) for more information.
 
-## `GenericTableEntry` { #sec-generic-table-entry}
-
-GenericTableEntry can be used to program non-PSA externs or non-P4 target-specific
-"fixed" features to their implementation in a generic way. This provides an alternative
-to `Extern` in a structured way and within p4runtime guidelines and semantics.
-The idea has been borrowed from TDI [Table Driven Interface](https://github.com/p4lang/tdi),
-that every state can be representated as a table or multiple tables. A table here is any
-data structure with one or more entries and each entry can be represented as a set of
-key fields and data fields.
-Actions in P4 tables behave like unions and that has been borrowed here in GenericTable.
-This can be potentially used targets to map to either TDI based backends, or even non-TDI
-based backends. If using TDI, then potentially, for every new feature to be added, only
-TDI backend support and remote client code will be required to make use of that function.
-All other middle layers should theoretically remain unchanged.
-
-P4Runtime supports inserting, modifying, deleting and reading GenericTable entries with
-the `GenericTableEntry` entity, which has the following fields:
-
-* `table_id`, which identifies the table instance; the `table_id` is determined
-  by the P4Info message.
-
-* `match`, a repeated field of `GenericFieldMatch` messages. Each element in the
-  repeated field is used to provide a value for the corresponding element in the
-  p4info.
-
-* `union`, which indicates which of the table's unions to execute in case of
-  match and with which argument values.
-
-* `priority`, a 32-bit integer used to order entries when the table's match key
-  includes an optional, ternary or range match.
-
-* `is_default_action`, a boolean flag which indicates whether the table entry is
-  the default entry for the table. See [Default entry](#sec-default-entry)
-  section for more information.
-
-* `metadata`, an arbitrary `bytes` value which is opaque to the
-  target. There is no requirement of where this is stored, but it must be
-  returned by the server along with the rest of the entry when the client
-  performs a read on the entry.
-
-The `priority` field must be set to a non-zero value if the match key includes a
-ternary match (&ie; in the case of PSA if the P4Info entry for the table
-indicates that one or more of its match fields has an `OPTIONAL`, `TERNARY` or
-`RANGE` match
-type) or to zero otherwise. A higher priority number indicates that the entry
-must be given higher priority when performing a table lookup. Clients must allow
-multiple entries to be added with the same priority value.  If a packet can
-match multiple entries with the same priority, it is not deterministic in the
-data plane which entry a packet will match.  If a client wishes to make the
-matching behavior deterministic, it must use different priority values for any
-pair of table entries that the same packet matches.
-
-The `match` and `priority` fields are used to uniquely identify an entry within
-a table. Therefore, these fields cannot be modified after the entry has been
-inserted and must be provided for `MODIFY` and `DELETE` updates. When deleting
-an entry, these key fields (along with `is_default_action`) are the only fields
-considered by the server. All other fields must be ignored, even if they have
-nonsensical values (such as an invalid action field). In the case of a *keyless*
-table (the table has an empty match key), the server must reject all attempts to
-`INSERT` a match entry and return an `INVALID_ARGUMENT` error.
-
-The number of match entries that a table *should* support is indicated in P4Info
-(`size` field of `Table` message). The guarantees provided to the P4Runtime
-client are the same as the ones described in the P4~16~ specification for the
-`size` property [@P4TableProperties]. In particular, some implementations may
-not be able to always accommodate an arbitrary set of entries up to the
-requested size, and other implementations may provide the P4Runtime client with
-more entries than requested. The P4Runtime server must return
-`RESOURCE_EXHAUSTED` when a table entry cannot be inserted because of a size
-limitation. It is recommended that, for the sake of portability, P4Runtime
-clients do not try to insert additional entries once the size indicated in
-P4Info has been reached.
+## `GenericTableEntry`
+See section [GenericTableEntry p4runtime](#sec-p4runtime-generic-table-entry) for more info
 
 # Error Reporting Messages { #sec-error-reporting-messages}
 
@@ -6404,6 +6278,155 @@ information contained in table properties in P4Info, which is why the
 field [@ProtoAny]. At the moment, there is not any mechanism to extend the
 `p4.v1.TableEntry` message based on the value of architecture-specific table
 properties, but we may include on in future versions of the API.
+
+# GenericTable { #sec-generic-table}
+
+## GenericTable p4info { #sec-p4info-generic-table}
+
+`GenericTable` messages are used to map non-PSA P4-externs or non-P4 target-
+specific "fixed" features to their implementation in a generic way. The same can be achieved
+via `Extern`, but GenericTable provides a structured way in which every feature is
+represented as a set of match-fields and data-fields. The data consists of unions
+wihch are similar to actions. One use of GenericTable in a server backend is
+with TDI [Table Driven Interface](https://github.com/p4lang/tdi), but targets
+can use Generic table to map to their own specific feature implementations as
+well.
+It defines the following fields
+
+* `preamble`, a `Preamble` message with the ID, name, and alias of this 
+  GenericTable.
+
+* `match_fields`, a repeated field of type `MatchField` representing the data to
+  be used to construct the lookup key matched in this table. For information check
+  the match_fields info in the [Table section](#sec-table)
+
+* `union_refs`, a repeated `UnionRef` field representing the set of possible
+  unions for this table. Functionally, it behaves same as that of ActionRefs.
+  Hence it has been kept as ActionRefs itself.
+  Please check the action_refs info in the [Table section](#sec-table)
+
+* `const_default_union_id`, if this table has a constant default union, this
+  field will carry the `uint32` identifier of that action, otherwise its value
+  will be 0. A default union is the data when the key is null. It is similar to
+  a default action for Match Tables.
+  Being constant means that the control plane cannot
+  set a different default union at runtime or change the default union's
+  arguments.
+
+* `size`, an `int64` describing the desired number of table entries that the
+  target should support for the table.  See the "Size" subsection within the
+  "Table Properties" section of the P4~16~ language specification for details
+  [@P4TableProperties].
+
+* `is_const_table`, a boolean flag indicating that the table cannot be modified
+  by the control plane at runtime.
+
+* `other_properties`, an `Any` Protobuf message [@ProtoAny] to embed
+  architecture-specific or target-specific table properties [@P4TableProperties]
+  that the target wants to convey.
+
+### `GenericData` { #sec-p4data-generic-data}
+
+`GenericData` is an addition to p4data.proto- which aims at adding support for
+data types which aren't covered by P4Data. This incorporates all the data types
+used as primitive data types like bytes, float, strings. It contains P
+
+  * bitstring : Bytes type used for simple unsigned integers or bytes
+  * float : Floating type values
+  * bool : Boolean type values
+  * generic_struct : Used to define a structure that can contain
+    one or more of the other members. So one structure can contain
+    different members of different types in GenericData
+  * generic_list : Used to define a list of same types. Even though the def
+    is same as that of generic_struct, this only allows for a variable list
+    of the same type. It can also be a list of generic_structs
+  * string : Used to define control plane strings. The max string length is
+    defined by the size
+  * enum : String representation with which safe enums are realized
+  * enum_val : bytes value with which unsafe/serializable enums are defined
+
+### `GenericTableEntry` { #sec-generic-table-entry}
+See section [GenericTableEntry p4runtime](#sec-p4runtime-generic-table-entry) for more info
+
+GenericTableEntry can be used to program non-PSA externs or non-P4 target-specific
+"fixed" features to their implementation in a generic way. This provides an alternative
+to `Extern` in a structured way and within p4runtime guidelines and semantics.
+The idea has been borrowed from TDI [Table Driven Interface](https://github.com/p4lang/tdi),
+that every state can be representated as a table or multiple tables. A table here is any
+data structure with one or more entries and each entry can be represented as a set of
+key fields and data fields.
+Actions in P4 tables behave like unions and that has been borrowed here in GenericTable.
+This can be potentially used targets to map to either TDI based backends, or even non-TDI
+based backends. If using TDI, then potentially, for every new feature to be added, only
+TDI backend support and remote client code will be required to make use of that function.
+All other middle layers should theoretically remain unchanged.
+
+P4Runtime supports inserting, modifying, deleting and reading GenericTable entries with
+the `GenericTableEntry` entity, which has the following fields:
+
+* `table_id`, which identifies the table instance; the `table_id` is determined
+  by the P4Info message.
+
+* `match`, a repeated field of `GenericFieldMatch` messages. Each element in the
+  repeated field is used to provide a value for the corresponding element in the
+  p4info.
+
+* `union`, which indicates which of the table's unions to execute in case of
+  match and with which argument values.
+
+* `priority`, a 32-bit integer used to order entries when the table's match key
+  includes an optional, ternary or range match.
+
+* `is_default_action`, a boolean flag which indicates whether the table entry is
+  the default entry for the table. See [Default entry](#sec-default-entry)
+  section for more information.
+
+* `metadata`, an arbitrary `bytes` value which is opaque to the
+  target. There is no requirement of where this is stored, but it must be
+  returned by the server along with the rest of the entry when the client
+  performs a read on the entry.
+
+The `priority` field must be set to a non-zero value if the match key includes a
+ternary match (&ie; in the case of PSA if the P4Info entry for the table
+indicates that one or more of its match fields has an `OPTIONAL`, `TERNARY` or
+`RANGE` match
+type) or to zero otherwise. A higher priority number indicates that the entry
+must be given higher priority when performing a table lookup. Clients must allow
+multiple entries to be added with the same priority value.  If a packet can
+match multiple entries with the same priority, it is not deterministic in the
+data plane which entry a packet will match.  If a client wishes to make the
+matching behavior deterministic, it must use different priority values for any
+pair of table entries that the same packet matches.
+
+The `match` and `priority` fields are used to uniquely identify an entry within
+a table. Therefore, these fields cannot be modified after the entry has been
+inserted and must be provided for `MODIFY` and `DELETE` updates. When deleting
+an entry, these key fields (along with `is_default_action`) are the only fields
+considered by the server. All other fields must be ignored, even if they have
+nonsensical values (such as an invalid action field). In the case of a *keyless*
+table (the table has an empty match key), the server must reject all attempts to
+`INSERT` a match entry and return an `INVALID_ARGUMENT` error.
+
+The number of match entries that a table *should* support is indicated in P4Info
+(`size` field of `Table` message). The guarantees provided to the P4Runtime
+client are the same as the ones described in the P4~16~ specification for the
+`size` property [@P4TableProperties]. In particular, some implementations may
+not be able to always accommodate an arbitrary set of entries up to the
+requested size, and other implementations may provide the P4Runtime client with
+more entries than requested. The P4Runtime server must return
+`RESOURCE_EXHAUSTED` when a table entry cannot be inserted because of a size
+limitation. It is recommended that, for the sake of portability, P4Runtime
+clients do not try to insert additional entries once the size indicated in
+P4Info has been reached.
+
+
+
+
+
+
+
+
+
 
 # Known Limitations of Current P4Runtime Version
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -6353,15 +6353,27 @@ used as primitive data types like bytes, float, strings. It contains P
   * float : Floating type values
   * bool : Boolean type values
   * generic_struct : Used to define a structure that can contain
-    one or more of the other members. So one structure can contain
-    different members of different types in GenericData
-  * generic_list : Used to define a list of same types. Even though the def
-    is same as that of generic_struct, this only allows for a variable list
-    of the same type. It can also be a list of generic_structs
+    one or more of the other members as named. One structure can contain
+    different members of different types in GenericData.
+  * generic_bag : Unordered collection of members of same type. Duplicates
+    are allowed.
+  * generic_list : Used to define a list of same types. Only allows for a
+    collection of the same type. It can also be a list of generic_structs.
+    Members are ordered and duplicates are allowed.
+  * generic_set : Used to define a set of same types. It can also be a set
+    of generic_structs. Members are unordered and duplicates are not allowed.
+  * generic_ordered_set : Used to define an ordered set of same types.
+    It can also be a set of generic_structs. Members are ordered and
+    duplicates are not allowed.
   * string : Used to define control plane strings. The max string length is
     defined by the size
   * enum : String representation with which safe enums are realized
   * enum_val : bytes value with which unsafe/serializable enums are defined
+  * p4_type : This is the same type as P4DataTypeSpec. This helps in achieving
+    parity with P4 types if the GenericTable is being generated from a P4 extern.
+    There are a few overlaps like bool, enums, new_type, bitstring. If the
+    entity is from a P4 extern and a P4 data type exists, then the p4_type is
+    used. Otherwise, the GenericDataType is used
 
 ## `GenericTableEntry` { #sec-generic-table-entry}
 See section [GenericTableEntry p4runtime](#sec-p4runtime-generic-table-entry) for more info
@@ -6444,10 +6456,33 @@ applicable on the table and the APIs.
 
   * Regular tables: Read, INSERT, MODIFY, DELETE work as intended. Entries in
     a table can be inserted, modified and deleted.
+    * `INSERT` : The union field must be set for every `INSERT` update. If
+      another entry with same match key exists, then `ALREADY_EXISTS` is
+      returned.
+    * `MODIFY` : Union field must be set since all data fields are under a
+      union. Modifies the union spec to new union or new field values if
+      same union.
+    * `DELETE` : Only Match fields must be set. `NOT_FOUND` is returned if
+      the entry isn't found. If no Match fields are given, then all entries
+      are rdeleted (wildcard delete). If the table contained init entries, they
+      are restored to initial state with their original union and union field
+      values.
 
   * Modify-only tables: Entries exists from the time of initialization. Entries
     cannot be inserted but only modified. Delete resets the entry to init time.
     Read works as intended.
+    * `INSERT` : Not supported. Returns `NOT_SUPPORTED` error
+    * `MODIFY` : Union field must be set since all data fields are under a
+      union. Modifies the union spec to new union or new field values if
+      same union.
+    * `DELETE` : Instead of deleting, this operation resets the entry with
+      default values for every field. The union field values are changed
+      but the union itself isn't changed.
+      Only Match fields must be set. `NOT_FOUND` is returned if
+      the entry isn't found. If no Match fields are given, then all entries
+      are reset (wildcard reset). If the table contained init entries, they
+      are restored to initial state with their original union and union field
+      values.
   
   * Read-only tables: Entries can only be read. Write RPC doesn't work.
   
@@ -6457,6 +6492,49 @@ applicable on the table and the APIs.
     calculation tables where matchfields are the field values and the union
     data contains the hash value.
 
+  * Indexed tables : Entries are ordered.
+
+  * Reset-only tables :
+    * `INSERT` : Not supported. Returns `NOT_SUPPORTED` error
+    * `MODIFY` : Not supported. Returns `NOT_SUPPORTED` error
+    * `DELETE` : Instead of deleting, this operation resets the entry with
+      default values for every field.
+      Only Match fields must be set. `NOT_FOUND` is returned if
+      the entry isn't found. If no Match fields are given, then all entries
+      are reset (wildcard reset). If the table contained init entries, they
+      are restored to initial state with their original union and union field
+      values.
+
+
+## GenericTable properties
+
+Properties exist at 3 different levels - Table, entry and field (match or union)
+
+### Table properties
+
+Table properties are at table level. A combination of these define a certain
+table category
+
+* Read-only
+* Modify-only
+* Reset-only
+* Indexed
+* Keyless
+* Calculation
+
+### Entry permissions
+
+* Const (read-only)
+* Non-const init
+* Modify-only
+* Reset-only
+
+### Field permissions
+
+* Read-only
+* Modify-only
+* Reset-only
+* Mandatory
 
 # Known Limitations of Current P4Runtime Version
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -6293,6 +6293,24 @@ can use Generic table to map to their own specific feature implementations as
 well.
 It defines the following fields
 
+* `generic_table_type_id`, a 8-bit unsigned integer which uniquely identifies the
+  generic_table_type in the context of the architecture.
+  This value is in the range of `[0x00, 0xff]`. 
+  The ID in the preamble is created as `0x18` `generic_table_type_id` `16 bits of
+  genereted ID`.
+  Note that this value does not need
+  to be unique across all architectures from all organizations, since at any
+  given time every device managed by a P4Runtime server maps to a single P4Info
+  message and a single architecture.
+
+* `generic_table_type_name`, which specifies the fully-qualified P4 name of the
+  generic_table in case of P4 entities. In cases of non-P4 entities, it is a
+  name which uniquely identifies this entity in the entire space including P4
+  objects
+
+* `generic_table_category_type`, please check section [GenericTable categories](#sec-generic-table-categories) for more details
+
+
 * `preamble`, a `Preamble` message with the ID, name, and alias of this 
   GenericTable.
 
@@ -6325,7 +6343,7 @@ It defines the following fields
   architecture-specific or target-specific table properties [@P4TableProperties]
   that the target wants to convey.
 
-### `GenericData` { #sec-p4data-generic-data}
+## `GenericData` { #sec-p4data-generic-data}
 
 `GenericData` is an addition to p4data.proto- which aims at adding support for
 data types which aren't covered by P4Data. This incorporates all the data types
@@ -6345,7 +6363,7 @@ used as primitive data types like bytes, float, strings. It contains P
   * enum : String representation with which safe enums are realized
   * enum_val : bytes value with which unsafe/serializable enums are defined
 
-### `GenericTableEntry` { #sec-generic-table-entry}
+## `GenericTableEntry` { #sec-generic-table-entry}
 See section [GenericTableEntry p4runtime](#sec-p4runtime-generic-table-entry) for more info
 
 GenericTableEntry can be used to program non-PSA externs or non-P4 target-specific
@@ -6419,13 +6437,25 @@ limitation. It is recommended that, for the sake of portability, P4Runtime
 clients do not try to insert additional entries once the size indicated in
 P4Info has been reached.
 
+## GenericTable Categories
 
+All tables fall into certain "categories" which define what APIs are
+applicable on the table and the APIs.
 
+  * Regular tables: Read, INSERT, MODIFY, DELETE work as intended. Entries in
+    a table can be inserted, modified and deleted.
 
-
-
-
-
+  * Modify-only tables: Entries exists from the time of initialization. Entries
+    cannot be inserted but only modified. Delete resets the entry to init time.
+    Read works as intended.
+  
+  * Read-only tables: Entries can only be read. Write RPC doesn't work.
+  
+  * Calculation tables: Entries can only be read. However different from
+    Read-only in the sense that there is no defined size of the table since
+    the possible range of matchfields can be immense. For example, hash
+    calculation tables where matchfields are the field values and the union
+    data contains the hash value.
 
 
 # Known Limitations of Current P4Runtime Version

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -6407,7 +6407,7 @@ the `GenericTableEntry` entity, which has the following fields:
 * `priority`, a 32-bit integer used to order entries when the table's match key
   includes an optional, ternary or range match.
 
-* `is_default_action`, a boolean flag which indicates whether the table entry is
+* `is_default_entry`, a boolean flag which indicates whether the table entry is
   the default entry for the table. See [Default entry](#sec-default-entry)
   section for more information.
 
@@ -6459,22 +6459,36 @@ applicable on the table and the APIs.
     * `INSERT` : The union field must be set for every `INSERT` update. If
       another entry with same match key exists, then `ALREADY_EXISTS` is
       returned.
+      If `default_entry` is true, then it is treated as a MODIFY. Const
+      default union rules apply. Match fields and priority should not be set.
     * `MODIFY` : Union field must be set since all data fields are under a
       union. Modifies the union spec to new union or new field values if
       same union.
+      If `default_entry` is true, then the default entry is modified. Match
+      fields and priority should not be set. Const default union rules apply.
     * `DELETE` : Only Match fields must be set. `NOT_FOUND` is returned if
       the entry isn't found. If no Match fields are given, then all entries
-      are rdeleted (wildcard delete). If the table contained init entries, they
+      are deleted (wildcard delete). If the table contained init entries, they
       are restored to initial state with their original union and union field
       values.
+      If `default_entry` is true, then the default entry is reset to initial
+      values. Const union rules apply.
+      Wildcard doesn't apply to default_entry.
+    * `READ` : The Read RPC. All entries can be read. If no entities are
+      provided in request, then all entries are read, AKA wildcard read.
+      If `default_entry` is true, then the default entry is returned. Match
+      fields should not be set in this case.
+      Wildcard read does NOT return default entry.
 
   * Modify-only tables: Entries exists from the time of initialization. Entries
     cannot be inserted but only modified. Delete resets the entry to init time.
     Read works as intended.
-    * `INSERT` : Not supported. Returns `NOT_SUPPORTED` error
+    * `INSERT` : Not supported. Returns `NOT_SUPPORTED` error.
     * `MODIFY` : Union field must be set since all data fields are under a
       union. Modifies the union spec to new union or new field values if
       same union.
+      If `default_entry` is true, then the default entry is modified. Match
+      fields and priority should not be set. Const default union rules apply.
     * `DELETE` : Instead of deleting, this operation resets the entry with
       default values for every field. The union field values are changed
       but the union itself isn't changed.
@@ -6483,16 +6497,21 @@ applicable on the table and the APIs.
       are reset (wildcard reset). If the table contained init entries, they
       are restored to initial state with their original union and union field
       values.
+      If `default_entry` is true, then the default entry is reset to initial
+      values. Const union rules apply.
+      Wildcard doesn't apply to default_entry.
+    * `READ` : The Read RPC. All entries can be read. If no entities are
+      provided in request, then all entries are read, AKA wildcard read.
+      If `default_entry` is true, then the default entry is returned. Match
+      fields should not be set in this case.
+      Wildcard read does NOT return default entry.
   
   * Read-only tables: Entries can only be read. Write RPC doesn't work.
-  
-  * Calculation tables: Entries can only be read. However different from
-    Read-only in the sense that there is no defined size of the table since
-    the possible range of matchfields can be immense. For example, hash
-    calculation tables where matchfields are the field values and the union
-    data contains the hash value.
-
-  * Indexed tables : Entries are ordered.
+    * `READ` : The Read RPC. All entries can be read. If no entities are
+      provided in request, then all entries are read, AKA wildcard read.
+      If `default_entry` is true, then the default entry is returned. Match
+      fields should not be set in this case.
+      Wildcard read does NOT return default entry.
 
   * Reset-only tables :
     * `INSERT` : Not supported. Returns `NOT_SUPPORTED` error
@@ -6504,6 +6523,24 @@ applicable on the table and the APIs.
       are reset (wildcard reset). If the table contained init entries, they
       are restored to initial state with their original union and union field
       values.
+      If `default_entry` is true, then the default entry is reset to initial
+      values. Const union rules apply.
+      Wildcard doesn't apply to default_entry.
+    * `READ` : The Read RPC. All entries can be read. If no entities are
+      provided in request, then all entries are read, AKA wildcard read.
+      If `default_entry` is true, then the default entry is returned. Match
+      fields should not be set in this case.
+      Wildcard read does NOT return default entry.
+  
+  * Calculation tables: Entries can only be read. However different from
+    Read-only in the sense that there is no defined size of the table since
+    the possible range of matchfields can be immense. For example, hash
+    calculation tables where matchfields are the field values and the union
+    data contains the hash value. There is no default_entry for such tables.
+    * `READ` : The Read RPC. Wildcard read doesn't exist for this table.
+      Match fields should always be set
+
+  * Indexed tables : Entries are ordered.
 
 
 ## GenericTable properties
@@ -6513,28 +6550,42 @@ Properties exist at 3 different levels - Table, entry and field (match or union)
 ### Table properties
 
 Table properties are at table level. A combination of these define a certain
-table category
+table category. By default, if absent, they are all always false
 
-* Read-only
-* Modify-only
-* Reset-only
-* Indexed
-* Keyless
-* Calculation
+* Read-only : No Add/Del/Mod work
+* Modify-only : Table entries can only be modifed
+* Reset-only : Table can only be reset. Either entire table or individual entries.
+* Indexed : The entries are ordered. Handles define the indexes.
+* Keyless : Only one entry, i.e., default entry exists.
+* Calculation : No defined range of key values. For example, hash calculation table
+    for a set of field values.
+* Volatile : Data plane can Add/Del/Mod entries. Example, Add-on-miss in PNA
 
-### Entry permissions
+#### Combinations that are possible
+
+|Table Cat name| Read-only | Modify-only | Reset-only | Indexed | Keyless | Calculation | Volatile |
+| ----         | ----      | ----        | ----       | ----    | ----    | ----        | ----     |
+| Read-Only    | True      | False       | False      | T/F     | T/F     | T/F         | T/F      |
+| Modify-Only  | False     | True        | False      | T/F     | T/F     | False       | T/F      |
+| Reset-Only   | False     | False       | True       | T/F     | T/F     | False       | T/F      |
+| Indexed      | T/F       | T/F         | T/F        | T/F     | False   | False       | T/F      |
+| Calculation  | True      | False       | False      | False   | False   | True        | False    |
+
+
+### Entry properties
 
 * Const (read-only)
 * Non-const init
 * Modify-only
 * Reset-only
 
-### Field permissions
+### Field properties
 
 * Read-only
 * Modify-only
 * Reset-only
 * Mandatory
+* Volatile : Data plane volatile. Example counter bytes.
 
 # Known Limitations of Current P4Runtime Version
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -2008,13 +2008,47 @@ The `Digest` message defines the following fields:
   of Arbitrary P4 Types](#sec-representation-of-arbitrary-p4-types)).
 
 ### `GenericTable` { #sec-p4info-generic-table}
-`GenericTable` messages are used to map non-PSA P4 externs or non-P4 target-
-specific features to their implementation in a generic way. The same can be achieved
-via Extern, but GenericTable provides a structured way in which every feature is
+`GenericTable` messages are used to map non-PSA P4-externs or non-P4 target-
+specific "fixed" features to their implementation in a generic way. The same can be achieved
+via `Extern`, but GenericTable provides a structured way in which every feature is
 represented as a set of match-fields and data-fields. The data consists of unions
-wihch are similar to actions. The best use of GenericTable in a server backend is
-with TDI (Table Driven Interface), but targets can use Generic table to map to their
-own specific feature implementations as well.
+wihch are similar to actions. One use of GenericTable in a server backend is
+with TDI [Table Driven Interface](https://github.com/p4lang/tdi), but targets
+can use Generic table to map to their own specific feature implementations as
+well.
+It defines the following fields
+
+* `preamble`, a `Preamble` message with the ID, name, and alias of this 
+  GenericTable.
+
+* `match_fields`, a repeated field of type `MatchField` representing the data to
+  be used to construct the lookup key matched in this table. For information check
+  the match_fields info in the [Table section](#sec-table)
+
+* `union_refs`, a repeated `UnionRef` field representing the set of possible
+  unions for this table. Functionally, it behaves same as that of ActionRefs.
+  Hence it has been kept as ActionRefs itself.
+  Please check the action_refs info in the [Table section](#sec-table)
+
+* `const_default_union_id`, if this table has a constant default union, this
+  field will carry the `uint32` identifier of that action, otherwise its value
+  will be 0. A default union is the data when the key is null. It is similar to
+  a default action for Match Tables.
+  Being constant means that the control plane cannot
+  set a different default union at runtime or change the default union's
+  arguments.
+
+* `size`, an `int64` describing the desired number of table entries that the
+  target should support for the table.  See the "Size" subsection within the
+  "Table Properties" section of the P4~16~ language specification for details
+  [@P4TableProperties].
+
+* `is_const_table`, a boolean flag indicating that the table cannot be modified
+  by the control plane at runtime.
+
+* `other_properties`, an `Any` Protobuf message [@ProtoAny] to embed
+  architecture-specific or target-specific table properties [@P4TableProperties]
+  that the target wants to convey.
 
 ### `Extern` { #sec-p4info-extern}
 
@@ -2050,9 +2084,6 @@ the following fields:
 
 If the P4 program does not include any instance of a given extern type, the
 `Extern` message instance for that type should be omitted from the P4Info.
-
-
-
 
 ## Support for Arbitrary P4 Types with P4TypeInfo
 
@@ -2944,6 +2975,26 @@ tables {
   # ...
 }
 ~ End Prototext
+
+### GenericData
+
+`GenericData` is an addition to p4data.proto- which aims at adding support for
+data types which aren't covered by P4Data. This incorporates all the data types
+used as primitive data types like bytes, float, strings.
+
+  * bitstring : Bytes type used for simple unsigned integers or bytes
+  * float : Floating type values
+  * bool : Boolean type values
+  * generic_struct : Used to define a structure that can contain
+    one or more of the other members. So one structure can contain
+    different members of different types in GenericData
+  * generic_list : Used to define a list of same types. Even though the def
+    is same as that of generic_struct, this only allows for a variable list
+    of the same type. It can also be a list of generic_structs
+  * string : Used to define control plane strings. The max string length is
+    defined by the size
+  * enum : String representation with which safe enums are realized
+  * enum_val : bytes value with which unsafe/serializable enums are defined
 
 # P4 Entity Messages { #sec-p4-entity-msgs}
 
@@ -4798,6 +4849,79 @@ P4Runtime server to perform the read or write operation. The underlying Protobuf
 message should be defined in a separate architecture-specific Protobuf file. See
 section on [Extending P4Runtime for non-PSA
 Architectures](#sec-extending-p4runtime) for more information.
+
+## `GenericTableEntry` { #sec-generic-table-entry}
+
+GenericTableEntry can be used to program non-PSA externs or non-P4 target-specific
+"fixed" features to their implementation in a generic way. This provides an alternative
+to `Extern` in a structured way and within p4runtime guidelines and semantics.
+The idea has been borrowed from TDI [Table Driven Interface](https://github.com/p4lang/tdi),
+that every state can be representated as a table or multiple tables. A table here is any
+data structure with one or more entries and each entry can be represented as a set of
+key fields and data fields.
+Actions in P4 tables behave like unions and that has been borrowed here in GenericTable.
+This can be potentially used targets to map to either TDI based backends, or even non-TDI
+based backends. If using TDI, then potentially, for every new feature to be added, only
+TDI backend support and remote client code will be required to make use of that function.
+All other middle layers should theoretically remain unchanged.
+
+P4Runtime supports inserting, modifying, deleting and reading GenericTable entries with
+the `GenericTableEntry` entity, which has the following fields:
+
+* `table_id`, which identifies the table instance; the `table_id` is determined
+  by the P4Info message.
+
+* `match`, a repeated field of `GenericFieldMatch` messages. Each element in the
+  repeated field is used to provide a value for the corresponding element in the
+  p4info.
+
+* `union`, which indicates which of the table's unions to execute in case of
+  match and with which argument values.
+
+* `priority`, a 32-bit integer used to order entries when the table's match key
+  includes an optional, ternary or range match.
+
+* `is_default_action`, a boolean flag which indicates whether the table entry is
+  the default entry for the table. See [Default entry](#sec-default-entry)
+  section for more information.
+
+* `metadata`, an arbitrary `bytes` value which is opaque to the
+  target. There is no requirement of where this is stored, but it must be
+  returned by the server along with the rest of the entry when the client
+  performs a read on the entry.
+
+The `priority` field must be set to a non-zero value if the match key includes a
+ternary match (&ie; in the case of PSA if the P4Info entry for the table
+indicates that one or more of its match fields has an `OPTIONAL`, `TERNARY` or
+`RANGE` match
+type) or to zero otherwise. A higher priority number indicates that the entry
+must be given higher priority when performing a table lookup. Clients must allow
+multiple entries to be added with the same priority value.  If a packet can
+match multiple entries with the same priority, it is not deterministic in the
+data plane which entry a packet will match.  If a client wishes to make the
+matching behavior deterministic, it must use different priority values for any
+pair of table entries that the same packet matches.
+
+The `match` and `priority` fields are used to uniquely identify an entry within
+a table. Therefore, these fields cannot be modified after the entry has been
+inserted and must be provided for `MODIFY` and `DELETE` updates. When deleting
+an entry, these key fields (along with `is_default_action`) are the only fields
+considered by the server. All other fields must be ignored, even if they have
+nonsensical values (such as an invalid action field). In the case of a *keyless*
+table (the table has an empty match key), the server must reject all attempts to
+`INSERT` a match entry and return an `INVALID_ARGUMENT` error.
+
+The number of match entries that a table *should* support is indicated in P4Info
+(`size` field of `Table` message). The guarantees provided to the P4Runtime
+client are the same as the ones described in the P4~16~ specification for the
+`size` property [@P4TableProperties]. In particular, some implementations may
+not be able to always accommodate an arbitrary set of entries up to the
+requested size, and other implementations may provide the P4Runtime client with
+more entries than requested. The P4Runtime server must return
+`RESOURCE_EXHAUSTED` when a table entry cannot be inserted because of a size
+limitation. It is recommended that, for the sake of portability, P4Runtime
+clients do not try to insert additional entries once the size indicated in
+P4Info has been reached.
 
 # Error Reporting Messages { #sec-error-reporting-messages}
 

--- a/proto/p4/GenericTable.md
+++ b/proto/p4/GenericTable.md
@@ -1,0 +1,108 @@
+# GenericTable example p4info
+
+Below is an example for realizing MulticastGroupEntry as a GenericTable.
+The key (MatchFields) comprise of only the group_id. 2 different ways of
+defining the data fields has been presented. Only 1 of them is required.
+
+```
+generic_tables {
+  generic_table_type_id : 145
+  generic_table_type_name : "MulticastGroup"
+  preamble {
+    id: 45332650
+    name: "MulticastGroup"
+    alias: "multicast_group"
+  }
+  generic_match_fields {
+    id: 1
+    name: "multicast_group_id"
+    match_type: EXACT
+    type {
+      type : "bytes"
+      width : 32
+    }
+  }
+  union_refs {
+    id: 23557840
+  }
+  size: 1024
+}
+```
+
+In the below one, both `instance` and `port` are separate
+repeated fields. So the check on `len(instance_array) == len(port_array)`
+needs to be a runtime check. This however keeps implementation simpler
+and faster since we avoid further recursive nesting.
+
+`port` is a varbytes of max size 64 bits each. The field is repeated so it
+is defined as list of varbits through p4info.
+
+```
+unions {
+  preamble {
+    id: 23557840
+    name: "multicast_group_member_add"
+    alias: "multicast_group_member_add"
+  }
+  params {
+    id: 1
+    name: "instance"
+    repeated: true
+    type {
+      type : "bytes"
+      width : 32
+    }
+  }
+  params {
+    id: 2
+    name: "port"
+    repeated: true
+    type {
+      type : "varbytes"
+      max_bit_width : 64
+    }
+  }
+}
+
+```
+
+The below one is similar to the above but both `instance` and `port` have
+been converted to a list of structs.
+
+```
+unions {
+  preamble {
+    id: 23557841
+    name: "multicast_group_member_add_2"
+    alias: "multicast_group_member_add_2"
+  }
+  params {
+    id: 1
+    name: "replica"
+    repeated: true
+    type {
+      type : "list"
+    }
+    params {
+      param {
+        id: 1
+        name: "instance"
+        repeated: true
+        type {
+          type : "bytes"
+          width : 32
+        }
+      }
+      param : {
+        id: 2
+        name: "port"
+        repeated: true
+        type {
+          type : "varbytes"
+          max_bit_width : 64
+        }
+      }
+    }
+  }
+}
+```

--- a/proto/p4/GenericTable.md
+++ b/proto/p4/GenericTable.md
@@ -48,8 +48,8 @@ unions {
     id: 1
     name: "instance"
     type {
-      repetition_type : "list"
-      repetition_max_size : 10
+      container_type : "list"
+      container_max_size : 10
       type : "bytes"
       width : 32
     }
@@ -58,8 +58,8 @@ unions {
     id: 2
     name: "port"
     type {
-      repetition_type : "list"
-      repetition_max_size : 10
+      container_type : "list"
+      container_max_size : 10
       type : "varbytes"
       max_bit_width : 64
     }
@@ -82,7 +82,7 @@ unions {
     id: 1
     name: "replica"
     type {
-      repetition_type : "list"
+      container_type : "list"
       type : "struct"
     }
     params {

--- a/proto/p4/GenericTable.md
+++ b/proto/p4/GenericTable.md
@@ -34,8 +34,8 @@ repeated fields. So the check on `len(instance_array) == len(port_array)`
 needs to be a runtime check. This however keeps implementation simpler
 and faster since we avoid further recursive nesting.
 
-`port` is a varbytes of max size 64 bits each. The field is repeated so it
-is defined as list of varbits through p4info.
+`port` is a varbytes of max size 64 bits each. The field has a `repeated_type`
+as well, so it is defined as list of varbits through p4info.
 
 ```
 unions {
@@ -47,8 +47,9 @@ unions {
   params {
     id: 1
     name: "instance"
-    repeated: true
     type {
+      repetition_type : "list"
+      repetition_max_size : 10
       type : "bytes"
       width : 32
     }
@@ -56,8 +57,9 @@ unions {
   params {
     id: 2
     name: "port"
-    repeated: true
     type {
+      repetition_type : "list"
+      repetition_max_size : 10
       type : "varbytes"
       max_bit_width : 64
     }
@@ -79,15 +81,14 @@ unions {
   params {
     id: 1
     name: "replica"
-    repeated: true
     type {
-      type : "list"
+      repetition_type : "list"
+      type : "struct"
     }
     params {
       param {
         id: 1
         name: "instance"
-        repeated: true
         type {
           type : "bytes"
           width : 32
@@ -96,7 +97,6 @@ unions {
       param : {
         id: 2
         name: "port"
-        repeated: true
         type {
           type : "varbytes"
           max_bit_width : 64

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -37,6 +37,7 @@ message P4Info {
   repeated Register registers = 11;
   repeated Digest digests = 12;
   repeated GenericTable generic_tables = 13;
+  repeated Union unions = 14;
   repeated Extern externs = 100;
   P4TypeInfo type_info = 200;
 }

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -229,7 +229,7 @@ message Table {
 message GenericTable {
   Preamble preamble = 1;
   repeated MatchField match_fields = 2;
-  repeated UnionRef union_refs = 3;
+  repeated ActionRef union_refs = 3;
   // 0 (default value) means that the table does not have a const default action
   uint32 const_default_union_id= 4;
   int64 size = 5;  // max number of entries in table
@@ -238,41 +238,6 @@ message GenericTable {
   // architecture-specific table properties which are not part of the core P4
   // language or of the PSA architecture.
   google.protobuf.Any other_properties = 100;
-}
-
-// used to list all possible unions in a Table
-message UnionRef {
-  uint32 id = 1;
-  enum Scope {
-    TABLE_AND_DEFAULT = 0;
-    TABLE_ONLY = 1;
-    DEFAULT_ONLY = 2;
-  }
-  Scope scope = 3;
-  repeated string annotations = 2;
-  // Optional. If present, the location of `annotations[i]` is given by
-  // `annotation_locations[i]`.
-  repeated SourceLocation annotation_locations = 5;
-  repeated StructuredAnnotation structured_annotations = 4;
-}
-
-message Union {
-  Preamble preamble = 1;
-  message Param {
-    uint32 id = 1;
-    string name = 2;
-    repeated string annotations = 3;
-    // Optional. If present, the location of `annotations[i]` is given by
-    // `annotation_locations[i]`.
-    repeated SourceLocation annotation_locations = 8;
-    int32 bitwidth = 4;
-    // Documentation of the Param
-    Documentation doc = 5;
-    // unset if not user-defined type
-    P4NamedType type_name = 6;
-    repeated StructuredAnnotation structured_annotations = 7;
-  }
-  repeated Param params = 2;
 }
 
 // used to list all possible actions in a Table

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -420,10 +420,7 @@ message Digest {
 message GenericMatchField {
   uint32 id = 1;
   string name = 2;
-  repeated string annotations = 3;
-  // Optional. If present, the location of `annotations[i]` is given by
-  // `annotation_locations[i]`.
-  repeated SourceLocation annotation_locations = 10;
+  bool repeated = 3;
   GenericDataTypeSpec type_spec = 4;
   enum MatchType {
     UNSPECIFIED = 0;
@@ -437,11 +434,15 @@ message GenericMatchField {
     MatchType match_type = 5;
     // used for architecture-specific match types which are not part of the core
     // P4 language or of the PSA architecture.
-    string other_match_type = 7;
+    string other_match_type = 6;
   }
   // Documentation of the match field
-  Documentation doc = 6;
+  Documentation doc = 7;
+  repeated string annotations = 8;
+  // Optional. If present, the location of `annotations[i]` is given by
+  // `annotation_locations[i]`.
   repeated StructuredAnnotation structured_annotations = 9;
+  repeated SourceLocation annotation_locations = 10;
 }
 
 // used to list all possible unions in a Table
@@ -465,14 +466,15 @@ message Union {
   message Param {
     uint32 id = 1;
     string name = 2;
-    repeated string annotations = 3;
+    bool repeated = 3;
+    repeated string annotations = 4;
+    GenericDataTypeSpec type_spec = 5;
+    // Documentation of the Param
+    Documentation doc = 6;
+    repeated StructuredAnnotation structured_annotations = 7;
     // Optional. If present, the location of `annotations[i]` is given by
     // `annotation_locations[i]`.
-    GenericDataTypeSpec type_spec = 4;
-    repeated SourceLocation annotation_locations = 7;
-    // Documentation of the Param
-    Documentation doc = 5;
-    repeated StructuredAnnotation structured_annotations = 6;
+    repeated SourceLocation annotation_locations = 8;
   }
   repeated Param params = 2;
 }

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -36,6 +36,7 @@ message P4Info {
   repeated ValueSet value_sets = 10;
   repeated Register registers = 11;
   repeated Digest digests = 12;
+  repeated GenericTable generic_tables = 13;
   repeated Extern externs = 100;
   P4TypeInfo type_info = 200;
 }
@@ -222,6 +223,55 @@ message Table {
   // architecture-specific table properties which are not part of the core P4
   // language or of the PSA architecture.
   google.protobuf.Any other_properties = 100;
+}
+
+message GenericTable {
+  Preamble preamble = 1;
+  repeated MatchField match_fields = 2;
+  repeated UnionRef union_refs = 3;
+  // 0 (default value) means that the table does not have a const default action
+  uint32 const_default_union_id= 4;
+  int64 size = 5;  // max number of entries in table
+  // Const table, cannot be modified at runtime
+  bool is_const_table = 6;
+  // architecture-specific table properties which are not part of the core P4
+  // language or of the PSA architecture.
+  google.protobuf.Any other_properties = 100;
+}
+
+// used to list all possible unions in a Table
+message UnionRef {
+  uint32 id = 1;
+  enum Scope {
+    TABLE_AND_DEFAULT = 0;
+    TABLE_ONLY = 1;
+    DEFAULT_ONLY = 2;
+  }
+  Scope scope = 3;
+  repeated string annotations = 2;
+  // Optional. If present, the location of `annotations[i]` is given by
+  // `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 5;
+  repeated StructuredAnnotation structured_annotations = 4;
+}
+
+message Union {
+  Preamble preamble = 1;
+  message Param {
+    uint32 id = 1;
+    string name = 2;
+    repeated string annotations = 3;
+    // Optional. If present, the location of `annotations[i]` is given by
+    // `annotation_locations[i]`.
+    repeated SourceLocation annotation_locations = 8;
+    int32 bitwidth = 4;
+    // Documentation of the Param
+    Documentation doc = 5;
+    // unset if not user-defined type
+    P4NamedType type_name = 6;
+    repeated StructuredAnnotation structured_annotations = 7;
+  }
+  repeated Param params = 2;
 }
 
 // used to list all possible actions in a Table

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -37,6 +37,7 @@ message P4Info {
   repeated Register registers = 11;
   repeated Digest digests = 12;
   repeated GenericTable generic_tables = 13;
+  repeated Union unions = 14;
   repeated Extern externs = 100;
   P4TypeInfo type_info = 200;
 }
@@ -104,9 +105,26 @@ message P4Ids {
     DIRECT_METER = 0x15;
     REGISTER = 0x16;
     DIGEST = 0x17;
+    GENERIC_TABLE = 0x18;
 
     // externs for other architectures (vendor extensions)
     OTHER_EXTERNS_START = 0x80;
+
+    // max value for an unsigned 8-bit byte
+    MAX = 0xff;
+    // requires protoc >= 3.5.0
+    // reserved 0x100 to max;
+  }
+}
+
+// A subtype of P4IDs for GenericTables
+message GenericTableType {
+  // The ID space is for Generic tables. In the Preamble ID, the MSB will be
+  // 0x18 but the next MSB is reserved for this enum. This shortens the ID
+  // space for tables in each type but it is still 64k (16 bits) for each table
+  enum Prefix {
+
+    GENERIC_TABLES_START = 0x00;
 
     // max value for an unsigned 8-bit byte
     MAX = 0xff;
@@ -220,20 +238,6 @@ message Table {
   IdleTimeoutBehavior idle_timeout_behavior = 9;
   // table with static P4 entries, cannot be modified at runtime
   bool is_const_table = 10;
-  // architecture-specific table properties which are not part of the core P4
-  // language or of the PSA architecture.
-  google.protobuf.Any other_properties = 100;
-}
-
-message GenericTable {
-  Preamble preamble = 1;
-  repeated MatchField match_fields = 2;
-  repeated ActionRef union_refs = 3;
-  // 0 (default value) means that the table does not have a const default action
-  uint32 const_default_union_id= 4;
-  int64 size = 5;  // max number of entries in table
-  // Const table, cannot be modified at runtime
-  bool is_const_table = 6;
   // architecture-specific table properties which are not part of the core P4
   // language or of the PSA architecture.
   google.protobuf.Any other_properties = 100;
@@ -412,3 +416,85 @@ message Digest {
   Preamble preamble = 1;
   P4DataTypeSpec type_spec = 2;
 }
+
+message GenericMatchField {
+  uint32 id = 1;
+  string name = 2;
+  repeated string annotations = 3;
+  // Optional. If present, the location of `annotations[i]` is given by
+  // `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 10;
+  GenericDataTypeSpec type_spec = 4;
+  enum MatchType {
+    UNSPECIFIED = 0;
+    EXACT = 2;
+    LPM = 3;
+    TERNARY = 4;
+    RANGE = 5;
+    OPTIONAL = 6;
+  }
+  oneof match {
+    MatchType match_type = 5;
+    // used for architecture-specific match types which are not part of the core
+    // P4 language or of the PSA architecture.
+    string other_match_type = 7;
+  }
+  // Documentation of the match field
+  Documentation doc = 6;
+  repeated StructuredAnnotation structured_annotations = 9;
+}
+
+// used to list all possible unions in a Table
+message UnionRef {
+  uint32 id = 1;
+  enum Scope {
+    TABLE_AND_DEFAULT = 0;
+    TABLE_ONLY = 1;
+    DEFAULT_ONLY = 2;
+  }
+  Scope scope = 3;
+  repeated string annotations = 2;
+  // Optional. If present, the location of `annotations[i]` is given by
+  // `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 5;
+  repeated StructuredAnnotation structured_annotations = 4;
+}
+
+message Union {
+  Preamble preamble = 1;
+  message Param {
+    uint32 id = 1;
+    string name = 2;
+    repeated string annotations = 3;
+    // Optional. If present, the location of `annotations[i]` is given by
+    // `annotation_locations[i]`.
+    GenericDataTypeSpec type_spec = 4;
+    repeated SourceLocation annotation_locations = 7;
+    // Documentation of the Param
+    Documentation doc = 5;
+    repeated StructuredAnnotation structured_annotations = 6;
+  }
+  repeated Param params = 2;
+}
+
+// All Tables of one type will be grouped in one message.
+message GenericTable {
+  uint32 generic_table_type_id = 1;
+  string generic_table_type_name = 2;
+  repeated GenericTableInstance instances = 3;
+}
+
+message GenericTableInstance {
+  Preamble preamble = 1;
+  repeated GenericMatchField match_fields = 2;
+  repeated UnionRef union_refs = 3;
+  // 0 (default value) means that the table does not have a const default action
+  uint32 const_default_union_id= 4;
+  int64 size = 5;  // max number of entries in table
+  // Const table, cannot be modified at runtime
+  bool is_const_table = 6;
+  // architecture-specific table properties which are not part of the core P4
+  // language or of the PSA architecture.
+  google.protobuf.Any other_properties = 100;
+}
+

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -37,7 +37,6 @@ message P4Info {
   repeated Register registers = 11;
   repeated Digest digests = 12;
   repeated GenericTable generic_tables = 13;
-  repeated Union unions = 14;
   repeated Extern externs = 100;
   P4TypeInfo type_info = 200;
 }

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -333,17 +333,18 @@ message GenericBoolType { }
 message GenericFloatType { }
 
 message GenericBitstringLikeTypeSpec {
-  oneof type_spec { // Variable bit isn't required since list can be used for the same
+  oneof type_spec {
     GenericBitTypeSpec bit = 1;  // bit<W>
     GenericIntTypeSpec int = 2;  // int<W>
+    GenericVarbitTypeSpec varbit = 3;  // varbit<W>
   }
   // Useful to identify well-known types, such as IP address or Ethernet MAC
   // address.
-  repeated string annotations = 3;
+  repeated string annotations = 4;
   // Optional. If present, the location of `annotations[i]` is given by
  // `annotation_locations[i]`.
-  repeated SourceLocation annotation_locations = 4;
-  repeated StructuredAnnotation structured_annotations = 5;
+  repeated SourceLocation annotation_locations = 5;
+  repeated StructuredAnnotation structured_annotations = 6;
 }
 
 message GenericBitTypeSpec {
@@ -354,6 +355,9 @@ message GenericIntTypeSpec {
   int32 bitwidth = 1;
 }
 
+message GenericVarbitTypeSpec {
+  int32 max_bitwidth = 1;
+}
 message GenericStructTypeSpec {
   message Member {
     string name = 1;
@@ -367,6 +371,7 @@ message GenericStructTypeSpec {
   repeated StructuredAnnotation structured_annotations = 6;
 }
 
+// If a field is of type list, then repeated = true in p4info
 message GenericListTypeSpec {
   message Member {
     string name = 1;
@@ -376,8 +381,8 @@ message GenericListTypeSpec {
   repeated string annotations = 2;
   // Optional. If present, the location of `annotations[i]` is given by
   // `annotation_locations[i]`.
-  int32 min_size = 4;
-  int32 max_size = 5;
+  int32 min_size = 4; // 0 if not present
+  int32 max_size = 5; // no max size defined if not present
   repeated SourceLocation annotation_locations = 6;
   repeated StructuredAnnotation structured_annotations = 7;
 }

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -292,4 +292,160 @@ message P4NewTypeSpec {
   repeated StructuredAnnotation structured_annotations = 4;
 }
 
+//////// Generic Data types
+
+// Instead of duplicating the type spec for these
+// every time the type is used, we include the type spec once in this
+// GenericTypeInfo message and refer to the types by name in the
+// GenericDataTypeSpec message. We also
+// support annotations for these type specs which can be useful, e.g. to
+// identify well-known headers (such as ipv4).
+message GenericTypeInfo {
+  map<string, GenericStructTypeSpec> structs = 1;
+  map<string, GenericListTypeSpec> lists = 2;
+  map<string, GenericEnumTypeSpec> enums = 3;
+  map<string, GenericSerializableEnumTypeSpec> serializable_enums = 4;
+  map<string, GenericNewTypeSpec> new_types = 5;
+}
+
+// Describes Generic Data types.
+message GenericDataTypeSpec {
+  oneof type_spec {
+    GenericBitstringLikeTypeSpec bitstring = 1;
+    GenericFloatType float = 2;
+    GenericBoolType bool = 3;
+    GenericNamedType struct = 4;
+    GenericNamedType list = 5;
+    GenericNamedType string = 6;
+    GenericNamedType enum = 7;
+    GenericNamedType serializable_enum = 8;
+    GenericNamedType new_type = 12;
+  }
+}
+
+message GenericNamedType {
+  string name = 1;
+}
+
+// Empty message as no type information needed, just used as a placeholder in
+// the oneof to identify boolean types.
+message GenericBoolType { }
+message GenericFloatType { }
+
+message GenericBitstringLikeTypeSpec {
+  oneof type_spec { // Variable bit isn't required since list can be used for the same
+    GenericBitTypeSpec bit = 1;  // bit<W>
+    GenericIntTypeSpec int = 2;  // int<W>
+  }
+  // Useful to identify well-known types, such as IP address or Ethernet MAC
+  // address.
+  repeated string annotations = 3;
+  // Optional. If present, the location of `annotations[i]` is given by
+ // `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 4;
+  repeated StructuredAnnotation structured_annotations = 5;
+}
+
+message GenericBitTypeSpec {
+  int32 bitwidth = 1;
+}
+
+message GenericIntTypeSpec {
+  int32 bitwidth = 1;
+}
+
+message GenericStructTypeSpec {
+  message Member {
+    string name = 1;
+    GenericDataTypeSpec type_spec = 2;
+  }
+  repeated Member members = 1;
+  repeated string annotations = 2;
+  // Optional. If present, the location of `annotations[i]` is given by
+ // `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 5;
+  repeated StructuredAnnotation structured_annotations = 6;
+}
+
+message GenericListTypeSpec {
+  message Member {
+    string name = 1;
+    GenericDataTypeSpec type_spec = 2;
+  }
+  repeated Member members = 1;
+  repeated string annotations = 2;
+  // Optional. If present, the location of `annotations[i]` is given by
+  // `annotation_locations[i]`.
+  int32 min_size = 4;
+  int32 max_size = 5;
+  repeated SourceLocation annotation_locations = 6;
+  repeated StructuredAnnotation structured_annotations = 7;
+}
+message GenericEnumTypeSpec {
+  message Member {
+    string name = 1;
+    repeated string annotations = 2;
+    // Optional. If present, the location of `annotations[i]` is given by
+   // `annotation_locations[i]`.
+    repeated SourceLocation annotation_locations = 4;
+    repeated StructuredAnnotation structured_annotations = 3;
+  }
+  repeated Member members = 1;
+  repeated string annotations = 2;
+  // Optional. If present, the location of `annotations[i]` is given by
+ // `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 4;
+  repeated StructuredAnnotation structured_annotations = 3;
+}
+message GenericSerializableEnumTypeSpec {
+  message Member {
+    string name = 1;
+    bytes value = 2;
+    repeated string annotations = 3;
+    // Optional. If present, the location of `annotations[i]` is given by
+   // `annotation_locations[i]`.
+    repeated SourceLocation annotation_locations = 5;
+    repeated StructuredAnnotation structured_annotations = 4;
+  }
+  GenericBitTypeSpec underlying_type = 1;
+  repeated Member members = 2;
+  repeated string annotations = 3;
+  // Optional. If present, the location of `annotations[i]` is given by
+ // `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 5;
+  repeated StructuredAnnotation structured_annotations = 4;
+}
+
+// User defined types
+message GenericNewTypeTranslation {
+  message SdnString {}
+
+  // the URI uniquely identifies the translation in order to enable the
+  // P4Runtime agent to perform value-mapping appropriately when required. It is
+  // recommended that the URI includes at least the P4 architecture name and the
+  // type name. In case of target specific types, target_name should be included
+  string uri = 1;
+
+  // The object is either represented as an unsigned integer with a bitwidth of
+  // `sdn_bitwidth`, or as a string.
+  oneof sdn_type {
+    int32 sdn_bitwidth = 2;
+    SdnString sdn_string = 3;
+  }
+}
+message GenericNewTypeSpec {
+  oneof representation {
+    // if no @p4runtime_translation annotation present
+    GenericDataTypeSpec original_type = 1;
+    // if @p4runtime_translation annotation present
+    GenericNewTypeTranslation translated_type = 2;
+  }
+  // for other annotations (not @p4runtime_translation)
+  repeated string annotations = 3;
+  // Optional. If present, the location of `annotations[i]` is given by
+ // `annotation_locations[i]`.
+  repeated SourceLocation annotation_locations = 5;
+  repeated StructuredAnnotation structured_annotations = 4;
+}
+
 // End of P4 type specs --------------------------------------------------------

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -319,7 +319,12 @@ message GenericDataTypeSpec {
     GenericNamedType string = 6;
     GenericNamedType enum = 7;
     GenericNamedType serializable_enum = 8;
-    GenericNamedType new_type = 12;
+    GenericNamedType new_type = 9;
+    // P4 data type spec can help achieve parity with types being used
+    // in P4 externs. For example, if Register is using a type in P4
+    // Data type spec, then it will make it easier to map here when using
+    // GenericTables
+    P4DataTypeSpec p4_type = 10;
   }
 }
 
@@ -373,11 +378,7 @@ message GenericStructTypeSpec {
 
 // If a field is of type list, then repeated = true in p4info
 message GenericListTypeSpec {
-  message Member {
-    string name = 1;
-    GenericDataTypeSpec type_spec = 2;
-  }
-  repeated Member members = 1;
+  GenericDataTypeSpec type_spec = 1;
   repeated string annotations = 2;
   // Optional. If present, the location of `annotations[i]` is given by
   // `annotation_locations[i]`.

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -315,16 +315,19 @@ message GenericDataTypeSpec {
     GenericFloatType float = 2;
     GenericBoolType bool = 3;
     GenericNamedType struct = 4;
-    GenericNamedType list = 5;
-    GenericNamedType string = 6;
-    GenericNamedType enum = 7;
-    GenericNamedType serializable_enum = 8;
-    GenericNamedType new_type = 9;
+    GenericNamedType bag = 5;
+    GenericNamedType list = 6;
+    GenericNamedType set = 7;
+    GenericNamedType ordered_set = 8;
+    GenericNamedType string = 9;
+    GenericNamedType enum = 10;
+    GenericNamedType serializable_enum = 11;
+    GenericNamedType new_type = 12;
     // P4 data type spec can help achieve parity with types being used
     // in P4 externs. For example, if Register is using a type in P4
     // Data type spec, then it will make it easier to map here when using
     // GenericTables
-    P4DataTypeSpec p4_type = 10;
+    P4DataTypeSpec p4_type = 13;
   }
 }
 
@@ -376,9 +379,51 @@ message GenericStructTypeSpec {
   repeated StructuredAnnotation structured_annotations = 6;
 }
 
-// If a field is of type list, then repeated = true in p4info
+// If a field is of type bag, then container_type is in p4info
+// and value == "bag"
+// unordered and duplicates_allowed
+message GenericBagTypeSpec {
+  GenericDataTypeSpec type_spec = 1;// The container_type
+  repeated string annotations = 2;
+  // Optional. If present, the location of `annotations[i]` is given by
+  // `annotation_locations[i]`.
+  int32 min_size = 4; // 0 if not present
+  int32 max_size = 5; // no max size defined if not present
+  repeated SourceLocation annotation_locations = 6;
+  repeated StructuredAnnotation structured_annotations = 7;
+}
+// If a field is of type list, then container_type is in p4info
+// and value == "list"
+// ordered and duplicates allowed.
+// If max_size and min_size are equal, then fixed size.
 message GenericListTypeSpec {
-  GenericDataTypeSpec type_spec = 1;
+  GenericDataTypeSpec type_spec = 1;// The container_type
+  repeated string annotations = 2;
+  // Optional. If present, the location of `annotations[i]` is given by
+  // `annotation_locations[i]`.
+  int32 min_size = 4; // 0 if not present
+  int32 max_size = 5; // no max size defined if not present
+  repeated SourceLocation annotation_locations = 6;
+  repeated StructuredAnnotation structured_annotations = 7;
+}
+// If a field is of type set, then container_type is in p4info
+// and value == "set"
+// Unordered and duplicates not allowed
+message GenericSetTypeSpec {
+  GenericDataTypeSpec type_spec = 1;// The container_type
+  repeated string annotations = 2;
+  // Optional. If present, the location of `annotations[i]` is given by
+  // `annotation_locations[i]`.
+  int32 min_size = 4; // 0 if not present
+  int32 max_size = 5; // no max size defined if not present
+  repeated SourceLocation annotation_locations = 6;
+  repeated StructuredAnnotation structured_annotations = 7;
+}
+// If a field is of type "unordered_set", then container_type is in p4info
+// value == "unordered_set"
+// ordered and duplicates not allowed
+message GenericUnorderedSetTypeSpec {
+  GenericDataTypeSpec type_spec = 1;// The container_type
   repeated string annotations = 2;
   // Optional. If present, the location of `annotations[i]` is given by
   // `annotation_locations[i]`.

--- a/proto/p4/config/v1/p4types.proto
+++ b/proto/p4/config/v1/p4types.proto
@@ -383,7 +383,7 @@ message GenericStructTypeSpec {
 // and value == "bag"
 // unordered and duplicates_allowed
 message GenericBagTypeSpec {
-  GenericDataTypeSpec type_spec = 1;// The container_type
+  GenericDataTypeSpec type_spec = 1;// The element_type
   repeated string annotations = 2;
   // Optional. If present, the location of `annotations[i]` is given by
   // `annotation_locations[i]`.
@@ -397,7 +397,7 @@ message GenericBagTypeSpec {
 // ordered and duplicates allowed.
 // If max_size and min_size are equal, then fixed size.
 message GenericListTypeSpec {
-  GenericDataTypeSpec type_spec = 1;// The container_type
+  GenericDataTypeSpec type_spec = 1;// The element_type
   repeated string annotations = 2;
   // Optional. If present, the location of `annotations[i]` is given by
   // `annotation_locations[i]`.
@@ -410,7 +410,7 @@ message GenericListTypeSpec {
 // and value == "set"
 // Unordered and duplicates not allowed
 message GenericSetTypeSpec {
-  GenericDataTypeSpec type_spec = 1;// The container_type
+  GenericDataTypeSpec type_spec = 1;// The element_type
   repeated string annotations = 2;
   // Optional. If present, the location of `annotations[i]` is given by
   // `annotation_locations[i]`.
@@ -423,7 +423,7 @@ message GenericSetTypeSpec {
 // value == "unordered_set"
 // ordered and duplicates not allowed
 message GenericUnorderedSetTypeSpec {
-  GenericDataTypeSpec type_spec = 1;// The container_type
+  GenericDataTypeSpec type_spec = 1;// The element_type
   repeated string annotations = 2;
   // Optional. If present, the location of `annotations[i]` is given by
   // `annotation_locations[i]`.

--- a/proto/p4/v1/p4data.proto
+++ b/proto/p4/v1/p4data.proto
@@ -34,6 +34,24 @@ message P4Data {
     bytes enum_value = 12;  // serializable enums only
   }
 }
+message GenericData {
+  oneof data {
+    bytes bitstring = 1;
+    float float = 2;
+    bool bool = 3;
+    GenericStructLike generic_struct = 4; // one struct
+    GenericList generic_list = 5; // list of bytes/floats/bool/structs/strings/enums/enum_values.
+    string string = 6;  // control plane arbitrary length string
+    string enum = 7;  // safe (non-serializable) enums only
+    bytes enum_value = 8;  // serializable enums only
+  }
+}
+message GenericStructLike {
+  repeated GenericData members = 1;
+}
+message GenericList {
+  repeated GenericStructLike members = 1;
+}
 
 message P4Varbit {
   bytes bitstring = 1;

--- a/proto/p4/v1/p4data.proto
+++ b/proto/p4/v1/p4data.proto
@@ -50,7 +50,7 @@ message GenericStructLike {
   repeated GenericData members = 1;
 }
 message GenericList {
-  repeated GenericStructLike members = 1;
+  repeated GenericData members = 1;
 }
 
 message P4Varbit {

--- a/proto/p4/v1/p4data.proto
+++ b/proto/p4/v1/p4data.proto
@@ -37,13 +37,14 @@ message P4Data {
 message GenericData {
   oneof data {
     bytes bitstring = 1;
-    float float = 2;
-    bool bool = 3;
-    GenericStructLike generic_struct = 4; // one struct
-    GenericList generic_list = 5; // list of bytes/floats/bool/structs/strings/enums/enum_values.
-    string string = 6;  // control plane arbitrary length string
-    string enum = 7;  // safe (non-serializable) enums only
-    bytes enum_value = 8;  // serializable enums only
+    GenericVarbit varbitstring = 2;
+    float float = 3;
+    bool bool = 4;
+    GenericStructLike generic_struct = 5; // one struct
+    GenericList generic_list = 6; // list of bytes/floats/bool/structs/strings/enums/enum_values.
+    string string = 7;  // control plane arbitrary length string
+    string enum = 8;  // safe (non-serializable) enums only
+    bytes enum_value = 9;  // serializable enums only
   }
 }
 message GenericStructLike {
@@ -51,6 +52,11 @@ message GenericStructLike {
 }
 message GenericList {
   repeated GenericData members = 1;
+}
+
+message GenericVarbit {
+  bytes bitstring = 1;
+  int32 bitwidth = 2;  // dynamic bitwidth of the field
 }
 
 message P4Varbit {

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -138,6 +138,7 @@ message Entity {
     ValueSetEntry value_set_entry = 10;
     RegisterEntry register_entry = 11;
     DigestEntry digest_entry = 12;
+    GenericTableEntry generic_table_entry = 13;
   }
 }
 
@@ -239,6 +240,43 @@ message FieldMatch {
   // Otherwise, this behaves like an exact match.
   message Optional {
     bytes value = 1;
+  }
+
+  oneof field_match_type {
+    Exact exact = 2;
+    Ternary ternary = 3;
+    LPM lpm = 4;
+    Range range = 6;
+    Optional optional = 7;
+    // Architecture-specific match value; it corresponds to the other_match_type
+    // in the P4Info MatchField message.
+    .google.protobuf.Any other = 100;
+  }
+}
+message GenericFieldMatch {
+  uint32 field_id = 1;
+
+  message Exact {
+    GenericData value = 1;
+  }
+  message Ternary {
+    bytes value = 1;
+    bytes mask = 2;
+  }
+  message LPM {
+    bytes value = 1;
+    int32 prefix_len = 2;  // in bits
+  }
+  // A Range is logically a set that contains all values numerically between
+  // 'low' and 'high' inclusively.
+  message Range {
+    bytes low = 1;
+    bytes high = 2;
+  }
+  // If the Optional match should be a wildcard, the FieldMatch must be omitted.
+  // Otherwise, this behaves like an exact match.
+  message Optional {
+    GenericData value = 1;
   }
 
   oneof field_match_type {
@@ -508,6 +546,33 @@ message DigestEntry {
     int64 ack_timeout_ns = 3;  // timeout for DigestListAck message
   }
   Config config = 2;
+}
+
+message GenericTableEntry {
+  uint32 table_id = 1;
+  repeated GenericFieldMatch match = 2;
+  TableDataUnion table_data_union = 3;
+  // Should only be set if the match implies a TCAM lookup, i.e. at least one of
+  // the match fields is Optional, Ternary or Range.  A higher number indicates
+  // higher priority.  Only a highest priority entry that matches the packet
+  // must be selected.  Multiple entries in the same table with the same
+  // priority value are permitted.  See Section "TableEntry" in the
+  // specification for details of the behavior.
+  int32 priority = 4;
+  // Set to true if the table entry is being used to update the single default
+  // entry of the table. If true, the "match" field must be empty and
+  // the "data union" field must be populated with a valid data union.
+  bool is_default_entry = 5;
+  // Arbitrary metadata from the controller that is opaque to the target.
+  bytes metadata = 6;
+}
+message TableDataUnion {
+  uint32 union_id = 1;
+  message Param {
+    uint32 param_id = 2;
+    GenericData value = 3;
+  }
+  repeated Param params = 4;
 }
 
 //------------------------------------------------------------------------------

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -211,6 +211,10 @@ message TableEntry {
   IdleTimeout time_since_last_hit = 10;
   // Arbitrary metadata from the controller that is opaque to the target.
   bytes metadata = 11;
+  // list of GenericTableEntry
+  // The match fields aren't used.
+  // Only the union fields and priority
+  repeated GenericTableEntry resources = 13;
 }
 
 // field_match_type ::= exact | ternary | lpm | range | optional
@@ -566,6 +570,7 @@ message GenericTableEntry {
   // Arbitrary metadata from the controller that is opaque to the target.
   bytes metadata = 6;
 }
+
 message TableDataUnion {
   uint32 union_id = 1;
   message Param {


### PR DESCRIPTION
* Phase 1: 
  * Not extend any of the current RPC updates. Use INSERT, MODIFY, DELETE and Read RPC as is
  * Define Table categories/ properties
  * Define Entry and Field properties
  * Define Type system
  * Achieve Write/Read for simple PNA specific externs like ExactValueMatchLookupTable
  * Work on generic-table-dev
* Phase 2
  * Entry Handles
  * Table attributes (symmetric vs asymmetric)
  * New APIs
    * reset
    * add_or_mod
    * sync
    * usage_get
    * mod_inc
  * Table custom operations extensions. A way to define new operations via json modeling. For example, sync
* Phase 3
  * String representation of fields. Like IPv4 IPv6
  * Table notifications. Model notifications in a generic way
