### PR TITLE
Specify read-write symmetry exception for backup replicas in P4Runtime Spec

### DIFF
--- a/docs/v1/P4Runtime-Spec.adoc
+++ b/docs/v1/P4Runtime-Spec.adoc
@@ -2138,6 +2138,8 @@ preserved, it will be explicitly stated in this document. The
 C++ API supports comparing messages while treating repeated fields as sets, so
 that different orderings of the same elements are considered equal. This method
 of comparing Protobuf messages may come at a cost in performance.
+The `backup_replicas` must be returned in order when read to preserve the
+sequence of highest-preferred backup replicas.
 
 [#sec-data-plane-volatile-objects]
 ==== Data plane volatile objects

--- a/docs/v1/P4Runtime-Spec.adoc
+++ b/docs/v1/P4Runtime-Spec.adoc
@@ -6877,3 +6877,4 @@ described in <<#sec-table-entry>>.
 
 [bibliography]
 == References
+bibliography::references.bib[ieee]

--- a/docs/v1/P4Runtime-Spec.adoc
+++ b/docs/v1/P4Runtime-Spec.adoc
@@ -6877,4 +6877,3 @@ described in <<#sec-table-entry>>.
 
 [bibliography]
 == References
-bibliography::references.bib[ieee]


### PR DESCRIPTION
Update the P4Runtime Spec (now a .adoc). Previous discussion on https://github.com/p4lang/p4runtime/pull/547

cc: @smolkaj, @jafingerhut 