### PR TITLE
Add v1.4.0 comments to protobufs - fix https://github.com/p4lang/p4runtime/issues/487

### DIFF
--- a/go/p4/config/v1/p4info.pb.go
+++ b/go/p4/config/v1/p4info.pb.go
@@ -602,6 +602,7 @@ func (x *Documentation) GetDescription() string {
 }
 
 // Used to describe the required properties of the underlying platform.
+// Added in v1.4.0
 type PlatformProperties struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -704,6 +705,7 @@ type PkgInfo struct {
 	// If set, specifies the properties that the underlying platform should have.
 	// If the platform does not conform to these properties, the server should
 	// reject the P4Info when used with a SetForwardingPipelineConfigRequest.
+	// Added in 1.4.0
 	PlatformProperties *PlatformProperties `protobuf:"bytes,11,opt,name=platform_properties,json=platformProperties,proto3" json:"platform_properties,omitempty"`
 }
 
@@ -1654,11 +1656,13 @@ type isActionProfile_SelectorSizeSemantics interface {
 
 type ActionProfile_SumOfWeights_ struct {
 	// group size is the sum of the group's weights.
+	// Added in v1.4.0
 	SumOfWeights *ActionProfile_SumOfWeights `protobuf:"bytes,6,opt,name=sum_of_weights,json=sumOfWeights,proto3,oneof"`
 }
 
 type ActionProfile_SumOfMembers_ struct {
 	// group size is the sum of the group's members.
+	// Added in v1.4.0
 	SumOfMembers *ActionProfile_SumOfMembers `protobuf:"bytes,7,opt,name=sum_of_members,json=sumOfMembers,proto3,oneof"`
 }
 
@@ -2400,6 +2404,7 @@ func (x *Action_Param) GetStructuredAnnotations() []*StructuredAnnotation {
 // indicates that `size` and `max_group_size` represent the maximum sum of
 // weights that can be present across all selector groups and within a
 // single selector group respectively.
+// Added in v1.4.0
 type ActionProfile_SumOfWeights struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2441,6 +2446,7 @@ func (*ActionProfile_SumOfWeights) Descriptor() ([]byte, []int) {
 // indicates that `size` and `max_group_size` represent the maximum number
 // of members that can be present across all selector groups and within a
 // single selector group respectively.
+// Added in v1.4.0
 type ActionProfile_SumOfMembers struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/go/p4/v1/p4runtime.pb.go
+++ b/go/p4/v1/p4runtime.pb.go
@@ -370,8 +370,11 @@ type WriteRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	DeviceId uint64 `protobuf:"varint,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
+	// Deprecated in v1.4.0
+	//
 	// Deprecated: Marked as deprecated in p4/v1/p4runtime.proto.
-	RoleId     uint64   `protobuf:"varint,2,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty"`
+	RoleId uint64 `protobuf:"varint,2,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty"`
+	// Added in v1.4.0
 	Role       string   `protobuf:"bytes,6,opt,name=role,proto3" json:"role,omitempty"`
 	ElectionId *Uint128 `protobuf:"bytes,3,opt,name=election_id,json=electionId,proto3" json:"election_id,omitempty"`
 	// The write batch, comprising a list of Update operations. The P4Runtime
@@ -501,6 +504,7 @@ type ReadRequest struct {
 
 	DeviceId uint64 `protobuf:"varint,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
 	// When specified, only return table entries for the given role.
+	// Added in 1.4.0.
 	Role     string    `protobuf:"bytes,3,opt,name=role,proto3" json:"role,omitempty"`
 	Entities []*Entity `protobuf:"bytes,2,rep,name=entities,proto3" json:"entities,omitempty"`
 }
@@ -995,6 +999,7 @@ type TableEntry struct {
 	MeterConfig *MeterConfig `protobuf:"bytes,6,opt,name=meter_config,json=meterConfig,proto3" json:"meter_config,omitempty"`
 	CounterData *CounterData `protobuf:"bytes,7,opt,name=counter_data,json=counterData,proto3" json:"counter_data,omitempty"`
 	// Per color counters for tables with a direct meter.
+	// Added in v1.4.0
 	MeterCounterData *MeterCounterData `protobuf:"bytes,12,opt,name=meter_counter_data,json=meterCounterData,proto3" json:"meter_counter_data,omitempty"`
 	// Set to true if the table entry is being used to update the non-const
 	// default action of the table. If true, the "match" field must be empty and
@@ -1816,9 +1821,10 @@ type MeterEntry struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	MeterId     uint32            `protobuf:"varint,1,opt,name=meter_id,json=meterId,proto3" json:"meter_id,omitempty"`
-	Index       *Index            `protobuf:"bytes,2,opt,name=index,proto3" json:"index,omitempty"`
-	Config      *MeterConfig      `protobuf:"bytes,3,opt,name=config,proto3" json:"config,omitempty"`
+	MeterId uint32       `protobuf:"varint,1,opt,name=meter_id,json=meterId,proto3" json:"meter_id,omitempty"`
+	Index   *Index       `protobuf:"bytes,2,opt,name=index,proto3" json:"index,omitempty"`
+	Config  *MeterConfig `protobuf:"bytes,3,opt,name=config,proto3" json:"config,omitempty"`
+	// Added in v1.4.0
 	CounterData *MeterCounterData `protobuf:"bytes,4,opt,name=counter_data,json=counterData,proto3" json:"counter_data,omitempty"`
 }
 
@@ -1897,8 +1903,9 @@ type DirectMeterEntry struct {
 
 	// The associated table entry. This field is required.
 	// table_entry.action is ignored. Other fields specify the match.
-	TableEntry  *TableEntry       `protobuf:"bytes,1,opt,name=table_entry,json=tableEntry,proto3" json:"table_entry,omitempty"`
-	Config      *MeterConfig      `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+	TableEntry *TableEntry  `protobuf:"bytes,1,opt,name=table_entry,json=tableEntry,proto3" json:"table_entry,omitempty"`
+	Config     *MeterConfig `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+	// Added in v1.4.0
 	CounterData *MeterCounterData `protobuf:"bytes,3,opt,name=counter_data,json=counterData,proto3" json:"counter_data,omitempty"`
 }
 
@@ -2224,6 +2231,7 @@ func (x *CounterData) GetPacketCount() int64 {
 	return 0
 }
 
+// Added in v1.4.0
 type MeterCounterData struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2452,12 +2460,14 @@ type isReplica_PortKind interface {
 
 type Replica_EgressPort struct {
 	// Using uint32 as ports is deprecated, use port field instead.
+	// Deprecated in v1.4.0
 	//
 	// Deprecated: Marked as deprecated in p4/v1/p4runtime.proto.
 	EgressPort uint32 `protobuf:"varint,1,opt,name=egress_port,json=egressPort,proto3,oneof"`
 }
 
 type Replica_Port struct {
+	// Added in v1.4.0
 	Port []byte `protobuf:"bytes,3,opt,name=port,proto3,oneof"`
 }
 
@@ -3509,9 +3519,11 @@ type Role struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Uniquely identifies this role.
+	// Deprecated in 1.4.0.
 	//
 	// Deprecated: Marked as deprecated in p4/v1/p4runtime.proto.
-	Id   uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Added in 1.4.0.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// Describes the role configuration, i.e. what operations, P4 entities,
 	// behaviors, etc. are in the scope of a given role. If config is not set
@@ -3985,8 +3997,11 @@ type SetForwardingPipelineConfigRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	DeviceId uint64 `protobuf:"varint,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
+	// Deprecated in 1.4.0.
+	//
 	// Deprecated: Marked as deprecated in p4/v1/p4runtime.proto.
-	RoleId     uint64                                    `protobuf:"varint,2,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty"`
+	RoleId uint64 `protobuf:"varint,2,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty"`
+	// Added in 1.4.0.
 	Role       string                                    `protobuf:"bytes,6,opt,name=role,proto3" json:"role,omitempty"`
 	ElectionId *Uint128                                  `protobuf:"bytes,3,opt,name=election_id,json=electionId,proto3" json:"election_id,omitempty"`
 	Action     SetForwardingPipelineConfigRequest_Action `protobuf:"varint,4,opt,name=action,proto3,enum=p4.v1.SetForwardingPipelineConfigRequest_Action" json:"action,omitempty"`

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -49,6 +49,7 @@ message Documentation {
 }
 
 // Used to describe the required properties of the underlying platform.
+// Added in v1.4.0
 message PlatformProperties {
   // The minimum number of multicast entries (i.e. multicast groups) that the
   // platform is required to support. If 0, there are no requirements.
@@ -90,6 +91,7 @@ message PkgInfo {
   // If set, specifies the properties that the underlying platform should have.
   // If the platform does not conform to these properties, the server should
   // reject the P4Info when used with a SetForwardingPipelineConfigRequest.
+  // Added in 1.4.0
   PlatformProperties platform_properties = 11;
 }
 
@@ -304,11 +306,13 @@ message ActionProfile {
   // indicates that `size` and `max_group_size` represent the maximum sum of
   // weights that can be present across all selector groups and within a
   // single selector group respectively.
+  // Added in v1.4.0
   message SumOfWeights {}
 
   // indicates that `size` and `max_group_size` represent the maximum number
   // of members that can be present across all selector groups and within a
   // single selector group respectively.
+  // Added in v1.4.0
   message SumOfMembers {
     // the maximum weight of each individual member in a group.
     optional int32 max_member_weight = 1;
@@ -317,8 +321,10 @@ message ActionProfile {
   // specifies the semantics of `size` and `max_group_size` above
   oneof selector_size_semantics {
     // group size is the sum of the group's weights.
+    // Added in v1.4.0
     SumOfWeights sum_of_weights = 6;
     // group size is the sum of the group's members.
+    // Added in v1.4.0
     SumOfMembers sum_of_members = 7;
   }
 }

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -64,7 +64,9 @@ service P4Runtime {
 //------------------------------------------------------------------------------
 message WriteRequest {
   uint64 device_id = 1;
+  // Deprecated in v1.4.0
   uint64 role_id = 2 [deprecated=true];
+  // Added in v1.4.0
   string role = 6;
   Uint128 election_id = 3;
   // The write batch, comprising a list of Update operations. The P4Runtime
@@ -191,6 +193,7 @@ message TableEntry {
   MeterConfig meter_config = 6;
   CounterData counter_data = 7;
   // Per color counters for tables with a direct meter.
+  // Added in v1.4.0
   MeterCounterData meter_counter_data = 12;
   // Set to true if the table entry is being used to update the non-const
   // default action of the table. If true, the "match" field must be empty and
@@ -349,6 +352,7 @@ message MeterEntry {
   uint32 meter_id = 1;
   Index index = 2;
   MeterConfig config = 3;
+  // Added in v1.4.0
   MeterCounterData counter_data = 4;
 }
 
@@ -365,6 +369,7 @@ message DirectMeterEntry {
   // table_entry.action is ignored. Other fields specify the match.
   TableEntry table_entry = 1;
   MeterConfig config = 2;
+  // Added in v1.4.0
   MeterCounterData counter_data = 3;
 }
 
@@ -416,6 +421,7 @@ message CounterData {
   int64 packet_count = 2;
 }
 
+// Added in v1.4.0
 message MeterCounterData {
   CounterData green = 1;
   CounterData yellow = 2;
@@ -436,7 +442,9 @@ message PacketReplicationEngineEntry {
 message Replica {
   oneof port_kind {
     // Using uint32 as ports is deprecated, use port field instead.
+    // Deprecated in v1.4.0
     uint32 egress_port = 1 [deprecated=true];
+    // Added in v1.4.0
     bytes port = 3;
   }
   uint32 instance = 2;
@@ -617,7 +625,9 @@ message MasterArbitrationUpdate {
 
 message Role {
   // Uniquely identifies this role.
+  // Deprecated in 1.4.0.
   uint64 id = 1 [deprecated=true];
+  // Added in 1.4.0.
   string name = 3;
   // Describes the role configuration, i.e. what operations, P4 entities,
   // behaviors, etc. are in the scope of a given role. If config is not set
@@ -721,7 +731,9 @@ message SetForwardingPipelineConfigRequest {
     RECONCILE_AND_COMMIT = 5;
   }
   uint64 device_id = 1;
+  // Deprecated in 1.4.0.
   uint64 role_id = 2 [deprecated=true];
+  // Added in 1.4.0.
   string role = 6;
   Uint128 election_id = 3;
   Action action = 4;

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -107,6 +107,7 @@ message WriteResponse {
 message ReadRequest {
   uint64 device_id = 1;
   // When specified, only return table entries for the given role.
+  // Added in 1.4.0.
   string role = 3;
   repeated Entity entities = 2;
 }


### PR DESCRIPTION
This adds to staged version-1.4.0-rc branch which will be merged to main when we're ready to declare a 1.4.0 tag.
- Added comments to proto files with "Added in v1.4.0" or "Deprecated in v1.4.0" as needed.
I used the following commands to create a temp working file to examine changes since tagged version 1.3.0:
```
git diff v1.3.0 HEAD proto/p4/config/v1/*.proto > v1.3.0_diff.txt
git diff v1.3.0 HEAD proto/p4/v1/*.proto >> v1.3.0_diff.txt
```