### PR TITLE
Remove root-BUILD-file config from proto/BUILD.bazel

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,18 +1,3 @@
-load("@rules_license//rules:license.bzl", "license")
-
-package(
-    default_applicable_licenses = [":license"],
-    default_visibility = ["//visibility:public"],
-)
-
-license(
-    name = "license",
-    license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
-    license_text = "LICENSE",
-)
-
-exports_files(["LICENSE"])
-
 # -- Aliases for backward compatibility --------------------------------------
 # TODO(https://github.com/p4lang/p4runtime/issues/576): Remove in 2.0.
 


### PR DESCRIPTION
The config has been moved to the root BUILD.bazel, and we forgot to delete it here.