### PR TITLE
ci: standardize actions/checkout to v5 across all workflows

### DIFF
--- a/.github/workflows/any-branch-uploads.yml
+++ b/.github/workflows/any-branch-uploads.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.repository == 'p4lang/p4runtime' }}
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Build spec
       run: |
         make -C docs/tools/

--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -42,7 +42,7 @@ jobs:
       CACHE_KEY: ${{ matrix.os }}_bazel-${{ matrix.bazel_version }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
 

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -18,7 +18,7 @@ jobs:
   check-codegen:
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Compile protobufs
       run: |
         docker build -t p4runtime-ci -f codegen/Dockerfile .

--- a/.github/workflows/main-branch-uploads.yml
+++ b/.github/workflows/main-branch-uploads.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.repository == 'p4lang/p4runtime' }}
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         # fetch all history for all branches and tags
         fetch-depth: 0

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate that all files have copyright and license info
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install dev dependencies
         run: |
           ./CI/install-uv.sh

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate that all files have copyright and license info
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Install dev dependencies
         run: |
           ./CI/install-uv.sh
@@ -30,7 +30,7 @@ jobs:
   asciidoc-lint:
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Run linter
       run: |
         ./tools/asciidoclint.py docs/v1/P4Runtime-Spec.adoc
@@ -38,7 +38,7 @@ jobs:
   build-spec:
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Build spec
       run: |
         make -C docs/tools/

--- a/.github/workflows/tag-uploads.yml
+++ b/.github/workflows/tag-uploads.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       TAG: ${{ github.ref_name }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         # fetch all history for all branches and tags
         fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
     if: ${{ github.repository == 'p4lang/p4runtime' }}
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python
       uses: actions/setup-python@v3
       with:


### PR DESCRIPTION
## Summary

This repo's GitHub Actions workflows pinned `actions/checkout` to several different major versions inconsistently:

- `@v3` - `any-branch-uploads.yml`, `main-branch-uploads.yml`, `tag-uploads.yml` (x2), `codegen.yml`, `spec.yml` (asciidoc-lint, build-spec jobs)
- `@v4` - `bazel-build.yml`
- `@v5` - `rust-build.yml`, `google-rpc-status-synced.yml`
- `@v6` - `spec.yml` (verify-licenses job)

This PR standardizes all `actions/checkout` references to a single version: **`@v5`**.

## Why v5

- Already in use and working in this repo (`rust-build.yml`, `google-rpc-status-synced.yml`), so it's a proven baseline rather than an untested jump.
- Recent and actively supported, without being the very newly released `v7` (GA'd June 17, 2026), which introduces new default behavior for `pull_request_target`/`workflow_run` checkouts. None of this repo's workflows use those triggers, so it wouldn't have caused issues either way, but `v5` avoids being an early adopter of a days-old major version in CI.

## Changes

Purely mechanical version bumps, no other changes:

- `any-branch-uploads.yml`: `v3` -> `v5`
- `bazel-build.yml`: `v4` -> `v5`
- `codegen.yml`: `v3` -> `v5`
- `main-branch-uploads.yml`: `v3` -> `v5`
- `spec.yml`: `v6` -> `v5` (verify-licenses), `v3` -> `v5` (asciidoc-lint), `v3` -> `v5` (build-spec)
- `tag-uploads.yml`: `v3` -> `v5` (x2)

`rust-build.yml` and `google-rpc-status-synced.yml` are unchanged as they already used `v5`.
