### PR TITLE
Update P4Runtime-Spec.mdk to clarify length restrictions on Bytestrings

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -2394,7 +2394,7 @@ complement representation, this is called "sign extension", and leaves the
 numeric value represented unchanged.
 
 Upon receiving a binary string, the P4Runtime receiver (whether the server or
-the client) does not impose any restrictions on the length of the string
+the client) does not impose any restrictions on the maximum length of the string
 itself. Instead, the receiver verifies that the value encoded by the string fits
 within the expected type (signed or unsigned) and P4Info-specified bitwidth for
 the P4 object value.


### PR DESCRIPTION
The specification states that Bytestrings of length zero are not allowed. Clarify that there are no restrictions on the "maximum" length only, to avoid potential confusion.
Closes https://github.com/p4lang/p4runtime/issues/420