### PR TITLE
Fix #434: Remove obsolete TODO section in README

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -230,8 +230,17 @@ format and available at
 P4Runtime is designed to be implemented in conjunction with the P4~16~ language
 version or later. P4~14~ programs should be translated into P4~16~ to be made
 compatible with P4Runtime. This version of P4Runtime utilizes features which are
-not in P4~16~ 1.0, but were introduced in P4~16~ 1.1.0 [@P4Revisions110]. For
-this version of P4Runtime, we recommend using P4~16~ 1.2.1 [@P4Spec].
+not in P4~16~ 1.0, but were introduced in P4~16~ 1.2.4 [@P4Revisions124]. For
+this version of P4Runtime, we recommend using P4~16~ 1.2.4 [@P4Revisions124].
+
+This version of the P4Runtime specification does not yet explicitly
+address compatibility with the following P4~16~ language features
+introduced in version 1.2.2 of the language specification [@P4Revisions122]:
+
+* Added support for generic structures.
+* Added support for additional enumeration types.
+* Added support for 0-width bitstrings and varbits.
+
 
 ## In Scope
 

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -235,11 +235,23 @@ this version of P4Runtime, we recommend using P4~16~ 1.2.4 [@P4Revisions124].
 
 This version of the P4Runtime specification does not yet explicitly
 address compatibility with the following P4~16~ language features
-introduced in version 1.2.2 of the language specification [@P4Revisions122]:
+introduced in versions 1.2.2 or 1.2.4 of the language specification:
 
-* Added support for generic structures.
-* Added support for additional enumeration types.
-* Added support for 0-width bitstrings and varbits.
+* Added support for generic structures [@P4Revisions122].
+* Added support for additional enumeration types [@P4Revisions122].
+* Added support for 0-width bitstrings and varbits [@P4Revisions122].
+* Clarified restrictions for parameters with default values
+  [@P4Revisions124].
+* Specified that algorithm for generating control-plane names for keys
+  is optional [@P4Revisions124].
+* Allow ranges to be specified by serializable enums
+  [@P4Revisions124].
+* compiler-inserted `default_action` is not `const` [@P4Revisions124].
+* Clarified the restrictions on run time for tables with
+  `const entries` [@P4Revisions124].
+* Added `list` type [@P4Revisions124].
+* Clarified behavior of table with no `key` property, or if its list
+  of keys is empty [@P4Revisions124].
 
 
 ## In Scope

--- a/docs/v1/README.md
+++ b/docs/v1/README.md
@@ -7,7 +7,8 @@ specification document.
 
 The markup version uses Madoko (https://www.madoko.net) to produce
 HTML and PDF versions of the documentation. Pre-built versions of the
-documentation are available at **[TODO]**
+documentation are available on the [P4.org specifications
+page](https://p4.org/specs).
 
 
 Files:
@@ -63,13 +64,3 @@ Note that to build the PDF you need a functional TeX version installed.
 You need to install miktex [http://miktex.org/], madoko
 [https://www.madoko.net/] and node.js [https://nodejs.org/en/].  To
 build you can invoke the make.bat script.
-
-
-# TODO
-## Formating Fixups TODO
-
-## Content TODO
-Following are major content items which are missing or incomplete:
-*  Section 17. P4Runtime Versioning
-*  Section 18. Extending P4Runtime for non-PSA architectures
-*  Section 19. Lifetime of a session

--- a/docs/v1/references.bib
+++ b/docs/v1/references.bib
@@ -65,6 +65,16 @@
     url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-summary-of-changes-made-in-version-110"
 }
 
+@ONLINE { P4Revisions122,
+    title = "Summary of changes made in $P4_{16}$ version 1.2.2",
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.4.html#sec-summary-of-changes-made-in-version-122-released-may-17-2021"
+}
+
+@ONLINE { P4Revisions124,
+    title = "Summary of changes made in $P4_{16}$ version 1.2.4",
+    url = "https://p4.org/p4-spec/docs/P4-16-v1.2.4.html#sec-summary-of-changes-made-in-version-124"
+}
+
 @ONLINE { P4Spec,
     title = "$P4_{16}$ 1.2.1 specification",
     url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html"


### PR DESCRIPTION
Update the link to the auto-generated versions of the P4Runtime specification on the P4.org web site.

Update the section "P4 Language Version Applicability" to version 1.2.4 of the P4_16 language specification, but list 3 known exceptions of features that have not been explicitly addressed yet.