### PR TITLE
Fix CI P4Runtime Spec

### DIFF
--- a/.github/workflows/any-branch-uploads.yml
+++ b/.github/workflows/any-branch-uploads.yml
@@ -15,8 +15,7 @@ jobs:
       run: |
         make -C docs/tools/
         docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-asciidoc make
-        ls docs/v1/P4Runtime-Spec.pdf
-        ls docs/v1/P4Runtime-Spec.html
+        ls docs/v1/build
     - name: Upload spec to S3 if needed
       if: ${{ github.actor != 'dependabot[bot]' }}
       uses: jakejarvis/s3-sync-action@v0.5.1
@@ -27,5 +26,5 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-west-2'
-        SOURCE_DIR: 'docs/v1'
+        SOURCE_DIR: 'docs/v1/build'
         DEST_DIR: ci/${{ github.ref_name }} # only runs for push events

--- a/.github/workflows/main-branch-uploads.yml
+++ b/.github/workflows/main-branch-uploads.yml
@@ -18,8 +18,7 @@ jobs:
       run: |
         make -C docs/tools/
         docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-asciidoc make
-        ls docs/v1/P4Runtime-Spec.pdf
-        ls docs/v1/P4Runtime-Spec.html
+        ls docs/v1/build
     - name: Upload spec to S3
       uses: jakejarvis/s3-sync-action@v0.5.1
       with:
@@ -29,15 +28,14 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-west-2'
-        SOURCE_DIR: 'docs/v1'
+        SOURCE_DIR: 'docs/v1/build'
         DEST_DIR: docs/main
     - name: Prepare spec for upload to gh-pages
       run: |
         git checkout gh-pages
         mkdir -p spec
         rm -rf spec/main
-        cp docs/v1/P4Runtime-Spec.html spec/main
-        cp docs/v1/P4Runtime-Spec.pdf spec/main
+        cp -r docs/v1/build spec/main
     - name: Upload spec to gh-pages
       uses: EndBug/add-and-commit@v9
       with:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -27,5 +27,4 @@ jobs:
       run: |
         make -C docs/tools/
         docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-asciidoc make build_spec_with_images
-        ls docs/v1/P4Runtime-Spec.pdf
-        ls docs/v1/P4Runtime-Spec.html
+        ls docs/v1/build

--- a/.github/workflows/tag-uploads.yml
+++ b/.github/workflows/tag-uploads.yml
@@ -20,8 +20,7 @@ jobs:
       run: |
         make -C docs/tools/
         docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4rt-asciidoc make
-        ls docs/v1/P4Runtime-Spec.pdf
-        ls docs/v1/P4Runtime-Spec.html
+        ls docs/v1/build
     - name: Upload spec to S3
       uses: jakejarvis/s3-sync-action@v0.5.1
       with:
@@ -38,8 +37,7 @@ jobs:
         git checkout gh-pages
         mkdir -p spec
         rm -rf spec/$TAG
-        cp docs/v1/P4Runtime-Spec.html spec/$TAG
-        cp docs/v1/P4Runtime-Spec.pdf spec/$TAG
+        cp -r docs/v1/build spec/$TAG
     - name: Upload spec to gh-pages
       uses: EndBug/add-and-commit@v9
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Emacs
 *~
+docs/v1/build/
 .DS_Store
 build
 dist

--- a/docs/v1/Makefile
+++ b/docs/v1/Makefile
@@ -34,4 +34,4 @@ images:
 build_spec_with_images: images all
 
 clean:
-	/bin/rm -rf build resources/figs/*.png
+	/bin/rm -rf build resources/figs/*.png resources/figs/*.svg

--- a/docs/v1/Makefile
+++ b/docs/v1/Makefile
@@ -5,22 +5,27 @@ ROUGE_CSS=style
 
 all: ${SPEC}.pdf ${SPEC}.html
 
+folder:
+	mkdir -p build
+
 build:
 
-${SPEC}.pdf: ${SPEC}.adoc images
+${SPEC}.pdf: ${SPEC}.adoc images folder
 	time asciidoctor-pdf -v \
 	-a pdf-fontsdir=resources/fonts \
 	-r asciidoctor-mathematical \
 	-r asciidoctor-bibtex \
 	-r asciidoctor-lists \
-	-a rouge-style=$(ROUGE_STYLE) $<
+	-a rouge-style=$(ROUGE_STYLE) \
+	-D build $<
 
-${SPEC}.html: ${SPEC}.adoc images
+${SPEC}.html: ${SPEC}.adoc images folder
 	time asciidoctor -v \
 	-r asciidoctor-mathematical \
 	-r asciidoctor-bibtex \
 	-r asciidoctor-lists \
-	-a rouge-css=$(ROUGE_CSS) $<
+	-a rouge-css=$(ROUGE_CSS) \
+	-D build $<
 
 images:
 	soffice --convert-to svg --outdir resources/figs resources/figs/*.odg > /dev/null 2>&1
@@ -29,4 +34,4 @@ images:
 build_spec_with_images: images all
 
 clean:
-	/bin/rm -f ${SPEC}.pdf ${SPEC}.html
+	-rf build

--- a/docs/v1/Makefile
+++ b/docs/v1/Makefile
@@ -34,4 +34,4 @@ images:
 build_spec_with_images: images all
 
 clean:
-	-rf build
+	/bin/rm -rf build resources/figs/*.png


### PR DESCRIPTION
As pointed out by Antonin [here ](https://github.com/p4lang/p4runtime/pull/539#issuecomment-2628030281), the PR bringing back the build folder, where the `.pdf ` and ` .html `specs will be stored