### PR TITLE
Remove 4 P4 language spec compatibility issues from the list

### DIFF
--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -245,6 +245,8 @@ introduced in versions 1.2.2 or 1.2.4 of the language specification:
 * Allow ranges to be specified by serializable enums
   [@P4Revisions124].
 * Added `list` type [@P4Revisions124].
+* Clarified behavior of table with no `key` property, or if its list
+  of keys is empty [@P4Revisions124].
 
 
 ## In Scope

--- a/docs/v1/P4Runtime-Spec.mdk
+++ b/docs/v1/P4Runtime-Spec.mdk
@@ -242,16 +242,9 @@ introduced in versions 1.2.2 or 1.2.4 of the language specification:
 * Added support for 0-width bitstrings and varbits [@P4Revisions122].
 * Clarified restrictions for parameters with default values
   [@P4Revisions124].
-* Specified that algorithm for generating control-plane names for keys
-  is optional [@P4Revisions124].
 * Allow ranges to be specified by serializable enums
   [@P4Revisions124].
-* compiler-inserted `default_action` is not `const` [@P4Revisions124].
-* Clarified the restrictions on run time for tables with
-  `const entries` [@P4Revisions124].
 * Added `list` type [@P4Revisions124].
-* Clarified behavior of table with no `key` property, or if its list
-  of keys is empty [@P4Revisions124].
 
 
 ## In Scope


### PR DESCRIPTION
During 2023-Sep-08 P4.org API work group meeting, it was agreed that there are no changes required to the P4Runtime API specification to be compatible with these updates in the language spec.