### PR TITLE
Add support for building on macOS.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,10 @@
 common --enable_bzlmod
 common --noenable_workspace
 
+# Auto-select build:linux / build:macos / build:windows based on the host OS,
+# so platform-specific flags don't need manual --config= activation.
+common --enable_platform_specific_config
+
 # In Bazel 9, native C++ rules are no longer injected into the global namespace
 # by default.  Two files in grpc 1.76.0 still use native.cc_*:
 #   bazel/cython_library.bzl      (native.cc_binary)
@@ -12,3 +16,13 @@ build --incompatible_autoload_externally=+cc_library,+cc_binary
 # Use C++17 (required for recent gRPC versions).
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
+
+# Toolchain auto-configuration (cc_configure) needs repo_env=CC.
+# On macOS, use the absolute CLT path to avoid picking up a Homebrew clang
+# with an incompatible libc++.
+build:macos --repo_env=CC=/usr/bin/clang
+
+# Deployment target 10.13 is the minimum for C++17 aligned_alloc in libc++.
+# host_macos_minimum_os covers host tool builds (e.g. protoc).
+build:macos --macos_minimum_os=10.13
+build:macos --host_macos_minimum_os=10.13


### PR DESCRIPTION
Adds the `.bazelrc` flags needed to build on macOS out of the box.

**Key flags:**

- **`--enable_platform_specific_config`** — auto-selects `build:macos` /
  `build:linux` / `build:windows` based on the host OS, so macOS-specific flags
  activate automatically without manual `--config=macos`.
- **`build:macos --repo_env=CC=/usr/bin/clang`** — points `cc_configure` at the
  Command Line Tools clang, avoiding Homebrew clang with an incompatible libc++.
- **`build:macos --macos_minimum_os=10.13`** /
  **`build:macos --host_macos_minimum_os=10.13`** — minimum deployment target
  for C++17 `aligned_alloc` in libc++; `host_` variant covers tool builds
  (e.g. protoc).