### PR TITLE
docs: replace outdated CLA guidance with DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 You can fork the repo and submit a pull request in GitHub.
 
-### Apache CLA
+### Contributing License
 
-All developers must have signed the [P4.org](http://p4.org) CLA.
+The P4 organizations uses [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for contributions. Please take a look at our [guidelines](https://github.com/p4lang/governance/wiki/P4-DCO-Guidelines).
 
 ### AsciiDoc style checker
 


### PR DESCRIPTION
## Description

Replace the outdated P4.org CLA requirement in `CONTRIBUTING.md` with the current DCO contribution policy and a link to the P4 DCO guidelines.

The replacement wording matches the organization-wide and p4c contribution guidelines.

## Testing

Documentation-only change. Verified with `git diff --check`.

Fixes #632