### PR TITLE
Add reference for RFC2697 to bib

### DIFF
--- a/docs/v1/references.bib
+++ b/docs/v1/references.bib
@@ -151,6 +151,11 @@
     url = "https://tools.ietf.org/html/rfc2698"
 }
 
+@ONLINE { RFC2697,
+    title = "A Single Rate Three Color Marker",
+    url = "https://tools.ietf.org/html/rfc2697"
+}
+
 @ONLINE { P4MatchTypes,
     title = "Match types in P4",
     url = "https://p4.org/p4-spec/docs/P4-16-v1.2.1.html#sec-match-kind-type"


### PR DESCRIPTION
The reference for RFC 2697 was missing from the references.bib file.