### PR TITLE
Round 2 of adding copyright and license notices to files

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Steffen Smolka
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Exclude bazel sub-projects so `bazel build //...` works.
 bazel/example
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Steffen Smolka
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Use Bzlmod (`MODULE.bazel`) instead of `WORKSPACE.bazel`.
 common --enable_bzlmod
 common --noenable_workspace

--- a/.bazelversion.license
+++ b/.bazelversion.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 Steffen Smolka
+
+SPDX-License-Identifier: Apache-2.0

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,8 @@
 ---
+# SPDX-FileCopyrightText: 2018 Antonin Bas
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Bug report
 about: Create a report an issue with the code / documents hosted in this repository
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,4 +1,8 @@
 ---
+# SPDX-FileCopyrightText: 2018 Antonin Bas
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Feature request
 about: Suggest an idea for this project
 

--- a/.github/workflows/any-branch-uploads.yml
+++ b/.github/workflows/any-branch-uploads.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Antonin Bas
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Any branch uploads
 
 on:

--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Steffen Smolka
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: "Bazel build of protobufs"
 
 on:

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Antonin Bas
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Check generated code
 
 on:

--- a/.github/workflows/google-rpc-status-synced.yml
+++ b/.github/workflows/google-rpc-status-synced.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Steffen Smolka
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Ensure google/rpc/status.proto is synced with upstream.
 
 on:

--- a/.github/workflows/main-branch-uploads.yml
+++ b/.github/workflows/main-branch-uploads.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Antonin Bas
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Main branch uploads
 
 on:

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Steffen Smolka
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: "Rust build"
 
 on:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Antonin Bas
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Build spec
 
 on:

--- a/.github/workflows/tag-uploads.yml
+++ b/.github/workflows/tag-uploads.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Antonin Bas
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Tag uploads
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Antonin Bas
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Emacs
 *~
 docs/v1/build/

--- a/BUILD.bazel.license
+++ b/BUILD.bazel.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Steffen Smolka
+
+SPDX-License-Identifier: Apache-2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2019 Antonin Bas
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 You can fork the repo and submit a pull request in Github.
 
 ### Apache CLA

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+LICENSES/Apache-2.0.txt

--- a/MODULE.bazel.license
+++ b/MODULE.bazel.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Steffen Smolka
+
+SPDX-License-Identifier: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2018 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # P4Runtime
 
 P4 is a language for programming the data plane of network devices. 

--- a/WORKSPACE.bzlmod.license
+++ b/WORKSPACE.bzlmod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Steffen Smolka
+
+SPDX-License-Identifier: Apache-2.0

--- a/bazel/example/using-bzlmod/.bazelrc
+++ b/bazel/example/using-bzlmod/.bazelrc
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Steffen Smolka
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Use Bzlmod (`MODULE.bazel`) instead of `WORKSPACE.bazel`.
 common --enable_bzlmod
 common --noenable_workspace

--- a/bazel/example/using-bzlmod/BUILD.bazel.license
+++ b/bazel/example/using-bzlmod/BUILD.bazel.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Steffen Smolka
+
+SPDX-License-Identifier: Apache-2.0

--- a/bazel/example/using-bzlmod/MODULE.bazel.license
+++ b/bazel/example/using-bzlmod/MODULE.bazel.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Steffen Smolka
+
+SPDX-License-Identifier: Apache-2.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2018 Antonin Bas
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # P4Runtime specification documents
 
 ## Inline code with backticks

--- a/docs/libre-office.png.license
+++ b/docs/libre-office.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2018 Antonin Bas
+
+SPDX-License-Identifier: Apache-2.0

--- a/docs/tools/Dockerfile.asciidoc
+++ b/docs/tools/Dockerfile.asciidoc
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Davide Scano
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM  ruby:3.3.5
 LABEL maintainer="P4 API Working Group <p4-dev@lists.p4.org>"
 LABEL description="Dockerfile used for building the asciidoc specification"

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2018 Antonin Bas
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 Dockerfile.asciidoc  is used to build a Docker image which we use to render the
 P4Runtime specification (HTML & PDF) in CI. The image can also be used locally
 to build the specification without having to worry about installing all the

--- a/docs/tools/fonts/fix_helvetica.conf.license
+++ b/docs/tools/fonts/fix_helvetica.conf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2018 Antonin Bas
+
+SPDX-License-Identifier: Apache-2.0

--- a/docs/v1/README.md
+++ b/docs/v1/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2018 Antonin Bas
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # P4Runtime Specification Version 1
 
 This directory contains the sources for generating the official P4Runtime

--- a/docs/v1/guidance-for-generating-p4info.md
+++ b/docs/v1/guidance-for-generating-p4info.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2019 Andy Fingerhut
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Guidance for generating P4Info messages
 
 

--- a/docs/v1/p4runtime-id-notes.md
+++ b/docs/v1/p4runtime-id-notes.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2020 Andy Fingerhut
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # P4Runtime numeric id notes
 
 There are many kinds of numeric identifiers used in the P4Runtime API

--- a/docs/v1/resources/figs/.gitignore
+++ b/docs/v1/resources/figs/.gitignore
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2025 Davide Scano
+#
+# SPDX-License-Identifier: Apache-2.0
+
 stem*

--- a/docs/v1/resources/fonts/verify-font
+++ b/docs/v1/resources/fonts/verify-font
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2012 Dan Allen
+# SPDX-FileCopyrightText: 2012 Ryan Waldron
+# SPDX-FileCopyrightText: 2012 Sarah White
+# SPDX-FileCopyrightText: 2012 the individual contributors to Asciidoctor
+#
+# SPDX-License-Identifier: MIT
+
+# Source: The Asciidoctor PDF documentation.
+# Retrieved 2025 from https://docs.asciidoctor.org/pdf-converter/latest/theme/prepare-custom-font/
+
 require 'ttfunk'
 require 'ttfunk/subset_collection'
 

--- a/docs/v1/resources/theme/p4-stylesheet.css.license
+++ b/docs/v1/resources/theme/p4-stylesheet.css.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2013 Jonathan Neal
+SPDX-FileCopyrightText: 2013 Nicolas Gallagher
+
+SPDX-License-Identifier: MIT

--- a/docs/v1/resources/theme/references.bib
+++ b/docs/v1/resources/theme/references.bib
@@ -1,3 +1,9 @@
+@Comment{
+SPDX-FileCopyrightText: 2025 Davide Scano
+
+SPDX-License-Identifier: Apache-2.0
+}
+
 @ONLINE { P4RuntimeRepo,
     title  = "p4lang/p4Runtime repository",
     subtitle = "P4Runtime Protobuf definition files and specification",

--- a/go.mod.license
+++ b/go.mod.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2020 Antonin Bas
+
+SPDX-License-Identifier: Apache-2.0

--- a/go.sum.license
+++ b/go.sum.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2020 Antonin Bas
+
+SPDX-License-Identifier: Apache-2.0

--- a/proto/BUILD.bazel.license
+++ b/proto/BUILD.bazel.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2020 Steffen Smolka
+
+SPDX-License-Identifier: Apache-2.0

--- a/proto/google/rpc/status.proto.license
+++ b/proto/google/rpc/status.proto.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Google LLC
+
+SPDX-License-Identifier: Apache-2.0

--- a/proto/p4/config/v1/BUILD.bazel.license
+++ b/proto/p4/config/v1/BUILD.bazel.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Steffen Smolka
+
+SPDX-License-Identifier: Apache-2.0

--- a/proto/p4/v1/BUILD.bazel.license
+++ b/proto/p4/v1/BUILD.bazel.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Steffen Smolka
+
+SPDX-License-Identifier: Apache-2.0

--- a/py/LICENSE
+++ b/py/LICENSE
@@ -1,1 +1,201 @@
-../LICENSE
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/py/REUSE.toml
+++ b/py/REUSE.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[annotations]]
+path = [
+    "p4/**"
+]
+SPDX-FileCopyrightText = "2020 The P4 Language Consortium"
+SPDX-License-Identifier = "Apache-2.0"

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Antonin Bas
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [metadata]
 name = p4runtime
 description = Python bindings for P4Runtime protocol

--- a/rust/Cargo.lock.license
+++ b/rust/Cargo.lock.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Campbell He <kp.campbell.he@duskmoon314.com>
+
+SPDX-License-Identifier: Apache-2.0

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 Campbell He <kp.campbell.he@duskmoon314.com>
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # P4Runtime Rust Crates
 
 This directory contains Rust crates for the P4Runtime API specification.

--- a/tools/asciidocint.conf.json.license
+++ b/tools/asciidocint.conf.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Davide Scano
+
+SPDX-License-Identifier: Apache-2.0

--- a/tools/reuse-annotate-font-files.sh
+++ b/tools/reuse-annotate-font-files.sh
@@ -2,7 +2,7 @@
 
 # SPDX-FileCopyrightText: 2026 Andy Fingerhut
 #
-# SPDX-License-Identifier: apache
+# SPDX-License-Identifier: Apache-2.0
 
 # This is a simple Bash script that demonstrates one way to add
 # copyright and license information for files using the `reuse


### PR DESCRIPTION
With the current state of this PR as of commit 1, this adds copyright and license notices that are lintable via the open source REUSE program for all remaining files, except 2 that I am checking with Davide Scano whether he wrote them, or copied them from somewhere else.  I think this is reasonable to review and merge without those, and I can add info for those 2 files in a later PR if I do not find out the details soon enough for this PR.

For all files modified (or for which a <origfilename>.license file was added, if the original file does not support comments), the copyright holder is the person who first added the file to this repository, and the year is the year that happened.