### PR TITLE
Upgrade to C++17/Clang/Ubuntu 24.04/newer GH action versions.

### DIFF
--- a/.github/workflows/any-branch-uploads.yml
+++ b/.github/workflows/any-branch-uploads.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.repository == 'p4lang/p4runtime' }}
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build spec
       run: |
         docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-madoko:latest make

--- a/.github/workflows/ci-build-proto.yml
+++ b/.github/workflows/ci-build-proto.yml
@@ -14,33 +14,75 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
-    env:
-      BAZEL: bazelisk-linux-amd64
+    strategy:
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
-    
+
     - name: Mount bazel cache
-      uses: actions/cache@v2
+      uses: actions/cache/restore@v4
       with:
         # See https://docs.bazel.build/versions/master/output_directories.html
         path: "~/.cache/bazel"
         # Create a new cache entry whenever Bazel files change.
         # See https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
-        key: bazel-${{ runner.os }}-build-${{ hashFiles('**/*.bzl', '**/*.bazel') }}
+        key: bazel-${{ matrix.os }}-${{ hashFiles('**/*.bazel*') }}
         restore-keys: |
-          bazel-${{ runner.os }}-build-
+          bazel-${{ matrix.os }}-
 
-    - name: Install bazelisk
-      run: |
-        curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/$BAZEL"
-        chmod +x $BAZEL
-        sudo mv $BAZEL /usr/local/bin/bazel
+    - name: Save start time
+      uses: josStorer/get-current-time@v2
+      id: start-time
+      with:
+        # Unix timestamp -- seconds since 1970.
+        format: X
 
     - name: Build proto/
       run: cd proto && bazel build //... && bazel test //...
 
     - name: Build bazel/example/
       run: cd bazel/example/ && bazel build //...
+
+    - name: Save end time
+      # Always save the end time so we can calculate the build duration.
+      if: always()
+      uses: josStorer/get-current-time@v2
+      id: end-time
+      with:
+        # Unix timestamp -- seconds since 1970.
+        format: X
+
+    - name: Calculate build duration
+      # Always calculate the build duration so we can update the cache if needed.
+      if: always()
+      run: |
+        START=${{ steps.start-time.outputs.formattedTime }}
+        END=${{ steps.end-time.outputs.formattedTime }}
+        DURATION=$(( $END - $START ))
+        echo "duration=$DURATION" | tee "$GITHUB_ENV"
+
+    - name: Compress cache
+      # Always compress the cache so we can update the cache if needed.
+      if: always()
+      run: rm -rf $(bazel info repository_cache)
+
+    - name: Save bazel cache
+      uses: actions/cache/save@v4
+      # Only create a new cache entry if we're on the main branch or the build takes >5mins.
+      #
+      # NOTE: Even though `always()` evaluates to true, and `true && x == x`,
+      # the `always() &&` prefix is not redundant! The call to `always()` has a
+      # side effect, which is to override the default behavior of automagically
+      # canceling this step if a previous step failed.
+      # (Don't blame me, blame GitHub Actions!)
+      if: always() && (github.ref_name == 'main' || env.duration > 300)
+      with:
+        path: "~/.cache/bazel"
+        key: bazel-${{ matrix.os }}-${{ hashFiles('**/*.bazel*') }}-${{ github.run_id }}

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -14,7 +14,7 @@ jobs:
   check-codegen:
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Compile protobufs
       run: |
         docker build -t p4runtime-ci -f codegen/Dockerfile .

--- a/.github/workflows/main-branch-uploads.yml
+++ b/.github/workflows/main-branch-uploads.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.repository == 'p4lang/p4runtime' }}
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # fetch all history for all branches and tags
         fetch-depth: 0

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -14,7 +14,7 @@ jobs:
   madoko-lint:
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run linter
       run: |
         ./tools/madokolint.py docs/v1/P4Runtime-Spec.mdk
@@ -22,7 +22,7 @@ jobs:
   build-spec:
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build spec
       run: |
         docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-madoko:latest make

--- a/.github/workflows/tag-uploads.yml
+++ b/.github/workflows/tag-uploads.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       TAG: ${{ github.ref_name }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # fetch all history for all branches and tags
         fetch-depth: 0

--- a/bazel/example/.bazelrc
+++ b/bazel/example/.bazelrc
@@ -1,4 +1,10 @@
-# bazelrc file
+# Use C++17.
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
 
-# C++14 required for recent gRPC versions
-build --cxxopt='-std=c++14'
+# Use Clang.
+build --action_env=CC=clang
+build --action_env=CXX=clang++
+
+# Print test errors.
+common --test_output=errors //...

--- a/proto/.bazelrc
+++ b/proto/.bazelrc
@@ -1,4 +1,10 @@
-# bazelrc file
+# Use C++17.
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
 
-# C++14 required for recent gRPC versions
-build --cxxopt='-std=c++14'
+# Use Clang.
+build --action_env=CC=clang
+build --action_env=CXX=clang++
+
+# Print test errors.
+common --test_output=errors //...


### PR DESCRIPTION
From here on out, we're building on `ubuntu-22.04`, `ubuntu-24.04`, and `ubuntu-latest` so we can track backward compatibility while preventing bit rot.

Fixes https://github.com/p4lang/p4runtime/issues/514.