### PR TITLE
Upgrade rules_go version to 0.56.1 to make latest Bazel happy.

### DIFF
--- a/proto/MODULE.bazel
+++ b/proto/MODULE.bazel
@@ -28,8 +28,6 @@ bazel_dep(
     repo_name = "io_bazel_rules_go",
 )
 bazel_dep(name = "gazelle", version = "0.45.0")
-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
-go_deps.from_file(go_mod = "//:go.mod")
 
 switched_rules = use_extension("@com_google_googleapis//:extensions.bzl", "switched_rules")
 switched_rules.use_languages(


### PR DESCRIPTION
Fixes https://github.com/p4lang/p4runtime/issues/562.