### PR TITLE
(proto change) Add ActionSelectionMode and SizeSemantics to ActionProfileActionSet in P4Runtime. 

### DIFF
--- a/proto/p4/v1/p4runtime.proto
+++ b/proto/p4/v1/p4runtime.proto
@@ -284,6 +284,24 @@ message Action {
 
 message ActionProfileActionSet {
   repeated ActionProfileAction action_profile_actions = 1;
+  // Added in v1.5.0.
+  enum ActionSelectionMode {
+    DEFAULT_MODE_DETERMINED_BY_ACTION_SELECTOR = 0;
+    // Uses the hash mode specified by the action selector.
+    HASH = 1;
+    // Picks the action randomly.
+    RANDOM = 2;
+  }
+  // Added in v1.5.0.
+  enum SizeSemantics {
+    DEFAULT_SIZE_DETERMINED_BY_ACTION_SELECTOR = 0;
+    SUM_OF_WEIGHTS = 1;
+    SUM_OF_MEMBERS = 2;
+  }
+  // Support per-group hash modes.
+  ActionSelectionMode action_selection_mode = 2;
+  // Support per-group resource usage modes.
+  SizeSemantics size_semantics = 3;
 }
 
 message ActionProfileAction {


### PR DESCRIPTION
# Motivation 
Our switches currently support per-group hash modes and resource usage modes. We are currently not leveraging this capability. This P4 API change allows for more granular control of the WCMP implementation in GPINS.

# Summary of changes
Add `BucketSelectionMode` (with modes `DEFAULT_MODE_DETERMINED_BY_ACTION_SELECTOR`, `HASH`, and `RANDOM`) and `SizeSemantics` (with modes `DEFAULT_SIZE_DETERMINED_BY_ACTION_SELECTOR`, `SUM_OF_WEIGHTS`, and `SUM_OF_MEMBERS`) to `ActionProfileActionSet` in p4runtime.proto.