### PR TITLE
Update bazel build to c++17

### DIFF
--- a/bazel/example/using-bzlmod/.bazelrc
+++ b/bazel/example/using-bzlmod/.bazelrc
@@ -2,6 +2,6 @@
 common --enable_bzlmod
 common --noenable_workspace
 
-# Use C++14 (required for recent gRPC versions).
-build --cxxopt=-std=c++14
-build --host_cxxopt=-std=c++14
+# Use C++17 (required for recent gRPC versions).
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17

--- a/bazel/example/using-workspace/.bazelrc
+++ b/bazel/example/using-workspace/.bazelrc
@@ -2,6 +2,6 @@
 common --enable_workspace
 common --noenable_bzlmod
 
-# Use C++14 (required for recent gRPC versions).
-build --cxxopt=-std=c++14
-build --host_cxxopt=-std=c++14
+# Use C++17 (required for recent gRPC versions).
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17

--- a/proto/.bazelrc
+++ b/proto/.bazelrc
@@ -2,6 +2,6 @@
 common --enable_bzlmod
 common --noenable_workspace
 
-# Use C++14 (required for recent gRPC versions).
-build --cxxopt=-std=c++14
-build --host_cxxopt=-std=c++14
+# Use C++17 (required for recent gRPC versions).
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17


### PR DESCRIPTION
Update bazel build to c++17

c++17 has been out for awhile so this is a stable update.

c++17 is a prerequisite for migrating from proto3 to proto editions so would be nice to clear that prerequisite early