### PR TITLE
Derive Go Docker tag from Dockerfile's GO_VERSION in update.sh

### DIFF
--- a/codegen/update.sh
+++ b/codegen/update.sh
@@ -24,6 +24,14 @@ pushd "$THIS_DIR/.." >/dev/null
 
 docker build -t p4runtime-ci -f codegen/Dockerfile .
 
+# Read the Go version from the Dockerfile so this script and the CI image
+# can't drift out of sync with each other.
+GO_VERSION="$(sed -n 's/^ARG GO_VERSION=//p' codegen/Dockerfile)"
+if [ -z "$GO_VERSION" ]; then
+    echo "Could not determine GO_VERSION from codegen/Dockerfile" >&2
+    exit 1
+fi
+
 tmpdir="$(mktemp -d /tmp/p4rt.XXXXXX)"
 
 docker run --rm \
@@ -47,7 +55,7 @@ docker run --rm -u "$(id -u):$(id -g)" \
        -e "GOPATH=/tmp/gopath" \
        -v "$(pwd):/p4runtime" \
        -w /p4runtime \
-       golang:1.20 bash -c "go mod tidy"
+       "golang:${GO_VERSION}" bash -c "go mod tidy"
 
 rm -rf "$tmpdir"
 


### PR DESCRIPTION
## Summary
 
Removes a hardcoded Go version literal in `codegen/update.sh` that could silently drift out of sync with `codegen/Dockerfile`. No functional/behavioral changes when versions already match, this only changes how the version is sourced.
 
## Problem
 
Three places currently encode a Go version, independently of each other:
 
- `go.mod`: `go 1.20`
- `codegen/Dockerfile`: `ARG GO_VERSION=1.20.5`
- `codegen/update.sh`: hardcoded `golang:1.20` for the `go mod tidy` step
They agree today, but nothing ties them together. Bumping the Dockerfile's `GO_VERSION` (e.g. for a Go security patch or minor upgrade) doesn't touch `update.sh`, so the `go mod tidy` step could end up running against a different Go version than the one CI actually builds/tests with, a subtle, easy-to-miss source of drift.
 
## Change
 
`codegen/update.sh` now reads `GO_VERSION` directly out of `codegen/Dockerfile`:
 
```bash
GO_VERSION="$(sed -n 's/^ARG GO_VERSION=//p' codegen/Dockerfile)"
```
 
and uses it for the `go mod tidy` container instead of the hardcoded `golang:1.20` tag. A guard checks the value was actually found and fails loudly (instead of silently running `go mod tidy` under a stale/wrong image) if the Dockerfile's `ARG` line is ever renamed or removed.