### PR TITLE
ci: bump asciidoc Dockerfile ruby image to 3.3.11

### DIFF
--- a/docs/tools/Dockerfile.asciidoc
+++ b/docs/tools/Dockerfile.asciidoc
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM  ruby:3.3.5
+FROM  ruby:3.3.11
 LABEL maintainer="P4 API Working Group <p4-dev@lists.p4.org>"
 LABEL description="Dockerfile used for building the asciidoc specification"
 


### PR DESCRIPTION
## Summary

`docs/tools/Dockerfile.asciidoc` pinned `ruby:3.3.5`, a stale patch release. This PR bumps it to `ruby:3.3.11`, the current patch tag on the 3.3.x line, to pick up upstream security fixes.

## Why 3.3.11 (not 3.4.x or later)

- Stays within the same minor version (3.3.x) the image was already using, so the pinned gem versions and toolchain behavior (`asciidoctor-pdf` 2.3.19, `asciidoctor-lists` 1.1.2, the `rouge` build-from-source step, etc.) are unaffected.
- `3.3.11` is the latest published patch tag for `ruby:3.3` on Docker Hub as of this PR.
- Jumping to `3.4.x` or `4.0.x` would be a larger, riskier change better suited to its own PR with dedicated toolchain testing.

## Changes

One line, no other changes:

- `docs/tools/Dockerfile.asciidoc`: `FROM ruby:3.3.5` -> `FROM ruby:3.3.11`
