### PR TITLE
Clarify sending ActionProfile members with duplicate actions.

### DIFF
--- a/docs/v1/P4Runtime-Spec.adoc
+++ b/docs/v1/P4Runtime-Spec.adoc
@@ -3992,7 +3992,7 @@ It is possible to include several `ActionProfileAction` messages with the same
 exact `action` specification in one `ActionProfileActionSet` message. For
 `sum_of_members`, this allows clients to specify weights greater than the
 `max_member_weight` set. E.g. modifying the example above, we can weight
-nexthop 1 to be 2x100 (if `max_member_weight` is 100 as follows:
+nexthop 1 to be 2x100 (if `max_member_weight` is 100) as follows:
 [source,protobuf]
 ----
 table_entry {


### PR DESCRIPTION
Specifically, clarify that P4Runtime clients are only discouraged from sending ActionProfile members with duplicate actions when using the `sum_of_weights` group size calculation, since the same may literally not be achievable using the `weight` field otherwise.