### PR TITLE
proto: add curl fallback and validate downloaded status.proto

### DIFF
--- a/proto/update_google_rpc_status.sh
+++ b/proto/update_google_rpc_status.sh
@@ -22,9 +22,29 @@
 # The file is very stable and hasn't changed in many years, but we enforce
 # freshness of this copy using a GitHub Actions workflow just in case.
 
-set -e
+set -eu
 
 STATUS_PROTO_URL="https://raw.githubusercontent.com/googleapis/googleapis/refs/heads/master/google/rpc/status.proto"
 THIS_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+DEST_FILE="$THIS_DIR/google/rpc/status.proto"
 
-wget "$STATUS_PROTO_URL" -O "$THIS_DIR/google/rpc/status.proto"
+TMP_FILE="$(mktemp)"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+if command -v curl >/dev/null 2>&1; then
+    curl -fLsS "$STATUS_PROTO_URL" -o "$TMP_FILE"
+elif command -v wget >/dev/null 2>&1; then
+    wget -q "$STATUS_PROTO_URL" -O "$TMP_FILE"
+else
+    echo "Neither curl nor wget is available to download status.proto" >&2
+    exit 1
+fi
+
+# Basic sanity check: make sure we actually got a .proto file and not, say,
+# an HTML error/rate-limit page served with a 200-ish status.
+if ! grep -q '^syntax' "$TMP_FILE"; then
+    echo "Downloaded file does not look like a valid .proto file (missing 'syntax' line); aborting" >&2
+    exit 1
+fi
+
+mv "$TMP_FILE" "$DEST_FILE"


### PR DESCRIPTION
## Summary

Improve `proto/update_google_rpc_status.sh` by making the download process more robust.

### Changes

* Prefer `curl` when available and fall back to `wget`
* Exit with a clear error if neither download tool is installed
* Download to a temporary file before replacing the checked-in `status.proto`
* Add a basic sanity check to verify the downloaded file is a valid `.proto` before overwriting the existing file

This helps prevent invalid downloads from replacing `status.proto` and aligns the script with the download fallback pattern used elsewhere in the repository.
