### PR TITLE
codegen: use command -v instead of fragile which + \$? pattern

### DIFF
--- a/codegen/compile_protos.sh
+++ b/codegen/compile_protos.sh
@@ -25,24 +25,17 @@ if [ "$#" -ne 1 ]; then
 fi
 
 BUILD_DIR="$1"
-PROTOC="$(which protoc)"
-if [ "$?" -ne 0 ]; then
-    echo "Could not find protoc"
-    exit 2
-fi
+
+command -v protoc >/dev/null 2>&1 || { echo "Could not find protoc"; exit 2; }
+PROTOC="$(command -v protoc)"
 
 echo "Using $PROTOC"
 
-GRPC_CPP_PLUGIN="$(which grpc_cpp_plugin)"
-if [ "$?" -ne 0 ]; then
-    echo "Could not find CPP protoc plugin"
-    exit 2
-fi
-GRPC_PY_PLUGIN="$(which grpc_python_plugin)"
-if [ "$?" -ne 0 ]; then
-    echo "Could not find Python protoc plugin"
-    exit 2
-fi
+command -v grpc_cpp_plugin >/dev/null 2>&1 || { echo "Could not find CPP protoc plugin"; exit 2; }
+GRPC_CPP_PLUGIN="$(command -v grpc_cpp_plugin)"
+
+command -v grpc_python_plugin >/dev/null 2>&1 || { echo "Could not find Python protoc plugin"; exit 2; }
+GRPC_PY_PLUGIN="$(command -v grpc_python_plugin)"
 
 set -e
 


### PR DESCRIPTION
## Description
Refactored `codegen/compile_protos.sh` to use `command -v` instead of the fragile `which` + `$?` pattern. 

The previous implementation relied on checking `$?` immediately after a variable assignment (e.g., `PROTOC="$(which protoc)"`). While functional, this pattern is highly fragile as any commands accidentally inserted between the assignment and the `if` block would silently break the error handling. Additionally, `command -v` is the POSIX-compliant standard for binary verification, offering better portability than the external `which` command.

## Changes
- Replaced `which` lookups with direct short-circuit evaluation (`command -v ... || { ... }`).
- Removed fragile `$?` status checks following variable assignments.
- Reduced overall line count while preserving identical functional behavior.