### PR TITLE
fix(tools): correct extension error message and format string in asciidoclint

### DIFF
--- a/tools/asciidoclint.py
+++ b/tools/asciidoclint.py
@@ -273,7 +273,7 @@ def main():
             sys.exit(1)
         _, ext = os.path.splitext(f)
         if ext != ".adoc":
-            print("'{}' does not have an .mdk extension")
+            print("'{}' does not have an .adoc extension".format(f))
             sys.exit(1)
 
     conf_path = None


### PR DESCRIPTION
## Description
Fixes a copy-paste error string and an unformatted print bug in the `asciidoclint.py` tooling script. 

The script validates files ending with an `.adoc` extension, but the error message incorrectly stated that the file was missing an `.mdk` extension. Additionally, the original print statement did not call `.format(f)`, meaning the actual file path was never injected into the string.

## Changes
* Updated the error string to correctly reference `.adoc`.
* Appended `.format(f)` to ensure the target filename is printed when the validation fails.

## How Has This Been Tested?
* Verified the script output locally with an invalid file extension to ensure it prints the correct error string along with the targeted filename without crashing.