### PR TITLE
py: drop obsolete setuptools_scm_git_archive dependency

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -18,7 +18,6 @@
 requires = [
     "setuptools",
     "setuptools_scm[toml]",
-    "setuptools_scm_git_archive",
     "wheel",
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
## Summary

This PR removes `setuptools_scm_git_archive` from `py/pyproject.toml`'s `build-system.requires`.

`setuptools_scm_git_archive` has been archived and is no longer actively maintained. Modern versions of `setuptools_scm` no longer require it as a separate build dependency for standard versioning workflows, making this dependency unnecessary.

Removing the obsolete dependency simplifies the project's build requirements and reduces maintenance overhead.

## Changes

* Removed `setuptools_scm_git_archive` from `build-system.requires` in `py/pyproject.toml`.

## Testing

* Verified that this change only removes an unused build dependency.
* No functional source code changes were made.
