### PR TITLE
Version 1.4.0 rc updates to bazel and protobuf comments

### DIFF
--- a/bazel/example/WORKSPACE.bazel
+++ b/bazel/example/WORKSPACE.bazel
@@ -11,8 +11,8 @@ local_repository(
 
 # http_archive(
 #     name = "com_github_p4lang_p4runtime",
-#     urls = ["https://github.com/p4lang/p4runtime/archive/v1.3.0.tar.gz"],
-#     strip_prefix = "p4runtime-1.3.0/proto",
+#     urls = ["https://github.com/p4lang/p4runtime/archive/v1.4.0.tar.gz"],
+#     strip_prefix = "p4runtime-1.4.0/proto",
 #     # sha256 = "<insert hash value here>",
 # )
 
@@ -21,7 +21,7 @@ local_repository(
 #   remote = "https://github.com/p4lang/p4runtime.git",
 #   # strip_prefix = "proto",  # https://github.com/bazelbuild/bazel/issues/10062
 #   patch_cmds = ["mv proto/* ."],  # Workaround since strip_prefix is broken.
-#   tag = "v1.3.0",
+#   tag = "v1.4.0",
 # )
 
 load("@com_github_p4lang_p4runtime//:p4runtime_deps.bzl", "p4runtime_deps")

--- a/go/p4/config/v1/p4info.pb.go
+++ b/go/p4/config/v1/p4info.pb.go
@@ -667,6 +667,7 @@ func (x *Documentation) GetDescription() string {
 }
 
 // Used to describe the required properties of the underlying platform.
+// Added in v1.4.0
 type PlatformProperties struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -769,6 +770,7 @@ type PkgInfo struct {
 	// If set, specifies the properties that the underlying platform should have.
 	// If the platform does not conform to these properties, the server should
 	// reject the P4Info when used with a SetForwardingPipelineConfigRequest.
+	// Added in 1.4.0
 	PlatformProperties *PlatformProperties `protobuf:"bytes,11,opt,name=platform_properties,json=platformProperties,proto3" json:"platform_properties,omitempty"`
 }
 
@@ -1789,11 +1791,13 @@ type isActionProfile_SelectorSizeSemantics interface {
 
 type ActionProfile_SumOfWeights_ struct {
 	// group size is the sum of the group's weights.
+	// Added in v1.4.0
 	SumOfWeights *ActionProfile_SumOfWeights `protobuf:"bytes,6,opt,name=sum_of_weights,json=sumOfWeights,proto3,oneof"`
 }
 
 type ActionProfile_SumOfMembers_ struct {
 	// group size is the sum of the group's members.
+	// Added in v1.4.0
 	SumOfMembers *ActionProfile_SumOfMembers `protobuf:"bytes,7,opt,name=sum_of_members,json=sumOfMembers,proto3,oneof"`
 }
 
@@ -2599,6 +2603,7 @@ func (x *Action_Param) GetStructuredAnnotations() []*StructuredAnnotation {
 // indicates that `size` and `max_group_size` represent the maximum sum of
 // weights that can be present across all selector groups and within a
 // single selector group respectively.
+// Added in v1.4.0
 type ActionProfile_SumOfWeights struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2640,6 +2645,7 @@ func (*ActionProfile_SumOfWeights) Descriptor() ([]byte, []int) {
 // indicates that `size` and `max_group_size` represent the maximum number
 // of members that can be present across all selector groups and within a
 // single selector group respectively.
+// Added in v1.4.0
 type ActionProfile_SumOfMembers struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/go/p4/v1/p4runtime.pb.go
+++ b/go/p4/v1/p4runtime.pb.go
@@ -370,8 +370,11 @@ type WriteRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	DeviceId uint64 `protobuf:"varint,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
+	// Deprecated in v1.4.0
+	//
 	// Deprecated: Marked as deprecated in p4/v1/p4runtime.proto.
-	RoleId     uint64   `protobuf:"varint,2,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty"`
+	RoleId uint64 `protobuf:"varint,2,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty"`
+	// Added in v1.4.0
 	Role       string   `protobuf:"bytes,6,opt,name=role,proto3" json:"role,omitempty"`
 	ElectionId *Uint128 `protobuf:"bytes,3,opt,name=election_id,json=electionId,proto3" json:"election_id,omitempty"`
 	// The write batch, comprising a list of Update operations. The P4Runtime
@@ -501,6 +504,7 @@ type ReadRequest struct {
 
 	DeviceId uint64 `protobuf:"varint,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
 	// When specified, only return table entries for the given role.
+	// Added in 1.4.0.
 	Role     string    `protobuf:"bytes,3,opt,name=role,proto3" json:"role,omitempty"`
 	Entities []*Entity `protobuf:"bytes,2,rep,name=entities,proto3" json:"entities,omitempty"`
 }
@@ -995,6 +999,7 @@ type TableEntry struct {
 	MeterConfig *MeterConfig `protobuf:"bytes,6,opt,name=meter_config,json=meterConfig,proto3" json:"meter_config,omitempty"`
 	CounterData *CounterData `protobuf:"bytes,7,opt,name=counter_data,json=counterData,proto3" json:"counter_data,omitempty"`
 	// Per color counters for tables with a direct meter.
+	// Added in v1.4.0
 	MeterCounterData *MeterCounterData `protobuf:"bytes,12,opt,name=meter_counter_data,json=meterCounterData,proto3" json:"meter_counter_data,omitempty"`
 	// Set to true if the table entry is being used to update the non-const
 	// default action of the table. If true, the "match" field must be empty and
@@ -1816,9 +1821,10 @@ type MeterEntry struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	MeterId     uint32            `protobuf:"varint,1,opt,name=meter_id,json=meterId,proto3" json:"meter_id,omitempty"`
-	Index       *Index            `protobuf:"bytes,2,opt,name=index,proto3" json:"index,omitempty"`
-	Config      *MeterConfig      `protobuf:"bytes,3,opt,name=config,proto3" json:"config,omitempty"`
+	MeterId uint32       `protobuf:"varint,1,opt,name=meter_id,json=meterId,proto3" json:"meter_id,omitempty"`
+	Index   *Index       `protobuf:"bytes,2,opt,name=index,proto3" json:"index,omitempty"`
+	Config  *MeterConfig `protobuf:"bytes,3,opt,name=config,proto3" json:"config,omitempty"`
+	// Added in v1.4.0
 	CounterData *MeterCounterData `protobuf:"bytes,4,opt,name=counter_data,json=counterData,proto3" json:"counter_data,omitempty"`
 }
 
@@ -1897,8 +1903,9 @@ type DirectMeterEntry struct {
 
 	// The associated table entry. This field is required.
 	// table_entry.action is ignored. Other fields specify the match.
-	TableEntry  *TableEntry       `protobuf:"bytes,1,opt,name=table_entry,json=tableEntry,proto3" json:"table_entry,omitempty"`
-	Config      *MeterConfig      `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+	TableEntry *TableEntry  `protobuf:"bytes,1,opt,name=table_entry,json=tableEntry,proto3" json:"table_entry,omitempty"`
+	Config     *MeterConfig `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+	// Added in v1.4.0
 	CounterData *MeterCounterData `protobuf:"bytes,3,opt,name=counter_data,json=counterData,proto3" json:"counter_data,omitempty"`
 }
 
@@ -2246,6 +2253,7 @@ func (x *CounterData) GetPacketCount() int64 {
 	return 0
 }
 
+// Added in v1.4.0
 type MeterCounterData struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2474,12 +2482,14 @@ type isReplica_PortKind interface {
 
 type Replica_EgressPort struct {
 	// Using uint32 as ports is deprecated, use port field instead.
+	// Deprecated in v1.4.0
 	//
 	// Deprecated: Marked as deprecated in p4/v1/p4runtime.proto.
 	EgressPort uint32 `protobuf:"varint,1,opt,name=egress_port,json=egressPort,proto3,oneof"`
 }
 
 type Replica_Port struct {
+	// Added in v1.4.0
 	Port []byte `protobuf:"bytes,3,opt,name=port,proto3,oneof"`
 }
 
@@ -3531,9 +3541,11 @@ type Role struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Uniquely identifies this role.
+	// Deprecated in 1.4.0.
 	//
 	// Deprecated: Marked as deprecated in p4/v1/p4runtime.proto.
-	Id   uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Added in 1.4.0.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// Describes the role configuration, i.e. what operations, P4 entities,
 	// behaviors, etc. are in the scope of a given role. If config is not set
@@ -4007,8 +4019,11 @@ type SetForwardingPipelineConfigRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	DeviceId uint64 `protobuf:"varint,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
+	// Deprecated in 1.4.0.
+	//
 	// Deprecated: Marked as deprecated in p4/v1/p4runtime.proto.
-	RoleId     uint64                                    `protobuf:"varint,2,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty"`
+	RoleId uint64 `protobuf:"varint,2,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty"`
+	// Added in 1.4.0.
 	Role       string                                    `protobuf:"bytes,6,opt,name=role,proto3" json:"role,omitempty"`
 	ElectionId *Uint128                                  `protobuf:"bytes,3,opt,name=election_id,json=electionId,proto3" json:"election_id,omitempty"`
 	Action     SetForwardingPipelineConfigRequest_Action `protobuf:"varint,4,opt,name=action,proto3,enum=p4.v1.SetForwardingPipelineConfigRequest_Action" json:"action,omitempty"`

--- a/proto/p4/config/v1/p4info.proto
+++ b/proto/p4/config/v1/p4info.proto
@@ -49,6 +49,7 @@ message Documentation {
 }
 
 // Used to describe the required properties of the underlying platform.
+// Added in v1.4.0
 message PlatformProperties {
   // The minimum number of multicast entries (i.e. multicast groups) that the
   // platform is required to support. If 0, there are no requirements.
@@ -90,6 +91,7 @@ message PkgInfo {
   // If set, specifies the properties that the underlying platform should have.
   // If the platform does not conform to these properties, the server should
   // reject the P4Info when used with a SetForwardingPipelineConfigRequest.
+  // Added in 1.4.0
   PlatformProperties platform_properties = 11;
 }
 
@@ -321,11 +323,13 @@ message ActionProfile {
   // indicates that `size` and `max_group_size` represent the maximum sum of
   // weights that can be present across all selector groups and within a
   // single selector group respectively.
+  // Added in v1.4.0
   message SumOfWeights {}
 
   // indicates that `size` and `max_group_size` represent the maximum number
   // of members that can be present across all selector groups and within a
   // single selector group respectively.
+  // Added in v1.4.0
   message SumOfMembers {
     // the maximum weight of each individual member in a group.
     int32 max_member_weight = 1;
@@ -334,8 +338,10 @@ message ActionProfile {
   // specifies the semantics of `size` and `max_group_size` above
   oneof selector_size_semantics {
     // group size is the sum of the group's weights.
+    // Added in v1.4.0
     SumOfWeights sum_of_weights = 6;
     // group size is the sum of the group's members.
+    // Added in v1.4.0
     SumOfMembers sum_of_members = 7;
   }
 }

--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -58,7 +58,9 @@ service P4Runtime {
 //------------------------------------------------------------------------------
 message WriteRequest {
   uint64 device_id = 1;
-  uint64 role_id = 2 [deprecated = true];
+  // Deprecated in v1.4.0
+  uint64 role_id = 2 [deprecated=true];
+  // Added in v1.4.0
   string role = 6;
   Uint128 election_id = 3;
   // The write batch, comprising a list of Update operations. The P4Runtime
@@ -98,6 +100,7 @@ message WriteResponse {}
 message ReadRequest {
   uint64 device_id = 1;
   // When specified, only return table entries for the given role.
+  // Added in 1.4.0.
   string role = 3;
   repeated Entity entities = 2;
 }
@@ -184,6 +187,7 @@ message TableEntry {
   MeterConfig meter_config = 6;
   CounterData counter_data = 7;
   // Per color counters for tables with a direct meter.
+  // Added in v1.4.0
   MeterCounterData meter_counter_data = 12;
   // Set to true if the table entry is being used to update the non-const
   // default action of the table. If true, the "match" field must be empty and
@@ -342,6 +346,7 @@ message MeterEntry {
   uint32 meter_id = 1;
   Index index = 2;
   MeterConfig config = 3;
+  // Added in v1.4.0
   MeterCounterData counter_data = 4;
 }
 
@@ -358,6 +363,7 @@ message DirectMeterEntry {
   // table_entry.action is ignored. Other fields specify the match.
   TableEntry table_entry = 1;
   MeterConfig config = 2;
+  // Added in v1.4.0
   MeterCounterData counter_data = 3;
 }
 
@@ -424,6 +430,7 @@ message CounterData {
   int64 packet_count = 2;
 }
 
+// Added in v1.4.0
 message MeterCounterData {
   CounterData green = 1;
   CounterData yellow = 2;
@@ -444,7 +451,9 @@ message PacketReplicationEngineEntry {
 message Replica {
   oneof port_kind {
     // Using uint32 as ports is deprecated, use port field instead.
-    uint32 egress_port = 1 [deprecated = true];
+    // Deprecated in v1.4.0
+    uint32 egress_port = 1 [deprecated=true];
+    // Added in v1.4.0
     bytes port = 3;
   }
   uint32 instance = 2;
@@ -625,7 +634,9 @@ message MasterArbitrationUpdate {
 
 message Role {
   // Uniquely identifies this role.
-  uint64 id = 1 [deprecated = true];
+  // Deprecated in 1.4.0.
+  uint64 id = 1 [deprecated=true];
+  // Added in 1.4.0.
   string name = 3;
   // Describes the role configuration, i.e. what operations, P4 entities,
   // behaviors, etc. are in the scope of a given role. If config is not set
@@ -729,7 +740,9 @@ message SetForwardingPipelineConfigRequest {
     RECONCILE_AND_COMMIT = 5;
   }
   uint64 device_id = 1;
-  uint64 role_id = 2 [deprecated = true];
+  // Deprecated in 1.4.0.
+  uint64 role_id = 2 [deprecated=true];
+  // Added in 1.4.0.
   string role = 6;
   Uint128 election_id = 3;
   Action action = 4;

--- a/rust/src/p4.config.v1.rs
+++ b/rust/src/p4.config.v1.rs
@@ -472,6 +472,7 @@ pub struct Documentation {
     pub description: ::prost::alloc::string::String,
 }
 /// Used to describe the required properties of the underlying platform.
+/// Added in v1.4.0
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct PlatformProperties {
     /// The minimum number of multicast entries (i.e. multicast groups) that the
@@ -527,6 +528,7 @@ pub struct PkgInfo {
     /// If set, specifies the properties that the underlying platform should have.
     /// If the platform does not conform to these properties, the server should
     /// reject the P4Info when used with a SetForwardingPipelineConfigRequest.
+    /// Added in 1.4.0
     #[prost(message, optional, tag="11")]
     pub platform_properties: ::core::option::Option<PlatformProperties>,
 }
@@ -967,12 +969,14 @@ pub mod action_profile {
     /// indicates that `size` and `max_group_size` represent the maximum sum of
     /// weights that can be present across all selector groups and within a
     /// single selector group respectively.
+    /// Added in v1.4.0
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct SumOfWeights {
     }
     /// indicates that `size` and `max_group_size` represent the maximum number
     /// of members that can be present across all selector groups and within a
     /// single selector group respectively.
+    /// Added in v1.4.0
     #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct SumOfMembers {
         /// the maximum weight of each individual member in a group.
@@ -983,9 +987,11 @@ pub mod action_profile {
     #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
     pub enum SelectorSizeSemantics {
         /// group size is the sum of the group's weights.
+        /// Added in v1.4.0
         #[prost(message, tag="6")]
         SumOfWeights(SumOfWeights),
         /// group size is the sum of the group's members.
+        /// Added in v1.4.0
         #[prost(message, tag="7")]
         SumOfMembers(SumOfMembers),
     }

--- a/rust/src/p4.v1.rs
+++ b/rust/src/p4.v1.rs
@@ -89,9 +89,11 @@ pub struct P4HeaderUnionStack {
 pub struct WriteRequest {
     #[prost(uint64, tag="1")]
     pub device_id: u64,
+    /// Deprecated in v1.4.0
     #[deprecated]
     #[prost(uint64, tag="2")]
     pub role_id: u64,
+    /// Added in v1.4.0
     #[prost(string, tag="6")]
     pub role: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
@@ -164,6 +166,7 @@ pub struct ReadRequest {
     #[prost(uint64, tag="1")]
     pub device_id: u64,
     /// When specified, only return table entries for the given role.
+    /// Added in 1.4.0.
     #[prost(string, tag="3")]
     pub role: ::prost::alloc::string::String,
     #[prost(message, repeated, tag="2")]
@@ -314,6 +317,7 @@ pub struct TableEntry {
     #[prost(message, optional, tag="7")]
     pub counter_data: ::core::option::Option<CounterData>,
     /// Per color counters for tables with a direct meter.
+    /// Added in v1.4.0
     #[prost(message, optional, tag="12")]
     pub meter_counter_data: ::core::option::Option<MeterCounterData>,
     /// Set to true if the table entry is being used to update the non-const
@@ -562,6 +566,7 @@ pub struct MeterEntry {
     pub index: ::core::option::Option<Index>,
     #[prost(message, optional, tag="3")]
     pub config: ::core::option::Option<MeterConfig>,
+    /// Added in v1.4.0
     #[prost(message, optional, tag="4")]
     pub counter_data: ::core::option::Option<MeterCounterData>,
 }
@@ -581,6 +586,7 @@ pub struct DirectMeterEntry {
     pub table_entry: ::core::option::Option<TableEntry>,
     #[prost(message, optional, tag="2")]
     pub config: ::core::option::Option<MeterConfig>,
+    /// Added in v1.4.0
     #[prost(message, optional, tag="3")]
     pub counter_data: ::core::option::Option<MeterCounterData>,
 }
@@ -659,6 +665,7 @@ pub struct CounterData {
     #[prost(int64, tag="2")]
     pub packet_count: i64,
 }
+/// Added in v1.4.0
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct MeterCounterData {
     #[prost(message, optional, tag="1")]
@@ -699,8 +706,10 @@ pub mod replica {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum PortKind {
         /// Using uint32 as ports is deprecated, use port field instead.
+        /// Deprecated in v1.4.0
         #[prost(uint32, tag="1")]
         EgressPort(u32),
+        /// Added in v1.4.0
         #[prost(bytes, tag="3")]
         Port(::prost::alloc::vec::Vec<u8>),
     }
@@ -946,9 +955,11 @@ pub struct MasterArbitrationUpdate {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Role {
     /// Uniquely identifies this role.
+    /// Deprecated in 1.4.0.
     #[deprecated]
     #[prost(uint64, tag="1")]
     pub id: u64,
+    /// Added in 1.4.0.
     #[prost(string, tag="3")]
     pub name: ::prost::alloc::string::String,
     /// Describes the role configuration, i.e. what operations, P4 entities,
@@ -1046,9 +1057,11 @@ pub struct Uint128 {
 pub struct SetForwardingPipelineConfigRequest {
     #[prost(uint64, tag="1")]
     pub device_id: u64,
+    /// Deprecated in 1.4.0.
     #[deprecated]
     #[prost(uint64, tag="2")]
     pub role_id: u64,
+    /// Added in 1.4.0.
     #[prost(string, tag="6")]
     pub role: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]


### PR DESCRIPTION
Merge accumulated 1.4.0 updates by consensus in WG mtg:
- Add missing comments "Added in 1.4.0" and "Deprecated in 1.4.0" to protobufs
- Update script bazel comments to reflect version 1.4.0
- Regenerate protobuf client code