### PR TITLE
Temporarily pin Ubuntu CI version to 22.04, since 24.04 causes regression. 

### DIFF
--- a/.github/workflows/ci-build-proto.yml
+++ b/.github/workflows/ci-build-proto.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       BAZEL: bazelisk-linux-amd64
     steps:


### PR DESCRIPTION
@jafingerhut  https://github.com/p4lang/p4runtime/pull/512#issuecomment-2537572636